### PR TITLE
Add platform_init() to iothubserviceclient samples

### DIFF
--- a/iothub_service_client/samples/iothub_devicemethod_sample/iothub_devicemethod_sample.c
+++ b/iothub_service_client/samples/iothub_devicemethod_sample/iothub_devicemethod_sample.c
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 #include "azure_c_shared_utility/crt_abstractions.h"
+#include "azure_c_shared_utility/platform.h"
 #include "azure_c_shared_utility/threadapi.h"
 #include "azure_c_shared_utility/map.h"
 #include "azure_c_shared_utility/lock.h"
@@ -26,53 +27,60 @@ static unsigned int timeout = 60;
 
 void iothub_devicemethod_sample_run(void)
 {
-    (void)printf("Calling IoTHubServiceClientAuth_CreateFromConnectionString with connectionString\n");
-    IOTHUB_SERVICE_CLIENT_AUTH_HANDLE iotHubServiceClientHandle = IoTHubServiceClientAuth_CreateFromConnectionString(connectionString);
-    if (iotHubServiceClientHandle == NULL)
-    {
-        (void)printf("IoTHubServiceClientAuth_CreateFromConnectionString failed\n");
-    }
-    else
-    {
-        (void)printf("iotHubServiceClientDeviceMethodHandle has been created successfully\n");
+	if (platform_init() != 0)
+	{
+		(void)printf("Failed to initialize the platform.\r\n");
+	}
+	else
+	{
+		(void)printf("Calling IoTHubServiceClientAuth_CreateFromConnectionString with connectionString\n");
+		IOTHUB_SERVICE_CLIENT_AUTH_HANDLE iotHubServiceClientHandle = IoTHubServiceClientAuth_CreateFromConnectionString(connectionString);
+		if (iotHubServiceClientHandle == NULL)
+		{
+			(void)printf("IoTHubServiceClientAuth_CreateFromConnectionString failed\n");
+		}
+		else
+		{
+			(void)printf("iotHubServiceClientDeviceMethodHandle has been created successfully\n");
 
-        (void)printf("Creating serviceClientDeviceMethodHandle...\n");
-        IOTHUB_SERVICE_CLIENT_DEVICE_METHOD_HANDLE serviceClientDeviceMethodHandle = IoTHubDeviceMethod_Create(iotHubServiceClientHandle);
-        if (serviceClientDeviceMethodHandle == NULL)
-        {
-            (void)printf("IoTHubDeviceMethod_Create failed\n");
-        }
-        else
-        {
-            (void)printf("serviceClientDeviceMethodHandle has been created successfully\n");
+			(void)printf("Creating serviceClientDeviceMethodHandle...\n");
+			IOTHUB_SERVICE_CLIENT_DEVICE_METHOD_HANDLE serviceClientDeviceMethodHandle = IoTHubDeviceMethod_Create(iotHubServiceClientHandle);
+			if (serviceClientDeviceMethodHandle == NULL)
+			{
+				(void)printf("IoTHubDeviceMethod_Create failed\n");
+			}
+			else
+			{
+				(void)printf("serviceClientDeviceMethodHandle has been created successfully\n");
 
-            (void)printf("Invoking method on device...\n");
+				(void)printf("Invoking method on device...\n");
 
-            int responseStatus;
-            unsigned char* responsePayload;
-            size_t responsePayloadSize;
-            IOTHUB_DEVICE_METHOD_RESULT invokeResult = IoTHubDeviceMethod_Invoke(serviceClientDeviceMethodHandle, deviceId, methodName, methodPayload, timeout, &responseStatus, &responsePayload, &responsePayloadSize);
-            if (invokeResult == IOTHUB_DEVICE_METHOD_OK)
-            {
-                printf("\r\nDevice Method called\r\n");
-                printf("Device Method name:    %s\r\n", methodName);
-                printf("Device Method payload: %s\r\n", methodPayload);
+				int responseStatus;
+				unsigned char* responsePayload;
+				size_t responsePayloadSize;
+				IOTHUB_DEVICE_METHOD_RESULT invokeResult = IoTHubDeviceMethod_Invoke(serviceClientDeviceMethodHandle, deviceId, methodName, methodPayload, timeout, &responseStatus, &responsePayload, &responsePayloadSize);
+				if (invokeResult == IOTHUB_DEVICE_METHOD_OK)
+				{
+					printf("\r\nDevice Method called\r\n");
+					printf("Device Method name:    %s\r\n", methodName);
+					printf("Device Method payload: %s\r\n", methodPayload);
 
-                printf("\r\nResponse status: %d\r\n", responseStatus);
-                printf("Response payload: %.*s\r\n", (int)responsePayloadSize, (const char*)responsePayload);
+					printf("\r\nResponse status: %d\r\n", responseStatus);
+					printf("Response payload: %.*s\r\n", (int)responsePayloadSize, (const char*)responsePayload);
+					free(responsePayload);
+				}
+				else
+				{
+					(void)printf("IoTHubDeviceMethod_Invoke failed with result: %d\n", invokeResult);
+				}
 
-                free(responsePayload);
-            }
-            else
-            {
-                (void)printf("IoTHubDeviceMethod_Invoke failed with result: %d\n", invokeResult);
-            }
+				(void)printf("Calling IoTHubDeviceMethod_Destroy...\n");
+				IoTHubDeviceMethod_Destroy(serviceClientDeviceMethodHandle);
+			}
 
-            (void)printf("Calling IoTHubDeviceMethod_Destroy...\n");
-            IoTHubDeviceMethod_Destroy(serviceClientDeviceMethodHandle);
-        }
-
-        (void)printf("Calling IoTHubServiceClientAuth_Destroy...\n");
-        IoTHubServiceClientAuth_Destroy(iotHubServiceClientHandle);
-    }
+			(void)printf("Calling IoTHubServiceClientAuth_Destroy...\n");
+			IoTHubServiceClientAuth_Destroy(iotHubServiceClientHandle);
+		}
+		platform_deinit();
+	}
 }

--- a/iothub_service_client/samples/iothub_devicetwin_sample/iothub_devicetwin_sample.c
+++ b/iothub_service_client/samples/iothub_devicetwin_sample/iothub_devicetwin_sample.c
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 #include "azure_c_shared_utility/crt_abstractions.h"
+#include "azure_c_shared_utility/platform.h"
 #include "azure_c_shared_utility/threadapi.h"
 #include "azure_c_shared_utility/map.h"
 #include "azure_c_shared_utility/lock.h"
@@ -25,63 +26,69 @@ static const char* deviceId = "[Device Id]";
 
 void iothub_devicetwin_sample_run(void)
 {
-    //IOTHUB_TWIN_REQUEST_GET               GET      {iot hub}/twins/{device id}                     // Get device twin  
-    //IOTHUB_TWIN_REQUEST_UPDATE            PATCH    {iot hub}/twins/{device id}                     // Partally update device twin
-    //IOTHUB_TWIN_REQUEST_REPLACE_TAGS      PUT      {iot hub}/twins/{device id}/tags                // Replace update tags
-    //IOTHUB_TWIN_REQUEST_REPLACE_DESIRED   PUT      {iot hub}/twins/{device id}/properties/desired  // Replace update desired properties
-    //IOTHUB_TWIN_REQUEST_UPDATE_DESIRED    PATCH    {iot hub}/twins/{device id}/properties/desired  // Partially update desired properties
+	//IOTHUB_TWIN_REQUEST_GET               GET      {iot hub}/twins/{device id}                     // Get device twin
+	//IOTHUB_TWIN_REQUEST_UPDATE            PATCH    {iot hub}/twins/{device id}                     // Partally update device twin
+	//IOTHUB_TWIN_REQUEST_REPLACE_TAGS      PUT      {iot hub}/twins/{device id}/tags                // Replace update tags
+	//IOTHUB_TWIN_REQUEST_REPLACE_DESIRED   PUT      {iot hub}/twins/{device id}/properties/desired  // Replace update desired properties
+	//IOTHUB_TWIN_REQUEST_UPDATE_DESIRED    PATCH    {iot hub}/twins/{device id}/properties/desired  // Partially update desired properties
 
-    xlogging_set_log_function(consolelogger_log);
+	xlogging_set_log_function(consolelogger_log);
+	if (platform_init() != 0)
+	{
+		(void)printf("Failed to initialize the platform.\r\n");
+	}
+	else
+	{
+		(void)printf("Calling IoTHubServiceClientAuth_CreateFromConnectionString with the connection string\r\n");
+		IOTHUB_SERVICE_CLIENT_AUTH_HANDLE iotHubServiceClientHandle = IoTHubServiceClientAuth_CreateFromConnectionString(connectionString);
+		if (iotHubServiceClientHandle == NULL)
+		{
+			(void)printf("IoTHubServiceClientAuth_CreateFromConnectionString failed\r\n");
+		}
+		else
+		{
+			(void)printf("iotHubServiceClientHandle has been created successfully\r\n");
 
-    (void)printf("Calling IoTHubServiceClientAuth_CreateFromConnectionString with the connection string\r\n");
-    IOTHUB_SERVICE_CLIENT_AUTH_HANDLE iotHubServiceClientHandle = IoTHubServiceClientAuth_CreateFromConnectionString(connectionString);
-    if (iotHubServiceClientHandle == NULL)
-    {
-        (void)printf("IoTHubServiceClientAuth_CreateFromConnectionString failed\r\n");
-    }
-    else
-    {
-        (void)printf("iotHubServiceClientHandle has been created successfully\r\n");
+			IOTHUB_SERVICE_CLIENT_DEVICE_TWIN_HANDLE serviceClientDeviceTwinHandle = IoTHubDeviceTwin_Create(iotHubServiceClientHandle);
+			if (serviceClientDeviceTwinHandle == NULL)
+			{
+				(void)printf("IoTHubDeviceTwin_Create failed\r\n");
+			}
+			else
+			{
+				(void)printf("Getting DeviceTwin...\r\n");
 
-        IOTHUB_SERVICE_CLIENT_DEVICE_TWIN_HANDLE serviceClientDeviceTwinHandle = IoTHubDeviceTwin_Create(iotHubServiceClientHandle);
-        if (serviceClientDeviceTwinHandle == NULL)
-        {
-            (void)printf("IoTHubDeviceTwin_Create failed\r\n");
-        }
-        else
-        {
-            (void)printf("Getting DeviceTwin...\r\n");
+				char* deviceTwinJson;
 
-            char* deviceTwinJson;
+				if ((deviceTwinJson = IoTHubDeviceTwin_GetTwin(serviceClientDeviceTwinHandle, deviceId)) == NULL)
+				{
+					(void)printf("IoTHubDeviceTwin_GetTwin failed\r\n");
+				}
+				else
+				{
+					(void)printf("\r\nDeviceTwin:\r\n");
+					printf("%s\r\n", deviceTwinJson);
 
-            if ((deviceTwinJson = IoTHubDeviceTwin_GetTwin(serviceClientDeviceTwinHandle, deviceId)) == NULL)
-            {
-                (void)printf("IoTHubDeviceTwin_GetTwin failed\r\n");
-            }
-            else
-            {
-                (void)printf("\r\nDeviceTwin:\r\n");
-                printf("%s\r\n", deviceTwinJson);
+					const char* updateJson = "{\"properties\":{\"desired\":{\"telemetryInterval\":30}}}";
+					char* updatedDeviceTwinJson;
 
-                const char* updateJson = "{\"properties\":{\"desired\":{\"telemetryInterval\":30}}}";
-                char* updatedDeviceTwinJson;
+					if ((updatedDeviceTwinJson = IoTHubDeviceTwin_UpdateTwin(serviceClientDeviceTwinHandle, deviceId, updateJson)) == NULL)
+					{
+						(void)printf("IoTHubDeviceTwin_UpdateTwin failed\r\n");
+					}
+					else
+					{
+						(void)printf("\r\nDeviceTwin has been successfully updated (partial update):\r\n");
+						printf("%s\r\n", updatedDeviceTwinJson);
+						free(updatedDeviceTwinJson);
+					}
 
-                if ((updatedDeviceTwinJson = IoTHubDeviceTwin_UpdateTwin(serviceClientDeviceTwinHandle, deviceId, updateJson)) == NULL)
-                {
-                    (void)printf("IoTHubDeviceTwin_UpdateTwin failed\r\n");
-                }
-                else
-                {
-                    (void)printf("\r\nDeviceTwin has been successfully updated (partial update):\r\n");
-                    printf("%s\r\n", updatedDeviceTwinJson);
-
-                    free(updatedDeviceTwinJson);
-                }
-
-                free(deviceTwinJson);
-            }
-            IoTHubDeviceTwin_Destroy(serviceClientDeviceTwinHandle);
-        }
-        IoTHubServiceClientAuth_Destroy(iotHubServiceClientHandle);
-    }
+					free(deviceTwinJson);
+				}
+				IoTHubDeviceTwin_Destroy(serviceClientDeviceTwinHandle);
+			}
+			IoTHubServiceClientAuth_Destroy(iotHubServiceClientHandle);
+		}
+		platform_deinit();
+	}
 }


### PR DESCRIPTION
Fix curl_easy_perform() failed: Out of memory error seen when executing iothub_devicemethod and iothub_devicetwin iothub_service_client samples
