### PR TITLE
Add mqtt sample specifically for smaller devices like esp8266

### DIFF
--- a/iothub_client/samples/CMakeLists.txt
+++ b/iothub_client/samples/CMakeLists.txt
@@ -22,6 +22,7 @@ endif()
 
 if(${use_mqtt})
     add_sample_directory(iothub_client_sample_mqtt)
+    add_sample_directory(iothub_client_sample_mqtt_esp8266)
     add_sample_directory(iothub_client_sample_device_method)
 	if (${use_wsio})
 		add_sample_directory(iothub_client_sample_mqtt_websockets)

--- a/iothub_client/samples/iothub_client_sample_mqtt_esp8266/CMakeLists.txt
+++ b/iothub_client/samples/iothub_client_sample_mqtt_esp8266/CMakeLists.txt
@@ -1,0 +1,28 @@
+#Copyright (c) Microsoft. All rights reserved.
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#this is CMakeLists.txt for iothub_client_sample_mqtt_esp8266
+
+if(NOT ${use_mqtt})
+    message(FATAL_ERROR "iothub_client_sample_mqtt_esp8266 being generated without mqtt support")
+endif()
+
+compileAsC99()
+
+set(iothub_client_sample_mqtt_esp8266_c_files
+    iothub_client_sample_mqtt_esp8266.c
+)
+
+set(iothub_client_sample_mqtt_esp8266_h_files
+    iothub_client_sample_mqtt_esp8266.h
+)
+
+include_directories(.)
+
+add_executable(iothub_client_sample_mqtt_esp8266 ${iothub_client_sample_mqtt_esp8266_c_files} ${iothub_client_sample_mqtt_esp8266_h_files})
+
+target_link_libraries(iothub_client_sample_mqtt_esp8266  
+    iothub_client_mqtt_transport
+    iothub_client 
+)
+

--- a/iothub_client/samples/iothub_client_sample_mqtt_esp8266/iothub_client_sample_mqtt_esp8266.c
+++ b/iothub_client/samples/iothub_client_sample_mqtt_esp8266/iothub_client_sample_mqtt_esp8266.c
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "iothub_client.h"
+#include "iothub_message.h"
+#include "azure_c_shared_utility/threadapi.h"
+#include "azure_c_shared_utility/crt_abstractions.h"
+#include "azure_c_shared_utility/platform.h"
+#include "iothubtransportmqtt.h"
+
+#include "iothub_client_sample_mqtt_esp8266.h"
+
+/*String containing Hostname, Device Id & Device Key in the format:                         */
+/*  "HostName=<host_name>;DeviceId=<device_id>;SharedAccessKey=<device_key>"                */
+/*  "HostName=<host_name>;DeviceId=<device_id>;SharedAccessSignature=<device_sas_token>"    */
+static const char* connectionString = "[device connection string]";
+
+static int callbackCounter;
+static char msgText[1024];
+static char propText[1024];
+static bool g_continueRunning;
+#define MESSAGE_COUNT 50
+#define DOWORK_LOOP_NUM     3
+
+typedef struct EVENT_INSTANCE_TAG
+{
+    IOTHUB_MESSAGE_HANDLE messageHandle;
+    size_t messageTrackingId;  // For tracking the messages within the user callback.
+} EVENT_INSTANCE;
+
+static IOTHUBMESSAGE_DISPOSITION_RESULT ReceiveMessageCallback(IOTHUB_MESSAGE_HANDLE message, void* userContextCallback)
+{
+    int* counter = (int*)userContextCallback;
+    const char* buffer;
+    size_t size;
+
+    if (IoTHubMessage_GetByteArray(message, (const unsigned char**)&buffer, &size) != IOTHUB_MESSAGE_OK)
+    {
+        (void)printf("unable to retrieve the message data\r\n");
+    }
+    else
+    {
+        (void)printf("Received Message [%d] with Data: <<<%.*s>>> & Size=%d\r\n", *counter, (int)size, buffer, (int)size);
+        // If we receive the work 'quit' then we stop running
+        if (size == (strlen("quit") * sizeof(char)) && memcmp(buffer, "quit", size) == 0)
+        {
+            g_continueRunning = false;
+        }
+    }
+
+    // Retrieve properties from the message
+    MAP_HANDLE mapProperties = IoTHubMessage_Properties(message);
+    if (mapProperties != NULL)
+    {
+        const char*const* keys;
+        const char*const* values;
+        size_t propertyCount = 0;
+        if (Map_GetInternals(mapProperties, &keys, &values, &propertyCount) == MAP_OK)
+        {
+            if (propertyCount > 0)
+            {
+                size_t index = 0;
+                for (index = 0; index < propertyCount; index++)
+                {
+                    (void)printf("\tKey: %s Value: %s\r\n", keys[index], values[index]);
+                }
+                (void)printf("\r\n");
+            }
+        }
+    }
+
+    /* Some device specific action code goes here... */
+    (*counter)++;
+    return IOTHUBMESSAGE_ACCEPTED;
+}
+
+static void SendConfirmationCallback(IOTHUB_CLIENT_CONFIRMATION_RESULT result, void* userContextCallback)
+{
+    EVENT_INSTANCE* eventInstance = (EVENT_INSTANCE*)userContextCallback;
+    size_t id = eventInstance->messageTrackingId;
+
+    (void)printf("Confirmation[%d] received for message tracking id = %d with result = %s\r\n", callbackCounter, (int)id, ENUM_TO_STRING(IOTHUB_CLIENT_CONFIRMATION_RESULT, result));
+    /* Some device specific action code goes here... */
+    callbackCounter++;
+    IoTHubMessage_Destroy(eventInstance->messageHandle);
+}
+
+void iothub_client_sample_mqtt_esp8266_run(void)
+{
+    IOTHUB_CLIENT_LL_HANDLE iotHubClientHandle;
+
+    EVENT_INSTANCE messages[MESSAGE_COUNT];
+
+    g_continueRunning = true;
+    srand((unsigned int)time(NULL));
+    double avgWindSpeed = 10.0;
+    
+    callbackCounter = 0;
+    int receiveContext = 0;
+
+    if (platform_init() != 0)
+    {
+        (void)printf("Failed to initialize the platform.\r\n");
+    }
+    else
+    {
+        if ((iotHubClientHandle = IoTHubClient_LL_CreateFromConnectionString(connectionString, MQTT_Protocol)) == NULL)
+        {
+            (void)printf("ERROR: iotHubClientHandle is NULL!\r\n");
+        }
+        else
+        {
+            bool traceOn = true;
+            IoTHubClient_LL_SetOption(iotHubClientHandle, "logtrace", &traceOn);
+
+            /* Setting Message call back, so we can receive Commands. */
+            if (IoTHubClient_LL_SetMessageCallback(iotHubClientHandle, ReceiveMessageCallback, &receiveContext) != IOTHUB_CLIENT_OK)
+            {
+                (void)printf("ERROR: IoTHubClient_LL_SetMessageCallback..........FAILED!\r\n");
+            }
+            else
+            {
+                (void)printf("IoTHubClient_LL_SetMessageCallback...successful.\r\n");
+
+                /* Now that we are ready to receive commands, let's send some messages */
+                size_t iterator = 0;
+                do
+                {
+                    (void)printf("iterator: [%d], callbackCounter: [%d]. \r\n", (int)iterator, callbackCounter);
+                    
+                    if (iterator < MESSAGE_COUNT && (iterator <= callbackCounter))
+                    {
+                        sprintf_s(msgText, sizeof(msgText), "{\"deviceId\":\"myFirstDevice\",\"windSpeed\":%.2f}", avgWindSpeed + (rand() % 4 + 2));
+                        if ((messages[iterator].messageHandle = IoTHubMessage_CreateFromByteArray((const unsigned char*)msgText, strlen(msgText))) == NULL)
+                        {
+                            (void)printf("ERROR: iotHubMessageHandle is NULL!\r\n");
+                        }
+                        else
+                        {
+                            messages[iterator].messageTrackingId = iterator;
+                            MAP_HANDLE propMap = IoTHubMessage_Properties(messages[iterator].messageHandle);
+                            (void)sprintf_s(propText, sizeof(propText), "PropMsg_%zu", iterator);
+                            if (Map_AddOrUpdate(propMap, "PropName", propText) != MAP_OK)
+                            {
+                                (void)printf("ERROR: Map_AddOrUpdate Failed!\r\n");
+                            }
+
+                            if (IoTHubClient_LL_SendEventAsync(iotHubClientHandle, messages[iterator].messageHandle, SendConfirmationCallback, &messages[iterator]) != IOTHUB_CLIENT_OK)
+                            {
+                                (void)printf("ERROR: IoTHubClient_LL_SendEventAsync..........FAILED!\r\n");
+                            }
+                            else
+                            {
+                                (void)printf("IoTHubClient_LL_SendEventAsync accepted message [%d] for transmission to IoT Hub.\r\n", (int)iterator);
+                            }
+                        }
+                        iterator++;
+                    }
+                    IoTHubClient_LL_DoWork(iotHubClientHandle);
+                    ThreadAPI_Sleep(1);
+
+                    if (callbackCounter >= MESSAGE_COUNT)
+                    {
+                        printf("exit\n");
+                        break;
+                    }
+                } while (g_continueRunning);
+
+                (void)printf("iothub_client_sample_mqtt has gotten quit message, call DoWork %d more time to complete final sending...\r\n", DOWORK_LOOP_NUM);
+                size_t index = 0;
+                for (index = 0; index < DOWORK_LOOP_NUM; index++)
+                {
+                    IoTHubClient_LL_DoWork(iotHubClientHandle);
+                    ThreadAPI_Sleep(1);
+                }
+            }
+            IoTHubClient_LL_Destroy(iotHubClientHandle);
+        }
+        platform_deinit();
+    }
+}
+
+int main(void)
+{
+    iothub_client_sample_mqtt_esp8266_run();
+    return 0;
+}

--- a/iothub_client/samples/iothub_client_sample_mqtt_esp8266/iothub_client_sample_mqtt_esp8266.h
+++ b/iothub_client/samples/iothub_client_sample_mqtt_esp8266/iothub_client_sample_mqtt_esp8266.h
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef IOTHUB_CLIENT_SAMPLE_MQTT_H
+#define IOTHUB_CLIENT_SAMPLE_MQTT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	void iothub_client_sample_mqtt_esp8266_run(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* IOTHUB_CLIENT_SAMPLE_MQTT_H */

--- a/iothub_client/samples/iothub_client_sample_mqtt_esp8266/linux/CMakeLists.txt
+++ b/iothub_client/samples/iothub_client_sample_mqtt_esp8266/linux/CMakeLists.txt
@@ -1,0 +1,26 @@
+#Copyright (c) Microsoft. All rights reserved.
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#this is CMakeLists.txt for iothub_client_sample_mqtt
+cmake_minimum_required(VERSION 2.8.11)
+
+if(WIN32)
+    message(FATAL_ERROR "This CMake file is only support Linux builds!")
+endif()
+
+set(AZUREIOT_INC_FOLDER ".." "/usr/include/azureiot")
+
+include_directories(${AZUREIOT_INC_FOLDER})
+
+add_executable(iothub_client_sample_mqtt ${iothub_client_sample_mqtt_esp8266_c_files} ${iothub_client_sample_mqtt_esp8266_h_files})
+
+target_link_libraries(iothub_client_sample_mqtt_esp8266
+    iothub_client
+    iothub_client_mqtt_transport
+    aziotsharedutil
+    umqtt
+    pthread
+    curl
+    ssl
+    crypto
+)


### PR DESCRIPTION
@mamokarz @olivierbloch @tameraw @dcristoloveanu

This PR is part of the ESP8266 port of Azure IoT C SDK. It contains updates to the mqtt samples to reduce memory consumption per request. This is necessary as the device has very minimal runtime memory, thus requires us to update the mqtt sample to wait for each request to finish before sending the next one. Please take a look. Thanks!