### PR TITLE
Add E2E diagnostic support for AMQP protocol

### DIFF
--- a/iothub_client/devdoc/requirement_docs/uamqp_messaging_requirements.md
+++ b/iothub_client/devdoc/requirement_docs/uamqp_messaging_requirements.md
@@ -92,4 +92,6 @@ Creates a binary blob containing AMQP encoding of the same message defined by th
 **SRS_UAMQP_MESSAGING_31_119: [**Invoke underlying AMQP encode routines on data waiting to be encoded.  .**]**
 **SRS_UAMQP_MESSAGING_31_120: [**Create a blob that contains AMQP encoding of IOTHUB_MESSAGE_HANDLE.**]**
 **SRS_UAMQP_MESSAGING_31_121: [**Any errors during `message_create_uamqp_encoding_from_iothub_message` stop processing on this message.**]**
+**SRS_UAMQP_MESSAGING_32_001: [**If optional diagnostic properties are present in the iot hub message, encode them into the AMQP message as annotation properties.**]**
+**SRS_UAMQP_MESSAGING_32_002: [**If optional diagnostic properties are not present in the iot hub message, no error should happen.**]**
 

--- a/iothub_client/devdoc/requirement_docs/uamqp_messaging_requirements.md
+++ b/iothub_client/devdoc/requirement_docs/uamqp_messaging_requirements.md
@@ -92,6 +92,6 @@ Creates a binary blob containing AMQP encoding of the same message defined by th
 **SRS_UAMQP_MESSAGING_31_119: [**Invoke underlying AMQP encode routines on data waiting to be encoded.  .**]**
 **SRS_UAMQP_MESSAGING_31_120: [**Create a blob that contains AMQP encoding of IOTHUB_MESSAGE_HANDLE.**]**
 **SRS_UAMQP_MESSAGING_31_121: [**Any errors during `message_create_uamqp_encoding_from_iothub_message` stop processing on this message.**]**
-**SRS_UAMQP_MESSAGING_32_001: [**If optional diagnostic properties are present in the iot hub message, encode them into the AMQP message as annotation properties.**]**
+**SRS_UAMQP_MESSAGING_32_001: [**If optional diagnostic properties are present in the iot hub message, encode them into the AMQP message as annotation properties: `Diagnostic-Id` `Correlation-Context`.**]**
 **SRS_UAMQP_MESSAGING_32_002: [**If optional diagnostic properties are not present in the iot hub message, no error should happen.**]**
 

--- a/iothub_client/src/uamqp_messaging.c
+++ b/iothub_client/src/uamqp_messaging.c
@@ -24,6 +24,10 @@
 
 #define MESSAGE_ID_MAX_SIZE 128
 
+#define AMQP_DIAGNOSTIC_ID_KEY "Diagnostic-Id"
+#define AMQP_DIAGNOSTIC_CONTEXT_KEY "Correlation-Context"
+#define AMQP_DIAGNOSTIC_CREATION_TIME_UTC_KEY "creationtimeutc"
+
 static int encode_callback(void* context, const unsigned char* bytes, size_t length)
 {
     BINARY_DATA* message_body_binary = (BINARY_DATA*)context;
@@ -308,6 +312,118 @@ static int create_application_properties_to_encode(IOTHUB_MESSAGE_HANDLE message
     return result;
 }
 
+static int add_map_item(AMQP_VALUE map, const char* name, const char* value)
+{
+    int result;
+    AMQP_VALUE amqp_value_name;
+
+    if ((amqp_value_name = amqpvalue_create_symbol(name)) == NULL)
+    {
+        LogError("Failed creating AMQP_VALUE for name");
+        result = __FAILURE__;
+    }
+    else
+    {
+        AMQP_VALUE amqp_value_value = NULL;
+
+        if (value == NULL && (amqp_value_value = amqpvalue_create_null()) == NULL)
+        {
+            LogError("Failed creating AMQP_VALUE for NULL value");
+            result = __FAILURE__;
+        }
+        else if (value != NULL && (amqp_value_value = amqpvalue_create_string(value)) == NULL)
+        {
+            LogError("Failed creating AMQP_VALUE for value");
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (amqpvalue_set_map_value(map, amqp_value_name, amqp_value_value) != 0)
+            {
+                LogError("Failed adding key/value pair to map");
+                result = __FAILURE__;
+            }
+            else
+            {
+                result = RESULT_OK;
+            }
+
+            amqpvalue_destroy(amqp_value_value);
+        }
+
+        amqpvalue_destroy(amqp_value_name);
+    }
+
+    return result;
+}
+
+// Codes_SRS_UAMQP_MESSAGING_32_001: [If optional diagnostic properties are present in the iot hub message, encode them into the AMQP message as annotation properties. Errors stop processing on this message.]
+// Codes_SRS_UAMQP_MESSAGING_32_002: [If optional diagnostic properties are not present in the iot hub message, no error should happen.]
+static int create_message_annotations_to_encode(IOTHUB_MESSAGE_HANDLE messageHandle, AMQP_VALUE *message_annotations, size_t *message_annotations_length)
+{
+    AMQP_VALUE message_annotations_map = NULL;
+    int result;
+    const IOTHUB_MESSAGE_DIAGNOSTIC_PROPERTY_DATA* diagnosticData;
+
+    if ((diagnosticData = IoTHubMessage_GetDiagnosticPropertyData(messageHandle)) != NULL &&
+        diagnosticData->diagnosticId != NULL && diagnosticData->diagnosticCreationTimeUtc != NULL)
+    {
+        if ((message_annotations_map = amqpvalue_create_map()) == NULL)
+        {
+            LogError("Failed amqpvalue_create_map for annotations");
+            result = __FAILURE__;
+        }
+        else
+        {
+            char* diagContextBuffer = NULL;
+
+            if (add_map_item(message_annotations_map, AMQP_DIAGNOSTIC_ID_KEY, diagnosticData->diagnosticId) != RESULT_OK)
+            {
+                LogError("Failed adding diagnostic id");
+                result = __FAILURE__;
+            }
+            else if ((diagContextBuffer = (char*)malloc(strlen(AMQP_DIAGNOSTIC_CREATION_TIME_UTC_KEY) + 1
+                + strlen(diagnosticData->diagnosticCreationTimeUtc) + 1)) == NULL)
+            {
+                LogError("Failed malloc for diagnostic context");
+                result = __FAILURE__;
+            }
+            else if (sprintf(diagContextBuffer, "%s=%s", AMQP_DIAGNOSTIC_CREATION_TIME_UTC_KEY, diagnosticData->diagnosticCreationTimeUtc) < 0)
+            {
+                LogError("Failed sprintf diagnostic context");
+                result = __FAILURE__;
+            }
+            else if (add_map_item(message_annotations_map, AMQP_DIAGNOSTIC_CONTEXT_KEY, diagContextBuffer) != RESULT_OK)
+            {
+                LogError("Failed adding diagnostic context");
+                result = __FAILURE__;
+            }
+            else if((*message_annotations = amqpvalue_create_message_annotations(message_annotations_map)) == NULL)
+            {
+                LogError("Failed creating message annotations");
+                result = __FAILURE__;
+            }
+            else if (amqpvalue_get_encoded_size(*message_annotations, message_annotations_length) != 0)
+            {
+                LogError("Failed getting size of annotations");
+                result = __FAILURE__;
+            }
+            else
+            {
+                result = RESULT_OK;
+            }
+
+            free(diagContextBuffer);
+            amqpvalue_destroy(message_annotations_map);
+        }
+    }
+    else
+    {
+        result = RESULT_OK;
+    }
+    
+    return result;
+}
 
 // Codes_SRS_UAMQP_MESSAGING_31_118: [Gets data associated with IOTHUB_MESSAGE_HANDLE to encode, either from underlying byte array or string format.]
 static int create_data_to_encode(IOTHUB_MESSAGE_HANDLE messageHandle, AMQP_VALUE *data_value, size_t *data_length)
@@ -373,9 +489,11 @@ int message_create_uamqp_encoding_from_iothub_message(IOTHUB_MESSAGE_HANDLE mess
 
     AMQP_VALUE message_properties = NULL;
     AMQP_VALUE application_properties = NULL;
+    AMQP_VALUE message_annotations = NULL;
     AMQP_VALUE data_value = NULL;
     size_t message_properties_length = 0;
     size_t application_properties_length = 0;
+    size_t message_annotations_length = 0;
     size_t data_length = 0;
 
     body_binary_data->bytes = NULL;
@@ -391,14 +509,19 @@ int message_create_uamqp_encoding_from_iothub_message(IOTHUB_MESSAGE_HANDLE mess
         LogError("create_application_properties_to_encode() failed");
         result = __FAILURE__;
     }
+    else if (create_message_annotations_to_encode(message_handle, &message_annotations, &message_annotations_length) != RESULT_OK)
+    {
+        LogError("create_message_annotations_to_encode() failed");
+        result = __FAILURE__;
+    }
     else if (create_data_to_encode(message_handle, &data_value, &data_length) != RESULT_OK)
     {
         LogError("create_data_to_encode() failed");
         result = __FAILURE__;
     }
-    else if ((body_binary_data->bytes = malloc(message_properties_length + application_properties_length + data_length)) == NULL)
+    else if ((body_binary_data->bytes = malloc(message_properties_length + application_properties_length + data_length + message_annotations_length)) == NULL)
     {
-        LogError("malloc of %d bytes failed", message_properties_length + application_properties_length + data_length);
+        LogError("malloc of %d bytes failed", message_properties_length + application_properties_length + data_length + message_annotations_length);
         result = __FAILURE__;
     }
     // Codes_SRS_UAMQP_MESSAGING_31_119: [Invoke underlying AMQP encode routines on data waiting to be encoded.]
@@ -412,6 +535,11 @@ int message_create_uamqp_encoding_from_iothub_message(IOTHUB_MESSAGE_HANDLE mess
         LogError("amqpvalue_encode() for application properties failed");
         result = __FAILURE__;
     }
+    else if (message_annotations_length > 0 && amqpvalue_encode(message_annotations, &encode_callback, body_binary_data) != RESULT_OK)
+    {
+        LogError("amqpvalue_encode() for message annotations failed");
+        result = __FAILURE__;
+    }
     else if (RESULT_OK != amqpvalue_encode(data_value, &encode_callback, body_binary_data))
     {
         LogError("amqpvalue_encode() for data value failed");
@@ -419,7 +547,7 @@ int message_create_uamqp_encoding_from_iothub_message(IOTHUB_MESSAGE_HANDLE mess
     }
     else
     {
-        body_binary_data->length = message_properties_length + application_properties_length + data_length;
+        body_binary_data->length = message_properties_length + application_properties_length + data_length + message_annotations_length;
         result = RESULT_OK;
     }
 
@@ -431,6 +559,11 @@ int message_create_uamqp_encoding_from_iothub_message(IOTHUB_MESSAGE_HANDLE mess
     if (NULL != application_properties)
     {
         amqpvalue_destroy(application_properties);
+    }
+
+    if (NULL != message_annotations)
+    {
+        amqpvalue_destroy(message_annotations);
     }
 
     if (NULL != message_properties)

--- a/iothub_client/src/uamqp_messaging.c
+++ b/iothub_client/src/uamqp_messaging.c
@@ -357,8 +357,6 @@ static int add_map_item(AMQP_VALUE map, const char* name, const char* value)
     return result;
 }
 
-// Codes_SRS_UAMQP_MESSAGING_32_001: [If optional diagnostic properties are present in the iot hub message, encode them into the AMQP message as annotation properties. Errors stop processing on this message.]
-// Codes_SRS_UAMQP_MESSAGING_32_002: [If optional diagnostic properties are not present in the iot hub message, no error should happen.]
 static int create_message_annotations_to_encode(IOTHUB_MESSAGE_HANDLE messageHandle, AMQP_VALUE *message_annotations, size_t *message_annotations_length)
 {
     AMQP_VALUE message_annotations_map = NULL;
@@ -368,6 +366,7 @@ static int create_message_annotations_to_encode(IOTHUB_MESSAGE_HANDLE messageHan
     if ((diagnosticData = IoTHubMessage_GetDiagnosticPropertyData(messageHandle)) != NULL &&
         diagnosticData->diagnosticId != NULL && diagnosticData->diagnosticCreationTimeUtc != NULL)
     {
+        // Codes_SRS_UAMQP_MESSAGING_32_001: [If optional diagnostic properties are present in the iot hub message, encode them into the AMQP message as annotation properties. Errors stop processing on this message.]
         if ((message_annotations_map = amqpvalue_create_map()) == NULL)
         {
             LogError("Failed amqpvalue_create_map for annotations");
@@ -419,6 +418,7 @@ static int create_message_annotations_to_encode(IOTHUB_MESSAGE_HANDLE messageHan
     }
     else
     {
+        // Codes_SRS_UAMQP_MESSAGING_32_002: [If optional diagnostic properties are not present in the iot hub message, no error should happen.]
         result = RESULT_OK;
     }
     

--- a/iothub_client/tests/uamqp_messaging_ut/uamqp_messaging_ut.c
+++ b/iothub_client/tests/uamqp_messaging_ut/uamqp_messaging_ut.c
@@ -92,6 +92,7 @@ static int saved_amqpvalue_get_string_return = 0;
 
 static const char* TEST_CONTENT_TYPE = "text/plain";
 static const char* TEST_CONTENT_ENCODING = "utf8";
+static IOTHUB_MESSAGE_DIAGNOSTIC_PROPERTY_DATA TEST_DIAGNOSTIC_DATA = { "12345678",  "1506054179" };
 
 
 static int test_properties_get_message_id(PROPERTIES_HANDLE properties, AMQP_VALUE* message_id_value)
@@ -135,6 +136,41 @@ static int test_amqpvalue_get_uuid(AMQP_VALUE value, uuid* uuid_value)
     saved_amqpvalue_get_uuid_value = value;
     uuid_value = test_amqpvalue_get_uuid_uuid_value;
     return test_amqpvalue_get_uuid_return;
+}
+
+static void set_exp_calls_for_create_encoded_annotations_properties(bool has_diagnostic_properties)
+{
+    size_t encoding_size = TEST_AMQP_ENCODING_SIZE;
+
+    if (has_diagnostic_properties)
+    {
+        STRICT_EXPECTED_CALL(IoTHubMessage_GetDiagnosticPropertyData(TEST_IOTHUB_MESSAGE_HANDLE));
+        STRICT_EXPECTED_CALL(amqpvalue_create_map());
+
+        STRICT_EXPECTED_CALL(amqpvalue_create_symbol(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(amqpvalue_create_string(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(amqpvalue_set_map_value(TEST_AMQP_VALUE, TEST_AMQP_VALUE, TEST_AMQP_VALUE));
+        STRICT_EXPECTED_CALL(amqpvalue_destroy(TEST_AMQP_VALUE));
+        STRICT_EXPECTED_CALL(amqpvalue_destroy(TEST_AMQP_VALUE));
+
+        STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
+
+        STRICT_EXPECTED_CALL(amqpvalue_create_symbol(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(amqpvalue_create_string(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(amqpvalue_set_map_value(TEST_AMQP_VALUE, TEST_AMQP_VALUE, TEST_AMQP_VALUE));
+        STRICT_EXPECTED_CALL(amqpvalue_destroy(TEST_AMQP_VALUE));
+        STRICT_EXPECTED_CALL(amqpvalue_destroy(TEST_AMQP_VALUE));
+
+        STRICT_EXPECTED_CALL(amqpvalue_create_message_annotations(TEST_AMQP_VALUE));
+        STRICT_EXPECTED_CALL(amqpvalue_get_encoded_size(TEST_AMQP_VALUE, IGNORED_PTR_ARG))
+            .CopyOutArgumentBuffer(2, &encoding_size, sizeof(encoding_size));
+        STRICT_EXPECTED_CALL(free(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(amqpvalue_destroy(TEST_AMQP_VALUE));
+    }
+    else
+    {
+        STRICT_EXPECTED_CALL(IoTHubMessage_GetDiagnosticPropertyData(TEST_IOTHUB_MESSAGE_HANDLE)).SetReturn(NULL);
+    }
 }
 
 static void set_exp_calls_for_create_encoded_message_properties(bool has_message_id, bool has_correlation_id, const char* content_type, const char* content_encoding)
@@ -241,17 +277,22 @@ static void set_exp_calls_for_create_encoded_data(IOTHUBMESSAGE_CONTENT_TYPE msg
         .CopyOutArgumentBuffer(2, &encoding_size, sizeof(encoding_size));
 }
 
-static void set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(size_t number_of_app_properties, IOTHUBMESSAGE_CONTENT_TYPE msg_content_type, bool has_message_id, bool has_correlation_id, const char* content_type, const char* content_encoding)
+static void set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(size_t number_of_app_properties, IOTHUBMESSAGE_CONTENT_TYPE msg_content_type, bool has_message_id, bool has_correlation_id, bool has_diag_properties, const char* content_type, const char* content_encoding)
 {
     set_exp_calls_for_create_encoded_message_properties(has_message_id, has_correlation_id, content_type, content_encoding);
     set_exp_calls_for_create_encoded_application_properties(number_of_app_properties);
+    set_exp_calls_for_create_encoded_annotations_properties(has_diag_properties);
     set_exp_calls_for_create_encoded_data(msg_content_type);
 
-    STRICT_EXPECTED_CALL(malloc(IGNORED_NUM_ARG))
-        .SetReturn(g_encoding_buffer);
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
     STRICT_EXPECTED_CALL(amqpvalue_encode(TEST_AMQP_VALUE, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
 
     if (number_of_app_properties > 0)
+    {
+        STRICT_EXPECTED_CALL(amqpvalue_encode(TEST_AMQP_VALUE, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+    }
+
+    if (has_diag_properties)
     {
         STRICT_EXPECTED_CALL(amqpvalue_encode(TEST_AMQP_VALUE, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
     }
@@ -260,6 +301,10 @@ static void set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(
 
     STRICT_EXPECTED_CALL(amqpvalue_destroy(TEST_AMQP_VALUE));
     if (number_of_app_properties > 0)
+    {
+        STRICT_EXPECTED_CALL(amqpvalue_destroy(TEST_AMQP_VALUE));
+    }
+    if (has_diag_properties)
     {
         STRICT_EXPECTED_CALL(amqpvalue_destroy(TEST_AMQP_VALUE));
     }
@@ -453,6 +498,10 @@ TEST_SUITE_INITIALIZE(TestClassInitialize)
     REGISTER_UMOCK_ALIAS_TYPE(AMQP_TYPE, int);
     REGISTER_UMOCK_ALIAS_TYPE(AMQPVALUE_ENCODER_OUTPUT, void*);
     REGISTER_UMOCK_ALIAS_TYPE(data, void*);
+    REGISTER_UMOCK_ALIAS_TYPE(message_annotations, void*);
+
+    REGISTER_GLOBAL_MOCK_HOOK(gballoc_malloc, real_malloc);
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(gballoc_malloc, NULL);
 
     REGISTER_GLOBAL_MOCK_HOOK(properties_get_message_id, test_properties_get_message_id);
     REGISTER_GLOBAL_MOCK_HOOK(properties_get_correlation_id, test_properties_get_correlation_id);
@@ -547,6 +596,15 @@ TEST_SUITE_INITIALIZE(TestClassInitialize)
     REGISTER_GLOBAL_MOCK_RETURN(amqpvalue_create_application_properties, TEST_AMQP_VALUE);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(amqpvalue_create_application_properties, 0);
 
+    REGISTER_GLOBAL_MOCK_RETURN(amqpvalue_create_null, TEST_AMQP_VALUE);
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(amqpvalue_create_null, NULL);
+
+    REGISTER_GLOBAL_MOCK_RETURN(amqpvalue_create_symbol, TEST_AMQP_VALUE);
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(amqpvalue_create_symbol, NULL);
+
+    REGISTER_GLOBAL_MOCK_RETURN(amqpvalue_create_message_annotations, TEST_AMQP_VALUE);
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(amqpvalue_create_message_annotations, NULL);
+
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(IoTHubMessage_GetContentTypeSystemProperty, NULL);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(IoTHubMessage_GetContentEncodingSystemProperty, NULL);
     REGISTER_GLOBAL_MOCK_RETURN(properties_set_content_type, 0);
@@ -570,6 +628,9 @@ TEST_SUITE_INITIALIZE(TestClassInitialize)
 
     REGISTER_GLOBAL_MOCK_RETURN(UUID_to_string, TEST_UUID_STRING);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(UUID_to_string, NULL);
+
+    REGISTER_GLOBAL_MOCK_RETURN(IoTHubMessage_GetDiagnosticPropertyData, &TEST_DIAGNOSTIC_DATA);
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(IoTHubMessage_GetDiagnosticPropertyData, NULL);
 
     // Initialization of variables.
     TEST_MAP_KEYS = (char**)real_malloc(sizeof(char*) * 5);
@@ -625,11 +686,12 @@ TEST_FUNCTION_CLEANUP(TestMethodCleanup)
 // Tests_SRS_UAMQP_MESSAGING_31_115: [If optional content-encoding is present in the message, encode it into the AMQP message.  Errors stop processing on this message.]
 // Tests_SRS_UAMQP_MESSAGING_31_116: [Gets message properties associated with the IOTHUB_MESSAGE_HANDLE to encode, returning the properties and their encoded length.  Errors stop processing on this message.]
 // Tests_SRS_UAMQP_MESSAGING_31_117: [Get application message properties associated with the IOTHUB_MESSAGE_HANDLE to encode, returning the properties and their encoded length.  Errors stop processing on this message.]
+// Tests_SRS_UAMQP_MESSAGING_32_001: [If optional diagnostic properties are present in the iot hub message, encode them into the AMQP message as annotation properties. Errors stop processing on this message.]
 TEST_FUNCTION(message_create_uamqp_encoding_from_iothub_message_bytearray_success)
 {
     // arrange
     umock_c_reset_all_calls();
-    set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(1, IOTHUBMESSAGE_BYTEARRAY, true, true, TEST_CONTENT_TYPE, TEST_CONTENT_ENCODING);
+    set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(1, IOTHUBMESSAGE_BYTEARRAY, true, true, true, TEST_CONTENT_TYPE, TEST_CONTENT_ENCODING);
 
     BINARY_DATA binary_data;
     memset(&binary_data, 0, sizeof(binary_data));
@@ -649,7 +711,7 @@ TEST_FUNCTION(message_create_from_iothub_message_zero_app_properties_success)
 {
     // arrange
     umock_c_reset_all_calls();
-    set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(0, IOTHUBMESSAGE_BYTEARRAY, true, true, TEST_CONTENT_TYPE, TEST_CONTENT_ENCODING);
+    set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(0, IOTHUBMESSAGE_BYTEARRAY, true, true, true, TEST_CONTENT_TYPE, TEST_CONTENT_ENCODING);
 
     BINARY_DATA binary_data;
     memset(&binary_data, 0, sizeof(binary_data));
@@ -669,7 +731,7 @@ TEST_FUNCTION(message_create_from_iothub_message_string_success)
 {
     // arrange
     umock_c_reset_all_calls();
-    set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(1, IOTHUBMESSAGE_STRING, true, true, TEST_CONTENT_TYPE, TEST_CONTENT_ENCODING);
+    set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(1, IOTHUBMESSAGE_STRING, true, true, true, TEST_CONTENT_TYPE, TEST_CONTENT_ENCODING);
 
     BINARY_DATA binary_data;
     memset(&binary_data, 0, sizeof(binary_data));
@@ -689,7 +751,7 @@ TEST_FUNCTION(message_create_from_iothub_message_no_message_id_success)
 {
     // arrange
     umock_c_reset_all_calls();
-    set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(1, IOTHUBMESSAGE_STRING, false, true, TEST_CONTENT_TYPE, TEST_CONTENT_ENCODING);
+    set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(1, IOTHUBMESSAGE_STRING, false, true, true, TEST_CONTENT_TYPE, TEST_CONTENT_ENCODING);
 
     BINARY_DATA binary_data;
     memset(&binary_data, 0, sizeof(binary_data));
@@ -704,12 +766,32 @@ TEST_FUNCTION(message_create_from_iothub_message_no_message_id_success)
     // cleanup
 }
 
+// Tests_SRS_UAMQP_MESSAGING_32_002: [If optional diagnostic properties are not present in the iot hub message, no error should happen.]
+TEST_FUNCTION(message_create_from_iothub_message_no_diagnostic_properties_success)
+{
+    // arrange
+    umock_c_reset_all_calls();
+    set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(1, IOTHUBMESSAGE_STRING, true, true, false, TEST_CONTENT_TYPE, TEST_CONTENT_ENCODING);
+
+    BINARY_DATA binary_data;
+    memset(&binary_data, 0, sizeof(binary_data));
+
+    ///act
+    int result = message_create_uamqp_encoding_from_iothub_message(TEST_IOTHUB_MESSAGE_HANDLE, &binary_data);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+    ASSERT_ARE_EQUAL(int, result, 0);
+
+    // cleanup
+}
+
 // Tests_SRS_UAMQP_MESSAGING_31_113: [If optional correlation-id is present in the message, encode it into the AMQP message.  Errors stop processing on this message.]
 TEST_FUNCTION(message_create_from_iothub_message_no_correlation_id_success)
 {
     // arrange
     umock_c_reset_all_calls();
-    set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(1, IOTHUBMESSAGE_STRING, true, false, TEST_CONTENT_TYPE, TEST_CONTENT_ENCODING);
+    set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(1, IOTHUBMESSAGE_STRING, true, false, true, TEST_CONTENT_TYPE, TEST_CONTENT_ENCODING);
 
     BINARY_DATA binary_data;
     memset(&binary_data, 0, sizeof(binary_data));
@@ -729,7 +811,7 @@ TEST_FUNCTION(message_create_from_iothub_message_no_content_type_success)
 {
     // arrange
     umock_c_reset_all_calls();
-    set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(1, IOTHUBMESSAGE_STRING, true, false, NULL, TEST_CONTENT_ENCODING);
+    set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(1, IOTHUBMESSAGE_STRING, true, false, true, NULL, TEST_CONTENT_ENCODING);
 
     BINARY_DATA binary_data;
     memset(&binary_data, 0, sizeof(binary_data));
@@ -749,7 +831,7 @@ TEST_FUNCTION(message_create_from_iothub_message_no_content_encoding_success)
 {
     // arrange
     umock_c_reset_all_calls();
-    set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(1, IOTHUBMESSAGE_STRING, true, false, TEST_CONTENT_TYPE, NULL);
+    set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(1, IOTHUBMESSAGE_STRING, true, false, true, TEST_CONTENT_TYPE, NULL);
 
     BINARY_DATA binary_data;
     memset(&binary_data, 0, sizeof(binary_data));
@@ -773,7 +855,7 @@ TEST_FUNCTION(message_create_from_iothub_message_BYTEARRAY_return_errors_fails)
     result = umock_c_negative_tests_init();
     ASSERT_ARE_EQUAL(int, 0, result);
     umock_c_reset_all_calls();
-    set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(1, IOTHUBMESSAGE_BYTEARRAY, true, true, TEST_CONTENT_TYPE, TEST_CONTENT_ENCODING);
+    set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(1, IOTHUBMESSAGE_BYTEARRAY, true, true, true, TEST_CONTENT_TYPE, TEST_CONTENT_ENCODING);
 
     umock_c_negative_tests_snapshot();
 
@@ -790,17 +872,24 @@ TEST_FUNCTION(message_create_from_iothub_message_BYTEARRAY_return_errors_fails)
             (i == 5) || //GetCorrelationId is optional
             (i == 9) || // ContentType is optional 
             (i == 11) ||  // ContentEncoding is optional
-            (i == 27) ||
             (i == 4) || // amqpvalue_destroy
             (i == 8) || // amqpvalue_destroy
             (i == 15) || // properties_destroy
             (i == 22) || // amqpvalue_destroy
             (i == 23) || // amqpvalue_destroy
             (i == 26) || // amqpvalue_destroy
-            (i == 35) || // amqpvalue_destroy
-            (i == 36) || // amqpvalue_destroy
-            (i == 37)
-           )
+            (i == 27) || //IoTHubMessage_GetDiagnosticPropertyData is optional
+            (i == 32) || // amqpvalue_destroy
+            (i == 33) || // amqpvalue_destroy
+            (i == 38) || // amqpvalue_destroy
+            (i == 39) || // amqpvalue_destroy
+            (i == 42) || // free
+            (i == 43) || // amqpvalue_destroy
+            (i == 53) || // amqpvalue_destroy
+            (i == 54) || // amqpvalue_destroy
+            (i == 55) || // amqpvalue_destroy
+            (i == 56) // amqpvalue_destroy
+            )
         {
             continue; // these lines have functions that do not return anything (void).
         }
@@ -829,7 +918,7 @@ TEST_FUNCTION(message_create_from_iothub_message_STRING_return_errors_fails)
     ASSERT_ARE_EQUAL(int, 0, result);
 
     umock_c_reset_all_calls();
-    set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(1, IOTHUBMESSAGE_STRING, true, true, TEST_CONTENT_TYPE, TEST_CONTENT_ENCODING);
+    set_exp_calls_for_message_create_uamqp_encoding_from_iothub_message(1, IOTHUBMESSAGE_STRING, true, true, true, TEST_CONTENT_TYPE, TEST_CONTENT_ENCODING);
 
     umock_c_negative_tests_snapshot();
 
@@ -852,10 +941,17 @@ TEST_FUNCTION(message_create_from_iothub_message_STRING_return_errors_fails)
             (i == 22) || // amqpvalue_destroy
             (i == 23) || // amqpvalue_destroy
             (i == 26) || // amqpvalue_destroy
-            (i == 34) || // amqpvalue_destroy
-            (i == 35) || // amqpvalue_destroy
-            (i == 36) || // amqpvalue_destroy
-            (i == 37) // amqpvalue_destroy
+            (i == 27) || //IoTHubMessage_GetDiagnosticPropertyData is optional
+            (i == 32) || // amqpvalue_destroy
+            (i == 33) || // amqpvalue_destroy
+            (i == 38) || // amqpvalue_destroy
+            (i == 39) || // amqpvalue_destroy
+            (i == 42) || // free
+            (i == 43) || // amqpvalue_destroy
+            (i == 53) || // amqpvalue_destroy
+            (i == 54) || // amqpvalue_destroy
+            (i == 55) || // amqpvalue_destroy
+            (i == 56) // amqpvalue_destroy
            )
         {
             continue; // these lines have functions that do not return anything (void).


### PR DESCRIPTION
The end to end diagnostic properties will be added as annotation properties in AMQP if they are present in IoT Hub message