### PR TITLE
Fix version tag format strings in devbox_setup.md (originally pull req #98)

### DIFF
--- a/doc/devbox_setup.md
+++ b/doc/devbox_setup.md
@@ -23,7 +23,7 @@ This document describes how to prepare your development environment to use the *
 
 - Clone the latest release of SDK to your local machine using the tag name you found:
   ```
-  git clone -b <yyyy-dd-mm> --recursive https://github.com/Azure/azure-iot-sdk-c.git
+  git clone -b <yyyy-mm-dd> --recursive https://github.com/Azure/azure-iot-sdk-c.git
   ```
 
   > The `--recursive` argument instructs git to clone other GitHub repos this SDK depends on. Dependencies are listed [here](https://github.com/Azure/azure-iot-sdk-c/blob/master/.gitmodules).
@@ -150,7 +150,7 @@ This section describes how to set up a development environment for the C SDK on 
 
 - Clone the latest release of SDK to your local machine using the tag name you found:
   ```
-  git clone -b <yyyy-dd-mm> --recursive https://github.com/Azure/azure-iot-sdk-c.git
+  git clone -b <yyyy-mm-dd> --recursive https://github.com/Azure/azure-iot-sdk-c.git
   ```
   > The `--recursive` argument instructs git to clone other GitHub repos this SDK depends on. Dependencies are listed [here](https://github.com/Azure/azure-iot-sdk-c/blob/master/.gitmodules).
 
@@ -205,7 +205,7 @@ We've tested the device SDK for C on macOS Sierra, with XCode version 8.
 
 - Clone the latest release of SDK to your local machine using the tag name you found:
   ```
-  git clone -b <yyyy-dd-mm> --recursive https://github.com/Azure/azure-iot-sdk-c.git
+  git clone -b <yyyy-mm-dd> --recursive https://github.com/Azure/azure-iot-sdk-c.git
   ```
   > The `--recursive` argument instructs git to clone other GitHub repos this SDK depends on. Dependencies are listed [here](https://github.com/Azure/azure-iot-sdk-c/blob/master/.gitmodules).
 
@@ -255,7 +255,7 @@ To build the SDK:
 
 - Clone the latest release of SDK to your local machine using the tag name you found:
   ```
-  git clone -b <yyyy-dd-mm> --recursive https://github.com/Azure/azure-iot-sdk-c.git
+  git clone -b <yyyy-mm-dd> --recursive https://github.com/Azure/azure-iot-sdk-c.git
   ```
 
   > The `--recursive` argument instructs git to clone other GitHub repos this SDK depends on. Dependencies are listed [here](https://github.com/Azure/azure-iot-sdk-c/blob/master/.gitmodules).


### PR DESCRIPTION
…q #98)

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [x] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-c/pull/98#pullrequestreview-29244021

# Description of the problem
devbox_setup.md has the version tag strings in incorrect format (yyyy-dd-mm; they should be yyyy-mm-dd)

# Description of the solution
Changed the format strings to reflect the actual format of the version tags (run ```git tag --list``` to confirm)