### PR TITLE
Stop including the cstdbool header for C++.

### DIFF
--- a/iothub_client/inc/iothub_client_authorization.h
+++ b/iothub_client/inc/iothub_client_authorization.h
@@ -6,7 +6,6 @@
 
 #ifdef __cplusplus
 extern "C" {
-#include <cstdbool>
 #else
 #include <stdbool.h>
 #endif /* __cplusplus */

--- a/iothub_client/tests/common_dt_e2e/iothubclient_common_dt_e2e.c
+++ b/iothub_client/tests/common_dt_e2e/iothubclient_common_dt_e2e.c
@@ -4,7 +4,6 @@
 #ifdef __cplusplus
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #else
 #include <stdlib.h>
 #include <stddef.h>

--- a/iothub_client/tests/common_e2e/iothubclient_common_e2e.c
+++ b/iothub_client/tests/common_e2e/iothubclient_common_e2e.c
@@ -4,7 +4,6 @@
 #ifdef __cplusplus
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #include <cstring>
 #else
 #include <stdlib.h>

--- a/iothub_client/tests/iothub_client_retry_control_ut/iothub_client_retry_control_ut.c
+++ b/iothub_client/tests/iothub_client_retry_control_ut/iothub_client_retry_control_ut.c
@@ -5,7 +5,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #include <cstdint>
 #else
 #include <stdio.h>

--- a/iothub_client/tests/iothubclient_ut/iothubclient_ut.c
+++ b/iothub_client/tests/iothubclient_ut/iothubclient_ut.c
@@ -4,7 +4,6 @@
 #ifdef __cplusplus
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #else
 #include <stdlib.h>
 #include <stddef.h>

--- a/iothub_client/tests/iothubtr_amqp_tel_msgr_ut/iothubtr_amqp_tel_msgr_ut.c
+++ b/iothub_client/tests/iothubtr_amqp_tel_msgr_ut/iothubtr_amqp_tel_msgr_ut.c
@@ -5,7 +5,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #include <cstdint>
 #else
 #include <stdio.h>

--- a/iothub_client/tests/iothubtransport_amqp_common_ut/iothubtransport_amqp_common_ut.c
+++ b/iothub_client/tests/iothubtransport_amqp_common_ut/iothubtransport_amqp_common_ut.c
@@ -5,7 +5,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #include <ctime>
 #else
 #include <stdio.h>

--- a/iothub_client/tests/iothubtransport_amqp_device_ut/iothubtransport_amqp_device_ut.c
+++ b/iothub_client/tests/iothubtransport_amqp_device_ut/iothubtransport_amqp_device_ut.c
@@ -5,7 +5,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #include <cstdint>
 #else
 #include <stdio.h>

--- a/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
+++ b/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
@@ -5,7 +5,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #else
 #include <stdio.h>
 #include <stdlib.h>

--- a/iothub_client/tests/iothubtransport_ut/iothubtransport_ut.cpp
+++ b/iothub_client/tests/iothubtransport_ut/iothubtransport_ut.cpp
@@ -3,7 +3,6 @@
 
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #include "testrunnerswitcher.h"
 #include "micromock.h"
 #include "micromockcharstararenullterminatedstrings.h"

--- a/iothub_client/tests/iothubtransportamqp_methods_ut/iothubtransportamqp_methods_ut.c
+++ b/iothub_client/tests/iothubtransportamqp_methods_ut/iothubtransportamqp_methods_ut.c
@@ -5,7 +5,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #else
 #include <stdio.h>
 #include <stdlib.h>

--- a/iothub_client/tests/iothubtransporthttp_ut/iothubtransporthttp_ut.cpp
+++ b/iothub_client/tests/iothubtransporthttp_ut/iothubtransporthttp_ut.cpp
@@ -3,7 +3,6 @@
 
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #include "testrunnerswitcher.h"
 #include "micromock.h"
 #include "micromockcharstararenullterminatedstrings.h"

--- a/iothub_client/tests/longhaul_tests/longhaul_tests.cpp
+++ b/iothub_client/tests/longhaul_tests/longhaul_tests.cpp
@@ -4,7 +4,6 @@
 
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #include <limits.h>
 #include "testrunnerswitcher.h"
 #include "micromock.h"

--- a/iothub_client/tests/uamqp_messaging_ut/uamqp_messaging_ut.c
+++ b/iothub_client/tests/uamqp_messaging_ut/uamqp_messaging_ut.c
@@ -4,7 +4,6 @@
 #ifdef __cplusplus
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #else
 #include <stdlib.h>
 #include <stddef.h>

--- a/serializer/tests/agentmacros_ut/agentmacros_ut.cpp
+++ b/serializer/tests/agentmacros_ut/agentmacros_ut.cpp
@@ -3,7 +3,6 @@
 
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #include "azure_c_shared_utility/optimize_size.h"
 #include "azure_c_shared_utility/macro_utils.h"
 #include "testrunnerswitcher.h"

--- a/serializer/tests/agenttypesystem_ut/agenttypesystem_ut.cpp
+++ b/serializer/tests/agenttypesystem_ut/agenttypesystem_ut.cpp
@@ -4,7 +4,6 @@
 #include <cstdlib>
 #include <cstdint>
 #include <cstddef>
-#include <cstdbool>
 #include <climits>
 #include <cfloat>
 

--- a/serializer/tests/datapublisher_ut/datapublisher_ut.c
+++ b/serializer/tests/datapublisher_ut/datapublisher_ut.c
@@ -4,7 +4,6 @@
 #ifdef __cplusplus
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #else
 #include <stdlib.h>
 #include <stddef.h>

--- a/serializer/tests/iotdevice_ut/iotdevice_ut.c
+++ b/serializer/tests/iotdevice_ut/iotdevice_ut.c
@@ -4,7 +4,6 @@
 #ifdef __cplusplus
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #else
 #include <stdlib.h>
 #include <stddef.h>

--- a/serializer/tests/jsonencoder_ut/jsonencoder_ut.cpp
+++ b/serializer/tests/jsonencoder_ut/jsonencoder_ut.cpp
@@ -3,7 +3,6 @@
 
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #include "testrunnerswitcher.h"
 #include "azure_c_shared_utility/optimize_size.h"
 #include "azure_c_shared_utility/crt_abstractions.h"

--- a/serializer/tests/multitree_ut/multitree_ut.cpp
+++ b/serializer/tests/multitree_ut/multitree_ut.cpp
@@ -3,7 +3,6 @@
 
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #include "testrunnerswitcher.h"
 #include "micromock.h"
 #include "micromockcharstararenullterminatedstrings.h"

--- a/serializer/tests/schemalib_ut/schemalib_ut.cpp
+++ b/serializer/tests/schemalib_ut/schemalib_ut.cpp
@@ -3,7 +3,6 @@
 
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #include "testrunnerswitcher.h"
 #include "micromock.h"
 #include "micromockcharstararenullterminatedstrings.h"

--- a/serializer/tests/schemalib_without_init_ut/schemalib_without_init_ut.cpp
+++ b/serializer/tests/schemalib_without_init_ut/schemalib_without_init_ut.cpp
@@ -3,7 +3,6 @@
 
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #include "azure_c_shared_utility/crt_abstractions.h"
 #include "testrunnerswitcher.h"
 #include "micromock.h"

--- a/serializer/tests/serializer_dt_ut/serializer_dt_ut.c
+++ b/serializer/tests/serializer_dt_ut/serializer_dt_ut.c
@@ -4,7 +4,6 @@
 #ifdef __cplusplus
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #include <cstdint>
 #else
 #include <stdlib.h>

--- a/serializer/tests/serializer_e2e/serializer_e2e.c
+++ b/serializer/tests/serializer_e2e/serializer_e2e.c
@@ -4,7 +4,6 @@
 #ifdef __cplusplus
 #include <cstdlib>
 #include <cstddef>
-#include <cstdbool>
 #include <ctime>
 #else
 #include <stdlib.h>


### PR DESCRIPTION
It doesn't do anything useful, and it's deprecated in C++17.

Fixes Azure/azure-iot-sdk-c#155.