### PR TITLE
doc: don't mention skipping tests as they are not run by default

### DIFF
--- a/doc/SDK_cross_compile_example.md
+++ b/doc/SDK_cross_compile_example.md
@@ -95,7 +95,7 @@ The final step in the process is to run the actual build. For this you will need
 cd ~/Source/azure-iot-sdks/c/build_all/linux
 ./build.sh --toolchain-file toolchain-rpi.cmake -cl --sysroot=$RPI_ROOT
 ```
-This will tell cmake to build the SDK using the toolchain file toolchain-rpi.cmake and skip running all tests which is important since the executables will (probably) not run successfully on the host anyway. Finally, and absolutely critical is the use of the *--sysroot* option. Without this the compiler will fail to find required headers and libraries.
+This will tell cmake to build the SDK using the toolchain file toolchain-rpi.cmake. Finally, and absolutely critical is the use of the *--sysroot* option. Without this the compiler will fail to find required headers and libraries.
 
 ### Specifying Additional Build Flags
 


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [X] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
The documentation for cross-compiling mentions unit tests being skipped when running a particular build command, but the option to skip tests does not exist anymore. So that part was misleading.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Removed the part mentioning unit tests.