### PR TITLE
Fix Linux install for iothub_service_client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,8 @@ else()
     set(THREAD_C_FILE ${SHARED_UTIL_ADAPTER_FOLDER}/threadapi_pthreads.c)
 endif()
 
+#Set CMAKE_INSTALL_LIBDIR if not defined
+include(GNUInstallDirs)
 
 if(NOT ${use_amqp} OR NOT ${use_http})
     set (build_service_client OFF)
@@ -230,8 +232,6 @@ if("${build_javawrapper}" STREQUAL "ON")
 endif()
 
 
-#Set CMAKE_INSTALL_LIBDIR if not defined
-include(GNUInstallDirs)
 
 if(${use_installed_dependencies})
     #Install azure_iot_sdks

--- a/iothub_client/CMakeLists.txt
+++ b/iothub_client/CMakeLists.txt
@@ -365,8 +365,6 @@ if(NOT IN_OPENWRT)
 endif()
 
 if(${use_installed_dependencies})
-    #Set CMAKE_INSTALL_LIBDIR if not defined
-    include(GNUInstallDirs)
 
     if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
         set(CMAKE_INSTALL_LIBDIR "lib")

--- a/iothub_client/CMakeLists.txt
+++ b/iothub_client/CMakeLists.txt
@@ -372,6 +372,10 @@ if(${use_installed_dependencies})
         set(CMAKE_INSTALL_LIBDIR "lib")
     endif()
 
+    if(NOT DEFINED CMAKE_INSTALL_INCLUDEDIR)    
+        set(CMAKE_INSTALL_INCLUDEDIR "include") 
+    endif()                                     
+
     install(TARGETS ${iothub_client_libs} EXPORT azure_iot_sdksTargets
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/iothub_service_client/CMakeLists.txt
+++ b/iothub_service_client/CMakeLists.txt
@@ -81,8 +81,14 @@ if(NOT IN_OPENWRT)
 endif()
 
 if(${use_installed_dependencies})
+    include(GNUInstallDirs)
+
     if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
         set(CMAKE_INSTALL_LIBDIR "lib")
+    endif()
+    
+    if(NOT DEFINED CMAKE_INSTALL_INCLUDEDIR)
+        set(CMAKE_INSTALL_INCLUDEDIR "include")
     endif()
 
     install(TARGETS iothub_service_client EXPORT azure_iot_sdksTargets

--- a/iothub_service_client/CMakeLists.txt
+++ b/iothub_service_client/CMakeLists.txt
@@ -81,7 +81,6 @@ if(NOT IN_OPENWRT)
 endif()
 
 if(${use_installed_dependencies})
-    include(GNUInstallDirs)
 
     if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
         set(CMAKE_INSTALL_LIBDIR "lib")


### PR DESCRIPTION
Force a default for `CMAKE_INSTALL_INCLUDEDIR`, include GNUInstallDirs for service client install.

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [X] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
Iot-Edge was not building - our build installs the C SDK libraries into an "install-deps" folder, but the service client was not installing there.  In Linux, it was attempting to install into `/azureiot` - `CMAKE_INSTALL_INCLUDEDIR` was not defined.



# Description of the solution



I included the GNUInstallDirs  into the service client CMakefile to guarantee the behavior the Edge wants, but I also set a default like we set a default for `CMAKE_INSTALL_LIBDIR`.