### PR TITLE
Fix for incorrect generation of USERNAME string when trying to reconnect in MQTT protocol.

### DIFF
--- a/iothub_client/src/iothubtransport_mqtt_common.c
+++ b/iothub_client/src/iothubtransport_mqtt_common.c
@@ -1721,6 +1721,8 @@ static int SendMqttConnectMsg(PMQTTTRANSPORT_HANDLE_DATA transport_data)
     {
         void* product_info;
         STRING_HANDLE clone;
+		// Create a clone of 'transport_data->configPassedThroughUsername' to keep the original
+		STRING_HANDLE configPassedThroughUsernameClone = STRING_clone(transport_data->configPassedThroughUsername);
         if ((IoTHubClient_LL_GetOption(transport_data->llClientHandle, OPTION_PRODUCT_INFO, &product_info) == IOTHUB_CLIENT_ERROR) || (product_info == NULL))
         {
             clone = STRING_construct_sprintf("%s%%2F%s", CLIENT_DEVICE_TYPE_PREFIX, IOTHUB_SDK_VERSION);
@@ -1731,14 +1733,14 @@ static int SendMqttConnectMsg(PMQTTTRANSPORT_HANDLE_DATA transport_data)
         }
         if (clone != NULL)
         {
-            (void)STRING_concat_with_STRING(transport_data->configPassedThroughUsername, clone);
+			(void)STRING_concat_with_STRING(configPassedThroughUsernameClone, clone);
             STRING_delete(clone);
         }
 
         MQTT_CLIENT_OPTIONS options = { 0 };
         options.clientId = (char*)STRING_c_str(transport_data->device_id);
         options.willMessage = NULL;
-        options.username = (char*)STRING_c_str(transport_data->configPassedThroughUsername);
+		options.username = (char*)STRING_c_str(configPassedThroughUsernameClone);
         if (sasToken != NULL)
         {
             options.password = sasToken;
@@ -1764,7 +1766,9 @@ static int SendMqttConnectMsg(PMQTTTRANSPORT_HANDLE_DATA transport_data)
         {
             result = __FAILURE__;
         }
-            
+        
+		STRING_delete(configPassedThroughUsernameClone);		
+			
         if (sasToken != NULL)
         {
             free(sasToken);

--- a/iothub_client/src/iothubtransport_mqtt_common.c
+++ b/iothub_client/src/iothubtransport_mqtt_common.c
@@ -1721,8 +1721,8 @@ static int SendMqttConnectMsg(PMQTTTRANSPORT_HANDLE_DATA transport_data)
     {
         void* product_info;
         STRING_HANDLE clone;
-		// Create a clone of 'transport_data->configPassedThroughUsername' to keep the original
-		STRING_HANDLE configPassedThroughUsernameClone = STRING_clone(transport_data->configPassedThroughUsername);
+        // Create a clone of 'transport_data->configPassedThroughUsername' to keep the original
+        STRING_HANDLE configPassedThroughUsernameClone = STRING_clone(transport_data->configPassedThroughUsername);
         if ((IoTHubClient_LL_GetOption(transport_data->llClientHandle, OPTION_PRODUCT_INFO, &product_info) == IOTHUB_CLIENT_ERROR) || (product_info == NULL))
         {
             clone = STRING_construct_sprintf("%s%%2F%s", CLIENT_DEVICE_TYPE_PREFIX, IOTHUB_SDK_VERSION);
@@ -1733,14 +1733,14 @@ static int SendMqttConnectMsg(PMQTTTRANSPORT_HANDLE_DATA transport_data)
         }
         if (clone != NULL)
         {
-			(void)STRING_concat_with_STRING(configPassedThroughUsernameClone, clone);
+            (void)STRING_concat_with_STRING(configPassedThroughUsernameClone, clone);
             STRING_delete(clone);
         }
 
         MQTT_CLIENT_OPTIONS options = { 0 };
         options.clientId = (char*)STRING_c_str(transport_data->device_id);
         options.willMessage = NULL;
-		options.username = (char*)STRING_c_str(configPassedThroughUsernameClone);
+        options.username = (char*)STRING_c_str(configPassedThroughUsernameClone);
         if (sasToken != NULL)
         {
             options.password = sasToken;
@@ -1767,7 +1767,7 @@ static int SendMqttConnectMsg(PMQTTTRANSPORT_HANDLE_DATA transport_data)
             result = __FAILURE__;
         }
         
-		STRING_delete(configPassedThroughUsernameClone);		
+        STRING_delete(configPassedThroughUsernameClone);		
 			
         if (sasToken != NULL)
         {


### PR DESCRIPTION
When the MQTT protocol tries to reconnect, the 'DeviceClientType' property is appended to the username string on each connection retry. So, that property is repeated the number of times a reconnection has happened. These screenshots are self-explanatory.

First connection:
![image](https://cloud.githubusercontent.com/assets/26146170/26500863/e1395b54-4237-11e7-9bf6-dec95b29114b.png)

After several connection retries:
![image](https://cloud.githubusercontent.com/assets/26146170/26500871/eee95376-4237-11e7-86d0-ca7825e78a30.png)

The solution is to create a temporary string to append the 'DeviceClientType' and use it as the username for the MQTT client options.