### PR TITLE
DLL is now built with the regular build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ if(IN_OPENWRT)
 endif()
 
 if (LINUX)
-    if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    if (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
         # now all static libraries use PIC flag for Python shared lib
         set(CMAKE_C_FLAGS "-fPIC ${CMAKE_C_FLAGS}")
         set(CMAKE_CXX_FLAGS "-fPIC ${CMAKE_CXX_FLAGS}")

--- a/iothub_client/CMakeLists.txt
+++ b/iothub_client/CMakeLists.txt
@@ -315,20 +315,21 @@ IF(WIN32)
     add_definitions(-DGB_MEASURE_MEMORY_FOR_THIS -DGB_DEBUG_ALLOC)
 ENDIF(WIN32)
 
-if(${build_as_dynamic})
-    add_library(iothub_client SHARED
-        ${iothub_client_c_files} 
-        ${iothub_client_h_files}
-        ./src/iothub_client.def
-    )
-    target_link_libraries(iothub_client ${iothub_client_libs})
-
-else()
-    add_library(iothub_client
-        ${iothub_client_c_files} 
-        ${iothub_client_h_files}
-    )
+add_library(iothub_client_dll SHARED
+    ${iothub_client_c_files} 
+    ${iothub_client_h_files}
+    ./src/iothub_client.def
+)
+target_link_libraries(iothub_client_dll ${iothub_client_libs})
+if(NOT WIN32)
+set_target_properties(iothub_client_dll PROPERTIES OUTPUT_NAME "iothub_client")
 endif()
+
+add_library(iothub_client
+    ${iothub_client_c_files} 
+    ${iothub_client_h_files}
+)
+target_link_libraries(iothub_client ${iothub_client_libs})
 
 linkSharedUtil(iothub_client)
 set(iothub_client_libs


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [X] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
The windows_c_dynamic build is a useless waste of electrons. And electrons are not happy when they are wasted.

# Description of the solution
Build IoTHub Client DLL as part of regular build.