### PR TITLE
Fix bug in file upload over proxy

### DIFF
--- a/iothub_client/inc/blob.h
+++ b/iothub_client/inc/blob.h
@@ -15,6 +15,7 @@
 
 #include "azure_c_shared_utility/macro_utils.h"
 #include "azure_c_shared_utility/buffer_.h"
+#include "azure_c_shared_utility/shared_util_options.h"
 
 #ifdef __cplusplus
 #include <cstddef>
@@ -44,10 +45,11 @@ DEFINE_ENUM(BLOB_RESULT, BLOB_RESULT_VALUES)
 * @param    httpStatus      A pointer to an out argument receiving the HTTP status (available only when the return value is BLOB_OK)
 * @param    httpResponse    A BUFFER_HANDLE that receives the HTTP response from the server (available only when the return value is BLOB_OK)
 * @param    certificates    A null terminated string containing CA certificates to be used
+* @param    proxyOptions    A structure that contains optional web proxy information
 *
 * @return	A @c BLOB_RESULT. BLOB_OK means the blob has been uploaded successfully. Any other value indicates an error
 */
-MOCKABLE_FUNCTION(, BLOB_RESULT, Blob_UploadFromSasUri,const char*, SASURI, const unsigned char*, source, size_t, size, unsigned int*, httpStatus, BUFFER_HANDLE, httpResponse, const char*, certificates)
+MOCKABLE_FUNCTION(, BLOB_RESULT, Blob_UploadFromSasUri,const char*, SASURI, const unsigned char*, source, size_t, size, unsigned int*, httpStatus, BUFFER_HANDLE, httpResponse, const char*, certificates, HTTP_PROXY_OPTIONS, *proxyOptions)
 
 #ifdef __cplusplus
 }

--- a/iothub_client/inc/blob.h
+++ b/iothub_client/inc/blob.h
@@ -49,7 +49,7 @@ DEFINE_ENUM(BLOB_RESULT, BLOB_RESULT_VALUES)
 *
 * @return	A @c BLOB_RESULT. BLOB_OK means the blob has been uploaded successfully. Any other value indicates an error
 */
-MOCKABLE_FUNCTION(, BLOB_RESULT, Blob_UploadFromSasUri,const char*, SASURI, const unsigned char*, source, size_t, size, unsigned int*, httpStatus, BUFFER_HANDLE, httpResponse, const char*, certificates, HTTP_PROXY_OPTIONS, *proxyOptions)
+MOCKABLE_FUNCTION(, BLOB_RESULT, Blob_UploadFromSasUri,const char*, SASURI, const unsigned char*, source, size_t, size, unsigned int*, httpStatus, BUFFER_HANDLE, httpResponse, const char*, certificates, HTTP_PROXY_OPTIONS*, proxyOptions)
 
 #ifdef __cplusplus
 }

--- a/iothub_client/src/blob.c
+++ b/iothub_client/src/blob.c
@@ -9,11 +9,12 @@
 #include "azure_c_shared_utility/httpapiex.h"
 #include "azure_c_shared_utility/xlogging.h"
 #include "azure_c_shared_utility/base64.h"
+#include "azure_c_shared_utility/shared_util_options.h"
 
 /*a block has 4MB*/
 #define BLOCK_SIZE (4*1024*1024)
 
-BLOB_RESULT Blob_UploadFromSasUri(const char* SASURI, const unsigned char* source, size_t size, unsigned int* httpStatus, BUFFER_HANDLE httpResponse, const char* certificates)
+BLOB_RESULT Blob_UploadFromSasUri(const char* SASURI, const unsigned char* source, size_t size, unsigned int* httpStatus, BUFFER_HANDLE httpResponse, const char* certificates, HTTP_PROXY_OPTIONS *proxyOptions)
 {
     BLOB_RESULT result;
     /*Codes_SRS_BLOB_02_001: [ If SASURI is NULL then Blob_UploadFromSasUri shall fail and return BLOB_INVALID_ARG. ]*/
@@ -100,266 +101,273 @@ BLOB_RESULT Blob_UploadFromSasUri(const char* SASURI, const unsigned char* sourc
                             }
                             else
                             {
+								if ((proxyOptions != NULL && proxyOptions->host_address != NULL) && HTTPAPIEX_SetOption(httpApiExHandle, OPTION_HTTP_PROXY, proxyOptions) == HTTPAPIEX_ERROR)
+								{
+									LogError("failure in setting proxy options");
+									result = BLOB_ERROR;
+								}
+								else
+								{
+									/*Codes_SRS_BLOB_02_008: [ Blob_UploadFromSasUri shall compute the relative path of the request from the SASURI parameter. ]*/
+									/*Codes_SRS_BLOB_02_019: [ Blob_UploadFromSasUri shall compute the base relative path of the request from the SASURI parameter. ]*/
+									const char* relativePath = hostnameEnd; /*this is where the relative path begins in the SasUri*/
 
-                                /*Codes_SRS_BLOB_02_008: [ Blob_UploadFromSasUri shall compute the relative path of the request from the SASURI parameter. ]*/
-                                /*Codes_SRS_BLOB_02_019: [ Blob_UploadFromSasUri shall compute the base relative path of the request from the SASURI parameter. ]*/
-                                const char* relativePath = hostnameEnd; /*this is where the relative path begins in the SasUri*/
+									if (size < 64 * 1024 * 1024) /*code path for sizes <64MB*/
+									{
+										/*Codes_SRS_BLOB_02_010: [ Blob_UploadFromSasUri shall create a BUFFER_HANDLE from source and size parameters. ]*/
+										BUFFER_HANDLE requestBuffer = BUFFER_create(source, size);
+										if (requestBuffer == NULL)
+										{
+											/*Codes_SRS_BLOB_02_011: [ If any of the previous steps related to building the HTTPAPI_EX_ExecuteRequest parameters fails, then Blob_UploadFromSasUri shall fail and return BLOB_ERROR. ]*/
+											LogError("unable to BUFFER_create");
+											result = BLOB_ERROR;
+										}
+										else
+										{
+											/*Codes_SRS_BLOB_02_009: [ Blob_UploadFromSasUri shall create an HTTP_HEADERS_HANDLE for the request HTTP headers carrying the following headers: ]*/
+											HTTP_HEADERS_HANDLE requestHttpHeaders = HTTPHeaders_Alloc();
+											if (requestHttpHeaders == NULL)
+											{
+												/*Codes_SRS_BLOB_02_011: [ If any of the previous steps related to building the HTTPAPI_EX_ExecuteRequest parameters fails, then Blob_UploadFromSasUri shall fail and return BLOB_ERROR. ]*/
+												LogError("unable to HTTPHeaders_Alloc");
+												result = BLOB_ERROR;
+											}
+											else
+											{
+												if (HTTPHeaders_AddHeaderNameValuePair(requestHttpHeaders, "x-ms-blob-type", "BlockBlob") != HTTP_HEADERS_OK)
+												{
+													/*Codes_SRS_BLOB_02_011: [ If any of the previous steps related to building the HTTPAPI_EX_ExecuteRequest parameters fails, then Blob_UploadFromSasUri shall fail and return BLOB_ERROR. ]*/
+													LogError("unable to HTTPHeaders_AddHeaderNameValuePair");
+													result = BLOB_ERROR;
+												}
+												else
+												{
+													/*Codes_SRS_BLOB_02_012: [ Blob_UploadFromSasUri shall call HTTPAPIEX_ExecuteRequest passing the parameters previously build, httpStatus and httpResponse ]*/
+													if (HTTPAPIEX_ExecuteRequest(httpApiExHandle, HTTPAPI_REQUEST_PUT, relativePath, requestHttpHeaders, requestBuffer, httpStatus, NULL, httpResponse) != HTTPAPIEX_OK)
+													{
+														/*Codes_SRS_BLOB_02_013: [ If HTTPAPIEX_ExecuteRequest fails, then Blob_UploadFromSasUri shall fail and return BLOB_HTTP_ERROR. ]*/
+														LogError("failed to HTTPAPIEX_ExecuteRequest");
+														result = BLOB_HTTP_ERROR;
+													}
+													else
+													{
+														/*Codes_SRS_BLOB_02_015: [ Otherwise, HTTPAPIEX_ExecuteRequest shall succeed and return BLOB_OK. ]*/
+														result = BLOB_OK;
+													}
+												}
+												HTTPHeaders_Free(requestHttpHeaders);
+											}
+											BUFFER_delete(requestBuffer);
+										}
+									}
+									else /*code path for size >= 64MB*/
+									{
+										size_t toUpload = size;
+										/*Codes_SRS_BLOB_02_028: [ Blob_UploadFromSasUri shall construct an XML string with the following content: ]*/
+										STRING_HANDLE xml = STRING_construct("<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<BlockList>"); /*the XML "build as we go"*/
+										if (xml == NULL)
+										{
+											/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+											LogError("failed to STRING_construct");
+											result = BLOB_HTTP_ERROR;
+										}
+										else
+										{
+											/*Codes_SRS_BLOB_02_021: [ For every block of 4MB the following operations shall happen: ]*/
+											unsigned int blockID = 0;
+											result = BLOB_ERROR;
 
-                                if (size < 64 * 1024 * 1024) /*code path for sizes <64MB*/
-                                {
-                                    /*Codes_SRS_BLOB_02_010: [ Blob_UploadFromSasUri shall create a BUFFER_HANDLE from source and size parameters. ]*/
-                                    BUFFER_HANDLE requestBuffer = BUFFER_create(source, size);
-                                    if (requestBuffer == NULL)
-                                    {
-                                        /*Codes_SRS_BLOB_02_011: [ If any of the previous steps related to building the HTTPAPI_EX_ExecuteRequest parameters fails, then Blob_UploadFromSasUri shall fail and return BLOB_ERROR. ]*/
-                                        LogError("unable to BUFFER_create");
-                                        result = BLOB_ERROR;
-                                    }
-                                    else
-                                    {
-                                        /*Codes_SRS_BLOB_02_009: [ Blob_UploadFromSasUri shall create an HTTP_HEADERS_HANDLE for the request HTTP headers carrying the following headers: ]*/
-                                        HTTP_HEADERS_HANDLE requestHttpHeaders = HTTPHeaders_Alloc();
-                                        if (requestHttpHeaders == NULL)
-                                        {
-                                            /*Codes_SRS_BLOB_02_011: [ If any of the previous steps related to building the HTTPAPI_EX_ExecuteRequest parameters fails, then Blob_UploadFromSasUri shall fail and return BLOB_ERROR. ]*/
-                                            LogError("unable to HTTPHeaders_Alloc");
-                                            result = BLOB_ERROR;
-                                        }
-                                        else
-                                        {
-                                            if (HTTPHeaders_AddHeaderNameValuePair(requestHttpHeaders, "x-ms-blob-type", "BlockBlob") != HTTP_HEADERS_OK)
-                                            {
-                                                /*Codes_SRS_BLOB_02_011: [ If any of the previous steps related to building the HTTPAPI_EX_ExecuteRequest parameters fails, then Blob_UploadFromSasUri shall fail and return BLOB_ERROR. ]*/
-                                                LogError("unable to HTTPHeaders_AddHeaderNameValuePair");
-                                                result = BLOB_ERROR;
-                                            }
-                                            else
-                                            {
-                                                /*Codes_SRS_BLOB_02_012: [ Blob_UploadFromSasUri shall call HTTPAPIEX_ExecuteRequest passing the parameters previously build, httpStatus and httpResponse ]*/
-                                                if (HTTPAPIEX_ExecuteRequest(httpApiExHandle, HTTPAPI_REQUEST_PUT, relativePath, requestHttpHeaders, requestBuffer, httpStatus, NULL, httpResponse) != HTTPAPIEX_OK)
-                                                {
-                                                    /*Codes_SRS_BLOB_02_013: [ If HTTPAPIEX_ExecuteRequest fails, then Blob_UploadFromSasUri shall fail and return BLOB_HTTP_ERROR. ]*/
-                                                    LogError("failed to HTTPAPIEX_ExecuteRequest");
-                                                    result = BLOB_HTTP_ERROR;
-                                                }
-                                                else
-                                                {
-                                                    /*Codes_SRS_BLOB_02_015: [ Otherwise, HTTPAPIEX_ExecuteRequest shall succeed and return BLOB_OK. ]*/
-                                                    result = BLOB_OK;
-                                                }
-                                            }
-                                            HTTPHeaders_Free(requestHttpHeaders);
-                                        }
-                                        BUFFER_delete(requestBuffer);
-                                    }
-                                }
-                                else /*code path for size >= 64MB*/
-                                {
-                                    size_t toUpload = size;
-                                    /*Codes_SRS_BLOB_02_028: [ Blob_UploadFromSasUri shall construct an XML string with the following content: ]*/
-                                    STRING_HANDLE xml = STRING_construct("<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<BlockList>"); /*the XML "build as we go"*/
-                                    if (xml == NULL)
-                                    {
-                                        /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-                                        LogError("failed to STRING_construct");
-                                        result = BLOB_HTTP_ERROR;
-                                    }
-                                    else
-                                    {
-                                        /*Codes_SRS_BLOB_02_021: [ For every block of 4MB the following operations shall happen: ]*/
-                                        unsigned int blockID = 0;
-                                        result = BLOB_ERROR;
+											int isError = 0; /*used to cleanly exit the loop*/
+											do
+											{
+												/*setting this block size*/
+												size_t thisBlockSize = (toUpload > BLOCK_SIZE) ? BLOCK_SIZE : toUpload;
+												/*Codes_SRS_BLOB_02_020: [ Blob_UploadFromSasUri shall construct a BASE64 encoded string from the block ID (000000... 0499999) ]*/
+												char temp[7]; /*this will contain 000000... 049999*/
+												if (sprintf(temp, "%6u", (unsigned int)blockID) != 6) /*produces 000000... 049999*/
+												{
+													/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+													LogError("failed to sprintf");
+													result = BLOB_ERROR;
+													isError = 1;
+												}
+												else
+												{
+													STRING_HANDLE blockIdString = Base64_Encode_Bytes((const unsigned char*)temp, 6);
+													if (blockIdString == NULL)
+													{
+														/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+														LogError("unable to Base64_Encode_Bytes");
+														result = BLOB_ERROR;
+														isError = 1;
+													}
+													else
+													{
+														/*add the blockId base64 encoded to the XML*/
+														if (!(
+															(STRING_concat(xml, "<Latest>") == 0) &&
+															(STRING_concat_with_STRING(xml, blockIdString) == 0) &&
+															(STRING_concat(xml, "</Latest>") == 0)
+															))
+														{
+															/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+															LogError("unable to STRING_concat");
+															result = BLOB_ERROR;
+															isError = 1;
+														}
+														else
+														{
+															/*Codes_SRS_BLOB_02_022: [ Blob_UploadFromSasUri shall construct a new relativePath from following string: base relativePath + "&comp=block&blockid=BASE64 encoded string of blockId" ]*/
+															STRING_HANDLE newRelativePath = STRING_construct(relativePath);
+															if (newRelativePath == NULL)
+															{
+																/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+																LogError("unable to STRING_construct");
+																result = BLOB_ERROR;
+																isError = 1;
+															}
+															else
+															{
+																if (!(
+																	(STRING_concat(newRelativePath, "&comp=block&blockid=") == 0) &&
+																	(STRING_concat_with_STRING(newRelativePath, blockIdString) == 0)
+																	))
+																{
+																	/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+																	LogError("unable to STRING concatenate");
+																	result = BLOB_ERROR;
+																	isError = 1;
+																}
+																else
+																{
+																	/*Codes_SRS_BLOB_02_023: [ Blob_UploadFromSasUri shall create a BUFFER_HANDLE from source and size parameters. ]*/
+																	BUFFER_HANDLE requestContent = BUFFER_create(source + (size - toUpload), thisBlockSize);
+																	if (requestContent == NULL)
+																	{
+																		/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+																		LogError("unable to BUFFER_create");
+																		result = BLOB_ERROR;
+																		isError = 1;
+																	}
+																	else
+																	{
+																		/*Codes_SRS_BLOB_02_024: [ Blob_UploadFromSasUri shall call HTTPAPIEX_ExecuteRequest with a PUT operation, passing httpStatus and httpResponse. ]*/
+																		if (HTTPAPIEX_ExecuteRequest(
+																			httpApiExHandle,
+																			HTTPAPI_REQUEST_PUT,
+																			STRING_c_str(newRelativePath),
+																			NULL,
+																			requestContent,
+																			httpStatus,
+																			NULL,
+																			httpResponse) != HTTPAPIEX_OK
+																			)
+																		{
+																			/*Codes_SRS_BLOB_02_025: [ If HTTPAPIEX_ExecuteRequest fails then Blob_UploadFromSasUri shall fail and return BLOB_HTTP_ERROR. ]*/
+																			LogError("unable to HTTPAPIEX_ExecuteRequest");
+																			result = BLOB_HTTP_ERROR;
+																			isError = 1;
+																		}
+																		else if (*httpStatus >= 300)
+																		{
+																			/*Codes_SRS_BLOB_02_026: [ Otherwise, if HTTP response code is >=300 then Blob_UploadFromSasUri shall succeed and return BLOB_OK. ]*/
+																			LogError("HTTP status from storage does not indicate success (%d)", (int)*httpStatus);
+																			result = BLOB_OK;
+																			isError = 1;
+																		}
+																		else
+																		{
+																			/*Codes_SRS_BLOB_02_027: [ Otherwise Blob_UploadFromSasUri shall continue execution. ]*/
+																		}
+																		BUFFER_delete(requestContent);
+																	}
+																}
+																STRING_delete(newRelativePath);
+															}
+														}
+														STRING_delete(blockIdString);
+													}
+												}
 
-                                        int isError = 0; /*used to cleanly exit the loop*/
-                                        do
-                                        {
-                                            /*setting this block size*/
-                                            size_t thisBlockSize = (toUpload > BLOCK_SIZE) ? BLOCK_SIZE : toUpload;
-                                            /*Codes_SRS_BLOB_02_020: [ Blob_UploadFromSasUri shall construct a BASE64 encoded string from the block ID (000000... 0499999) ]*/
-                                            char temp[7]; /*this will contain 000000... 049999*/
-                                            if (sprintf(temp, "%6u", (unsigned int)blockID) != 6) /*produces 000000... 049999*/
-                                            {
-                                                /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-                                                LogError("failed to sprintf");
-                                                result = BLOB_ERROR;
-                                                isError = 1;
-                                            }
-                                            else
-                                            {
-                                                STRING_HANDLE blockIdString = Base64_Encode_Bytes((const unsigned char*)temp, 6);
-                                                if (blockIdString == NULL)
-                                                {
-                                                    /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-                                                    LogError("unable to Base64_Encode_Bytes");
-                                                    result = BLOB_ERROR;
-                                                    isError = 1;
-                                                }
-                                                else
-                                                {
-                                                    /*add the blockId base64 encoded to the XML*/
-                                                    if (!(
-                                                        (STRING_concat(xml, "<Latest>") == 0) &&
-                                                        (STRING_concat_with_STRING(xml, blockIdString) == 0) &&
-                                                        (STRING_concat(xml, "</Latest>") == 0)
-                                                        ))
-                                                    {
-                                                        /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-                                                        LogError("unable to STRING_concat");
-                                                        result = BLOB_ERROR;
-                                                        isError = 1;
-                                                    }
-                                                    else
-                                                    {
-                                                        /*Codes_SRS_BLOB_02_022: [ Blob_UploadFromSasUri shall construct a new relativePath from following string: base relativePath + "&comp=block&blockid=BASE64 encoded string of blockId" ]*/
-                                                        STRING_HANDLE newRelativePath = STRING_construct(relativePath);
-                                                        if (newRelativePath == NULL)
-                                                        {
-                                                            /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-                                                            LogError("unable to STRING_construct");
-                                                            result = BLOB_ERROR;
-                                                            isError = 1;
-                                                        }
-                                                        else
-                                                        {
-                                                            if (!(
-                                                                (STRING_concat(newRelativePath, "&comp=block&blockid=") == 0) &&
-                                                                (STRING_concat_with_STRING(newRelativePath, blockIdString) == 0)
-                                                                ))
-                                                            {
-                                                                /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-                                                                LogError("unable to STRING concatenate");
-                                                                result = BLOB_ERROR;
-                                                                isError = 1;
-                                                            }
-                                                            else
-                                                            {
-                                                                /*Codes_SRS_BLOB_02_023: [ Blob_UploadFromSasUri shall create a BUFFER_HANDLE from source and size parameters. ]*/
-                                                                BUFFER_HANDLE requestContent = BUFFER_create(source + (size - toUpload), thisBlockSize);
-                                                                if (requestContent == NULL)
-                                                                {
-                                                                    /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-                                                                    LogError("unable to BUFFER_create");
-                                                                    result = BLOB_ERROR;
-                                                                    isError = 1;
-                                                                }
-                                                                else
-                                                                {
-                                                                    /*Codes_SRS_BLOB_02_024: [ Blob_UploadFromSasUri shall call HTTPAPIEX_ExecuteRequest with a PUT operation, passing httpStatus and httpResponse. ]*/
-                                                                    if (HTTPAPIEX_ExecuteRequest(
-                                                                        httpApiExHandle,
-                                                                        HTTPAPI_REQUEST_PUT,
-                                                                        STRING_c_str(newRelativePath),
-                                                                        NULL,
-                                                                        requestContent,
-                                                                        httpStatus,
-                                                                        NULL,
-                                                                        httpResponse) != HTTPAPIEX_OK
-                                                                        )
-                                                                    {
-                                                                        /*Codes_SRS_BLOB_02_025: [ If HTTPAPIEX_ExecuteRequest fails then Blob_UploadFromSasUri shall fail and return BLOB_HTTP_ERROR. ]*/
-                                                                        LogError("unable to HTTPAPIEX_ExecuteRequest");
-                                                                        result = BLOB_HTTP_ERROR;
-                                                                        isError = 1;
-                                                                    }
-                                                                    else if (*httpStatus >= 300)
-                                                                    {
-                                                                        /*Codes_SRS_BLOB_02_026: [ Otherwise, if HTTP response code is >=300 then Blob_UploadFromSasUri shall succeed and return BLOB_OK. ]*/
-                                                                        LogError("HTTP status from storage does not indicate success (%d)", (int)*httpStatus);
-                                                                        result = BLOB_OK;
-                                                                        isError = 1;
-                                                                    }
-                                                                    else
-                                                                    {
-                                                                        /*Codes_SRS_BLOB_02_027: [ Otherwise Blob_UploadFromSasUri shall continue execution. ]*/
-                                                                    }
-                                                                    BUFFER_delete(requestContent);
-                                                                }
-                                                            }
-                                                            STRING_delete(newRelativePath);
-                                                        }
-                                                    }
-                                                    STRING_delete(blockIdString);
-                                                }
-                                            }
+												blockID++;
+												toUpload -= thisBlockSize;
+											} while ((toUpload > 0) && !isError);
 
-                                            blockID++;
-                                            toUpload -= thisBlockSize;
-                                        } while ((toUpload > 0) && !isError);
-
-                                        if (isError)
-                                        {
-                                            /*do nothing, it will be reported "as is"*/
-                                        }
-                                        else
-                                        {
-                                            /*complete the XML*/
-                                            if (STRING_concat(xml, "</BlockList>") != 0)
-                                            {
-                                                /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-                                                LogError("failed to STRING_concat");
-                                                result = BLOB_ERROR;
-                                            }
-                                            else
-                                            {
-                                                /*Codes_SRS_BLOB_02_029: [Blob_UploadFromSasUri shall construct a new relativePath from following string : base relativePath + "&comp=blocklist"]*/
-                                                STRING_HANDLE newRelativePath = STRING_construct(relativePath);
-                                                if (newRelativePath == NULL)
-                                                {
-                                                    /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-                                                    LogError("failed to STRING_construct");
-                                                    result = BLOB_ERROR;
-                                                }
-                                                else
-                                                {
-                                                    if (STRING_concat(newRelativePath, "&comp=blocklist") != 0)
-                                                    {
-                                                        /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-                                                        LogError("failed to STRING_concat");
-                                                        result = BLOB_ERROR;
-                                                    }
-                                                    else
-                                                    {
-                                                        /*Codes_SRS_BLOB_02_030: [ Blob_UploadFromSasUri shall call HTTPAPIEX_ExecuteRequest with a PUT operation, passing the new relativePath, httpStatus and httpResponse and the XML string as content. ]*/
-                                                        const char* s = STRING_c_str(xml);
-                                                        BUFFER_HANDLE xmlAsBuffer = BUFFER_create((const unsigned char*)s, strlen(s));
-                                                        if (xmlAsBuffer == NULL)
-                                                        {
-                                                            /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-                                                            LogError("failed to BUFFER_create");
-                                                            result = BLOB_ERROR;
-                                                        }
-                                                        else
-                                                        {
-                                                            if (HTTPAPIEX_ExecuteRequest(
-                                                                httpApiExHandle,
-                                                                HTTPAPI_REQUEST_PUT,
-                                                                STRING_c_str(newRelativePath),
-                                                                NULL,
-                                                                xmlAsBuffer,
-                                                                httpStatus,
-                                                                NULL,
-                                                                httpResponse
-                                                            ) != HTTPAPIEX_OK)
-                                                            {
-                                                                /*Codes_SRS_BLOB_02_031: [ If HTTPAPIEX_ExecuteRequest fails then Blob_UploadFromSasUri shall fail and return BLOB_HTTP_ERROR. ]*/
-                                                                LogError("unable to HTTPAPIEX_ExecuteRequest");
-                                                                result = BLOB_HTTP_ERROR;
-                                                            }
-                                                            else
-                                                            {
-                                                                /*Codes_SRS_BLOB_02_032: [ Otherwise, Blob_UploadFromSasUri shall succeed and return BLOB_OK. ]*/
-                                                                result = BLOB_OK;
-                                                            }
-                                                            BUFFER_delete(xmlAsBuffer);
-                                                        }
-                                                    }
-                                                    STRING_delete(newRelativePath);
-                                                }
-                                            }
-                                        }
-                                        STRING_delete(xml);
-                                    }
-                                }
+											if (isError)
+											{
+												/*do nothing, it will be reported "as is"*/
+											}
+											else
+											{
+												/*complete the XML*/
+												if (STRING_concat(xml, "</BlockList>") != 0)
+												{
+													/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+													LogError("failed to STRING_concat");
+													result = BLOB_ERROR;
+												}
+												else
+												{
+													/*Codes_SRS_BLOB_02_029: [Blob_UploadFromSasUri shall construct a new relativePath from following string : base relativePath + "&comp=blocklist"]*/
+													STRING_HANDLE newRelativePath = STRING_construct(relativePath);
+													if (newRelativePath == NULL)
+													{
+														/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+														LogError("failed to STRING_construct");
+														result = BLOB_ERROR;
+													}
+													else
+													{
+														if (STRING_concat(newRelativePath, "&comp=blocklist") != 0)
+														{
+															/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+															LogError("failed to STRING_concat");
+															result = BLOB_ERROR;
+														}
+														else
+														{
+															/*Codes_SRS_BLOB_02_030: [ Blob_UploadFromSasUri shall call HTTPAPIEX_ExecuteRequest with a PUT operation, passing the new relativePath, httpStatus and httpResponse and the XML string as content. ]*/
+															const char* s = STRING_c_str(xml);
+															BUFFER_HANDLE xmlAsBuffer = BUFFER_create((const unsigned char*)s, strlen(s));
+															if (xmlAsBuffer == NULL)
+															{
+																/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+																LogError("failed to BUFFER_create");
+																result = BLOB_ERROR;
+															}
+															else
+															{
+																if (HTTPAPIEX_ExecuteRequest(
+																	httpApiExHandle,
+																	HTTPAPI_REQUEST_PUT,
+																	STRING_c_str(newRelativePath),
+																	NULL,
+																	xmlAsBuffer,
+																	httpStatus,
+																	NULL,
+																	httpResponse
+																) != HTTPAPIEX_OK)
+																{
+																	/*Codes_SRS_BLOB_02_031: [ If HTTPAPIEX_ExecuteRequest fails then Blob_UploadFromSasUri shall fail and return BLOB_HTTP_ERROR. ]*/
+																	LogError("unable to HTTPAPIEX_ExecuteRequest");
+																	result = BLOB_HTTP_ERROR;
+																}
+																else
+																{
+																	/*Codes_SRS_BLOB_02_032: [ Otherwise, Blob_UploadFromSasUri shall succeed and return BLOB_OK. ]*/
+																	result = BLOB_OK;
+																}
+																BUFFER_delete(xmlAsBuffer);
+															}
+														}
+														STRING_delete(newRelativePath);
+													}
+												}
+											}
+											STRING_delete(xml);
+										}
+									}
+								}
                             }
                             HTTPAPIEX_Destroy(httpApiExHandle);
                         }

--- a/iothub_client/src/blob.c
+++ b/iothub_client/src/blob.c
@@ -101,273 +101,273 @@ BLOB_RESULT Blob_UploadFromSasUri(const char* SASURI, const unsigned char* sourc
                             }
                             else
                             {
-								if ((proxyOptions != NULL && proxyOptions->host_address != NULL) && HTTPAPIEX_SetOption(httpApiExHandle, OPTION_HTTP_PROXY, proxyOptions) == HTTPAPIEX_ERROR)
-								{
-									LogError("failure in setting proxy options");
-									result = BLOB_ERROR;
-								}
-								else
-								{
-									/*Codes_SRS_BLOB_02_008: [ Blob_UploadFromSasUri shall compute the relative path of the request from the SASURI parameter. ]*/
-									/*Codes_SRS_BLOB_02_019: [ Blob_UploadFromSasUri shall compute the base relative path of the request from the SASURI parameter. ]*/
-									const char* relativePath = hostnameEnd; /*this is where the relative path begins in the SasUri*/
+                                if ((proxyOptions != NULL && proxyOptions->host_address != NULL) && HTTPAPIEX_SetOption(httpApiExHandle, OPTION_HTTP_PROXY, proxyOptions) == HTTPAPIEX_ERROR)
+                                {
+                                    LogError("failure in setting proxy options");
+                                    result = BLOB_ERROR;
+                                }
+                                else
+                                {
+                                    /*Codes_SRS_BLOB_02_008: [ Blob_UploadFromSasUri shall compute the relative path of the request from the SASURI parameter. ]*/
+                                    /*Codes_SRS_BLOB_02_019: [ Blob_UploadFromSasUri shall compute the base relative path of the request from the SASURI parameter. ]*/
+                                    const char* relativePath = hostnameEnd; /*this is where the relative path begins in the SasUri*/
 
-									if (size < 64 * 1024 * 1024) /*code path for sizes <64MB*/
-									{
-										/*Codes_SRS_BLOB_02_010: [ Blob_UploadFromSasUri shall create a BUFFER_HANDLE from source and size parameters. ]*/
-										BUFFER_HANDLE requestBuffer = BUFFER_create(source, size);
-										if (requestBuffer == NULL)
-										{
-											/*Codes_SRS_BLOB_02_011: [ If any of the previous steps related to building the HTTPAPI_EX_ExecuteRequest parameters fails, then Blob_UploadFromSasUri shall fail and return BLOB_ERROR. ]*/
-											LogError("unable to BUFFER_create");
-											result = BLOB_ERROR;
-										}
-										else
-										{
-											/*Codes_SRS_BLOB_02_009: [ Blob_UploadFromSasUri shall create an HTTP_HEADERS_HANDLE for the request HTTP headers carrying the following headers: ]*/
-											HTTP_HEADERS_HANDLE requestHttpHeaders = HTTPHeaders_Alloc();
-											if (requestHttpHeaders == NULL)
-											{
-												/*Codes_SRS_BLOB_02_011: [ If any of the previous steps related to building the HTTPAPI_EX_ExecuteRequest parameters fails, then Blob_UploadFromSasUri shall fail and return BLOB_ERROR. ]*/
-												LogError("unable to HTTPHeaders_Alloc");
-												result = BLOB_ERROR;
-											}
-											else
-											{
-												if (HTTPHeaders_AddHeaderNameValuePair(requestHttpHeaders, "x-ms-blob-type", "BlockBlob") != HTTP_HEADERS_OK)
-												{
-													/*Codes_SRS_BLOB_02_011: [ If any of the previous steps related to building the HTTPAPI_EX_ExecuteRequest parameters fails, then Blob_UploadFromSasUri shall fail and return BLOB_ERROR. ]*/
-													LogError("unable to HTTPHeaders_AddHeaderNameValuePair");
-													result = BLOB_ERROR;
-												}
-												else
-												{
-													/*Codes_SRS_BLOB_02_012: [ Blob_UploadFromSasUri shall call HTTPAPIEX_ExecuteRequest passing the parameters previously build, httpStatus and httpResponse ]*/
-													if (HTTPAPIEX_ExecuteRequest(httpApiExHandle, HTTPAPI_REQUEST_PUT, relativePath, requestHttpHeaders, requestBuffer, httpStatus, NULL, httpResponse) != HTTPAPIEX_OK)
-													{
-														/*Codes_SRS_BLOB_02_013: [ If HTTPAPIEX_ExecuteRequest fails, then Blob_UploadFromSasUri shall fail and return BLOB_HTTP_ERROR. ]*/
-														LogError("failed to HTTPAPIEX_ExecuteRequest");
-														result = BLOB_HTTP_ERROR;
-													}
-													else
-													{
-														/*Codes_SRS_BLOB_02_015: [ Otherwise, HTTPAPIEX_ExecuteRequest shall succeed and return BLOB_OK. ]*/
-														result = BLOB_OK;
-													}
-												}
-												HTTPHeaders_Free(requestHttpHeaders);
-											}
-											BUFFER_delete(requestBuffer);
-										}
-									}
-									else /*code path for size >= 64MB*/
-									{
-										size_t toUpload = size;
-										/*Codes_SRS_BLOB_02_028: [ Blob_UploadFromSasUri shall construct an XML string with the following content: ]*/
-										STRING_HANDLE xml = STRING_construct("<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<BlockList>"); /*the XML "build as we go"*/
-										if (xml == NULL)
-										{
-											/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-											LogError("failed to STRING_construct");
-											result = BLOB_HTTP_ERROR;
-										}
-										else
-										{
-											/*Codes_SRS_BLOB_02_021: [ For every block of 4MB the following operations shall happen: ]*/
-											unsigned int blockID = 0;
-											result = BLOB_ERROR;
+                                    if (size < 64 * 1024 * 1024) /*code path for sizes <64MB*/
+                                    {
+                                        /*Codes_SRS_BLOB_02_010: [ Blob_UploadFromSasUri shall create a BUFFER_HANDLE from source and size parameters. ]*/
+                                        BUFFER_HANDLE requestBuffer = BUFFER_create(source, size);
+                                        if (requestBuffer == NULL)
+                                        {
+                                            /*Codes_SRS_BLOB_02_011: [ If any of the previous steps related to building the HTTPAPI_EX_ExecuteRequest parameters fails, then Blob_UploadFromSasUri shall fail and return BLOB_ERROR. ]*/
+                                            LogError("unable to BUFFER_create");
+                                            result = BLOB_ERROR;
+                                        }
+                                        else
+                                        {
+                                            /*Codes_SRS_BLOB_02_009: [ Blob_UploadFromSasUri shall create an HTTP_HEADERS_HANDLE for the request HTTP headers carrying the following headers: ]*/
+                                            HTTP_HEADERS_HANDLE requestHttpHeaders = HTTPHeaders_Alloc();
+                                            if (requestHttpHeaders == NULL)
+                                            {
+                                                /*Codes_SRS_BLOB_02_011: [ If any of the previous steps related to building the HTTPAPI_EX_ExecuteRequest parameters fails, then Blob_UploadFromSasUri shall fail and return BLOB_ERROR. ]*/
+                                                LogError("unable to HTTPHeaders_Alloc");
+                                                result = BLOB_ERROR;
+                                            }
+                                            else
+                                            {
+                                                if (HTTPHeaders_AddHeaderNameValuePair(requestHttpHeaders, "x-ms-blob-type", "BlockBlob") != HTTP_HEADERS_OK)
+                                                {
+                                                    /*Codes_SRS_BLOB_02_011: [ If any of the previous steps related to building the HTTPAPI_EX_ExecuteRequest parameters fails, then Blob_UploadFromSasUri shall fail and return BLOB_ERROR. ]*/
+                                                    LogError("unable to HTTPHeaders_AddHeaderNameValuePair");
+                                                    result = BLOB_ERROR;
+                                                }
+                                                else
+                                                {
+                                                    /*Codes_SRS_BLOB_02_012: [ Blob_UploadFromSasUri shall call HTTPAPIEX_ExecuteRequest passing the parameters previously build, httpStatus and httpResponse ]*/
+                                                    if (HTTPAPIEX_ExecuteRequest(httpApiExHandle, HTTPAPI_REQUEST_PUT, relativePath, requestHttpHeaders, requestBuffer, httpStatus, NULL, httpResponse) != HTTPAPIEX_OK)
+                                                    {
+                                                        /*Codes_SRS_BLOB_02_013: [ If HTTPAPIEX_ExecuteRequest fails, then Blob_UploadFromSasUri shall fail and return BLOB_HTTP_ERROR. ]*/
+                                                        LogError("failed to HTTPAPIEX_ExecuteRequest");
+                                                        result = BLOB_HTTP_ERROR;
+                                                    }
+                                                    else
+                                                    {
+                                                        /*Codes_SRS_BLOB_02_015: [ Otherwise, HTTPAPIEX_ExecuteRequest shall succeed and return BLOB_OK. ]*/
+                                                        result = BLOB_OK;
+                                                    }
+                                                }
+                                                HTTPHeaders_Free(requestHttpHeaders);
+                                            }
+                                            BUFFER_delete(requestBuffer);
+                                        }
+                                    }
+                                    else /*code path for size >= 64MB*/
+                                    {
+                                        size_t toUpload = size;
+                                        /*Codes_SRS_BLOB_02_028: [ Blob_UploadFromSasUri shall construct an XML string with the following content: ]*/
+                                        STRING_HANDLE xml = STRING_construct("<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<BlockList>"); /*the XML "build as we go"*/
+                                        if (xml == NULL)
+                                        {
+                                            /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+                                            LogError("failed to STRING_construct");
+                                            result = BLOB_HTTP_ERROR;
+                                        }
+                                        else
+                                        {
+                                            /*Codes_SRS_BLOB_02_021: [ For every block of 4MB the following operations shall happen: ]*/
+                                            unsigned int blockID = 0;
+                                            result = BLOB_ERROR;
 
-											int isError = 0; /*used to cleanly exit the loop*/
-											do
-											{
-												/*setting this block size*/
-												size_t thisBlockSize = (toUpload > BLOCK_SIZE) ? BLOCK_SIZE : toUpload;
-												/*Codes_SRS_BLOB_02_020: [ Blob_UploadFromSasUri shall construct a BASE64 encoded string from the block ID (000000... 0499999) ]*/
-												char temp[7]; /*this will contain 000000... 049999*/
-												if (sprintf(temp, "%6u", (unsigned int)blockID) != 6) /*produces 000000... 049999*/
-												{
-													/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-													LogError("failed to sprintf");
-													result = BLOB_ERROR;
-													isError = 1;
-												}
-												else
-												{
-													STRING_HANDLE blockIdString = Base64_Encode_Bytes((const unsigned char*)temp, 6);
-													if (blockIdString == NULL)
-													{
-														/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-														LogError("unable to Base64_Encode_Bytes");
-														result = BLOB_ERROR;
-														isError = 1;
-													}
-													else
-													{
-														/*add the blockId base64 encoded to the XML*/
-														if (!(
-															(STRING_concat(xml, "<Latest>") == 0) &&
-															(STRING_concat_with_STRING(xml, blockIdString) == 0) &&
-															(STRING_concat(xml, "</Latest>") == 0)
-															))
-														{
-															/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-															LogError("unable to STRING_concat");
-															result = BLOB_ERROR;
-															isError = 1;
-														}
-														else
-														{
-															/*Codes_SRS_BLOB_02_022: [ Blob_UploadFromSasUri shall construct a new relativePath from following string: base relativePath + "&comp=block&blockid=BASE64 encoded string of blockId" ]*/
-															STRING_HANDLE newRelativePath = STRING_construct(relativePath);
-															if (newRelativePath == NULL)
-															{
-																/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-																LogError("unable to STRING_construct");
-																result = BLOB_ERROR;
-																isError = 1;
-															}
-															else
-															{
-																if (!(
-																	(STRING_concat(newRelativePath, "&comp=block&blockid=") == 0) &&
-																	(STRING_concat_with_STRING(newRelativePath, blockIdString) == 0)
-																	))
-																{
-																	/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-																	LogError("unable to STRING concatenate");
-																	result = BLOB_ERROR;
-																	isError = 1;
-																}
-																else
-																{
-																	/*Codes_SRS_BLOB_02_023: [ Blob_UploadFromSasUri shall create a BUFFER_HANDLE from source and size parameters. ]*/
-																	BUFFER_HANDLE requestContent = BUFFER_create(source + (size - toUpload), thisBlockSize);
-																	if (requestContent == NULL)
-																	{
-																		/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-																		LogError("unable to BUFFER_create");
-																		result = BLOB_ERROR;
-																		isError = 1;
-																	}
-																	else
-																	{
-																		/*Codes_SRS_BLOB_02_024: [ Blob_UploadFromSasUri shall call HTTPAPIEX_ExecuteRequest with a PUT operation, passing httpStatus and httpResponse. ]*/
-																		if (HTTPAPIEX_ExecuteRequest(
-																			httpApiExHandle,
-																			HTTPAPI_REQUEST_PUT,
-																			STRING_c_str(newRelativePath),
-																			NULL,
-																			requestContent,
-																			httpStatus,
-																			NULL,
-																			httpResponse) != HTTPAPIEX_OK
-																			)
-																		{
-																			/*Codes_SRS_BLOB_02_025: [ If HTTPAPIEX_ExecuteRequest fails then Blob_UploadFromSasUri shall fail and return BLOB_HTTP_ERROR. ]*/
-																			LogError("unable to HTTPAPIEX_ExecuteRequest");
-																			result = BLOB_HTTP_ERROR;
-																			isError = 1;
-																		}
-																		else if (*httpStatus >= 300)
-																		{
-																			/*Codes_SRS_BLOB_02_026: [ Otherwise, if HTTP response code is >=300 then Blob_UploadFromSasUri shall succeed and return BLOB_OK. ]*/
-																			LogError("HTTP status from storage does not indicate success (%d)", (int)*httpStatus);
-																			result = BLOB_OK;
-																			isError = 1;
-																		}
-																		else
-																		{
-																			/*Codes_SRS_BLOB_02_027: [ Otherwise Blob_UploadFromSasUri shall continue execution. ]*/
-																		}
-																		BUFFER_delete(requestContent);
-																	}
-																}
-																STRING_delete(newRelativePath);
-															}
-														}
-														STRING_delete(blockIdString);
-													}
-												}
+                                            int isError = 0; /*used to cleanly exit the loop*/
+                                            do
+                                            {
+                                                /*setting this block size*/
+                                                size_t thisBlockSize = (toUpload > BLOCK_SIZE) ? BLOCK_SIZE : toUpload;
+                                                /*Codes_SRS_BLOB_02_020: [ Blob_UploadFromSasUri shall construct a BASE64 encoded string from the block ID (000000... 0499999) ]*/
+                                                char temp[7]; /*this will contain 000000... 049999*/
+                                                if (sprintf(temp, "%6u", (unsigned int)blockID) != 6) /*produces 000000... 049999*/
+                                                {
+                                                    /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+                                                    LogError("failed to sprintf");
+                                                    result = BLOB_ERROR;
+                                                    isError = 1;
+                                                }
+                                                else
+                                                {
+                                                    STRING_HANDLE blockIdString = Base64_Encode_Bytes((const unsigned char*)temp, 6);
+                                                    if (blockIdString == NULL)
+                                                    {
+                                                        /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+                                                        LogError("unable to Base64_Encode_Bytes");
+                                                        result = BLOB_ERROR;
+                                                        isError = 1;
+                                                    }
+                                                    else
+                                                    {
+                                                        /*add the blockId base64 encoded to the XML*/
+                                                        if (!(
+                                                            (STRING_concat(xml, "<Latest>") == 0) &&
+                                                            (STRING_concat_with_STRING(xml, blockIdString) == 0) &&
+                                                            (STRING_concat(xml, "</Latest>") == 0)
+                                                            ))
+                                                        {
+                                                            /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+                                                            LogError("unable to STRING_concat");
+                                                            result = BLOB_ERROR;
+                                                            isError = 1;
+                                                        }
+                                                        else
+                                                        {
+                                                            /*Codes_SRS_BLOB_02_022: [ Blob_UploadFromSasUri shall construct a new relativePath from following string: base relativePath + "&comp=block&blockid=BASE64 encoded string of blockId" ]*/
+                                                            STRING_HANDLE newRelativePath = STRING_construct(relativePath);
+                                                            if (newRelativePath == NULL)
+                                                            {
+                                                                /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+                                                                LogError("unable to STRING_construct");
+                                                                result = BLOB_ERROR;
+                                                                isError = 1;
+                                                            }
+                                                            else
+                                                            {
+                                                                if (!(
+                                                                    (STRING_concat(newRelativePath, "&comp=block&blockid=") == 0) &&
+                                                                    (STRING_concat_with_STRING(newRelativePath, blockIdString) == 0)
+                                                                    ))
+                                                                {
+                                                                    /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+                                                                    LogError("unable to STRING concatenate");
+                                                                    result = BLOB_ERROR;
+                                                                    isError = 1;
+                                                                }
+                                                                else
+                                                                {
+                                                                    /*Codes_SRS_BLOB_02_023: [ Blob_UploadFromSasUri shall create a BUFFER_HANDLE from source and size parameters. ]*/
+                                                                    BUFFER_HANDLE requestContent = BUFFER_create(source + (size - toUpload), thisBlockSize);
+                                                                    if (requestContent == NULL)
+                                                                    {
+                                                                        /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+                                                                        LogError("unable to BUFFER_create");
+                                                                        result = BLOB_ERROR;
+                                                                        isError = 1;
+                                                                    }
+                                                                    else
+                                                                    {
+                                                                        /*Codes_SRS_BLOB_02_024: [ Blob_UploadFromSasUri shall call HTTPAPIEX_ExecuteRequest with a PUT operation, passing httpStatus and httpResponse. ]*/
+                                                                        if (HTTPAPIEX_ExecuteRequest(
+                                                                            httpApiExHandle,
+                                                                            HTTPAPI_REQUEST_PUT,
+                                                                            STRING_c_str(newRelativePath),
+                                                                            NULL,
+                                                                            requestContent,
+                                                                            httpStatus,
+                                                                            NULL,
+                                                                            httpResponse) != HTTPAPIEX_OK
+                                                                            )
+                                                                        {
+                                                                            /*Codes_SRS_BLOB_02_025: [ If HTTPAPIEX_ExecuteRequest fails then Blob_UploadFromSasUri shall fail and return BLOB_HTTP_ERROR. ]*/
+                                                                            LogError("unable to HTTPAPIEX_ExecuteRequest");
+                                                                            result = BLOB_HTTP_ERROR;
+                                                                            isError = 1;
+                                                                        }
+                                                                        else if (*httpStatus >= 300)
+                                                                        {
+                                                                            /*Codes_SRS_BLOB_02_026: [ Otherwise, if HTTP response code is >=300 then Blob_UploadFromSasUri shall succeed and return BLOB_OK. ]*/
+                                                                            LogError("HTTP status from storage does not indicate success (%d)", (int)*httpStatus);
+                                                                            result = BLOB_OK;
+                                                                            isError = 1;
+                                                                        }
+                                                                        else
+                                                                        {
+                                                                            /*Codes_SRS_BLOB_02_027: [ Otherwise Blob_UploadFromSasUri shall continue execution. ]*/
+                                                                        }
+                                                                        BUFFER_delete(requestContent);
+                                                                    }
+                                                                }
+                                                                STRING_delete(newRelativePath);
+                                                            }
+                                                        }
+                                                        STRING_delete(blockIdString);
+                                                    }
+                                                }
 
-												blockID++;
-												toUpload -= thisBlockSize;
-											} while ((toUpload > 0) && !isError);
+                                                blockID++;
+                                                toUpload -= thisBlockSize;
+                                            } while ((toUpload > 0) && !isError);
 
-											if (isError)
-											{
-												/*do nothing, it will be reported "as is"*/
-											}
-											else
-											{
-												/*complete the XML*/
-												if (STRING_concat(xml, "</BlockList>") != 0)
-												{
-													/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-													LogError("failed to STRING_concat");
-													result = BLOB_ERROR;
-												}
-												else
-												{
-													/*Codes_SRS_BLOB_02_029: [Blob_UploadFromSasUri shall construct a new relativePath from following string : base relativePath + "&comp=blocklist"]*/
-													STRING_HANDLE newRelativePath = STRING_construct(relativePath);
-													if (newRelativePath == NULL)
-													{
-														/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-														LogError("failed to STRING_construct");
-														result = BLOB_ERROR;
-													}
-													else
-													{
-														if (STRING_concat(newRelativePath, "&comp=blocklist") != 0)
-														{
-															/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-															LogError("failed to STRING_concat");
-															result = BLOB_ERROR;
-														}
-														else
-														{
-															/*Codes_SRS_BLOB_02_030: [ Blob_UploadFromSasUri shall call HTTPAPIEX_ExecuteRequest with a PUT operation, passing the new relativePath, httpStatus and httpResponse and the XML string as content. ]*/
-															const char* s = STRING_c_str(xml);
-															BUFFER_HANDLE xmlAsBuffer = BUFFER_create((const unsigned char*)s, strlen(s));
-															if (xmlAsBuffer == NULL)
-															{
-																/*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
-																LogError("failed to BUFFER_create");
-																result = BLOB_ERROR;
-															}
-															else
-															{
-																if (HTTPAPIEX_ExecuteRequest(
-																	httpApiExHandle,
-																	HTTPAPI_REQUEST_PUT,
-																	STRING_c_str(newRelativePath),
-																	NULL,
-																	xmlAsBuffer,
-																	httpStatus,
-																	NULL,
-																	httpResponse
-																) != HTTPAPIEX_OK)
-																{
-																	/*Codes_SRS_BLOB_02_031: [ If HTTPAPIEX_ExecuteRequest fails then Blob_UploadFromSasUri shall fail and return BLOB_HTTP_ERROR. ]*/
-																	LogError("unable to HTTPAPIEX_ExecuteRequest");
-																	result = BLOB_HTTP_ERROR;
-																}
-																else
-																{
-																	/*Codes_SRS_BLOB_02_032: [ Otherwise, Blob_UploadFromSasUri shall succeed and return BLOB_OK. ]*/
-																	result = BLOB_OK;
-																}
-																BUFFER_delete(xmlAsBuffer);
-															}
-														}
-														STRING_delete(newRelativePath);
-													}
-												}
-											}
-											STRING_delete(xml);
-										}
-									}
-								}
+                                            if (isError)
+                                            {
+                                                /*do nothing, it will be reported "as is"*/
+                                            }
+                                            else
+                                            {
+                                                /*complete the XML*/
+                                                if (STRING_concat(xml, "</BlockList>") != 0)
+                                                {
+                                                    /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+                                                    LogError("failed to STRING_concat");
+                                                    result = BLOB_ERROR;
+                                                }
+                                                else
+                                                {
+                                                    /*Codes_SRS_BLOB_02_029: [Blob_UploadFromSasUri shall construct a new relativePath from following string : base relativePath + "&comp=blocklist"]*/
+                                                    STRING_HANDLE newRelativePath = STRING_construct(relativePath);
+                                                    if (newRelativePath == NULL)
+                                                    {
+                                                        /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+                                                        LogError("failed to STRING_construct");
+                                                        result = BLOB_ERROR;
+                                                    }
+                                                    else
+                                                    {
+                                                        if (STRING_concat(newRelativePath, "&comp=blocklist") != 0)
+                                                        {
+                                                            /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+                                                            LogError("failed to STRING_concat");
+                                                            result = BLOB_ERROR;
+                                                        }
+                                                        else
+                                                        {
+                                                            /*Codes_SRS_BLOB_02_030: [ Blob_UploadFromSasUri shall call HTTPAPIEX_ExecuteRequest with a PUT operation, passing the new relativePath, httpStatus and httpResponse and the XML string as content. ]*/
+                                                            const char* s = STRING_c_str(xml);
+                                                            BUFFER_HANDLE xmlAsBuffer = BUFFER_create((const unsigned char*)s, strlen(s));
+                                                            if (xmlAsBuffer == NULL)
+                                                            {
+                                                                /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadFromSasUri shall fail and return BLOB_ERROR ]*/
+                                                                LogError("failed to BUFFER_create");
+                                                                result = BLOB_ERROR;
+                                                            }
+                                                            else
+                                                            {
+                                                                if (HTTPAPIEX_ExecuteRequest(
+                                                                    httpApiExHandle,
+                                                                    HTTPAPI_REQUEST_PUT,
+                                                                    STRING_c_str(newRelativePath),
+                                                                    NULL,
+                                                                    xmlAsBuffer,
+                                                                    httpStatus,
+                                                                    NULL,
+                                                                    httpResponse
+                                                                ) != HTTPAPIEX_OK)
+                                                                {
+                                                                    /*Codes_SRS_BLOB_02_031: [ If HTTPAPIEX_ExecuteRequest fails then Blob_UploadFromSasUri shall fail and return BLOB_HTTP_ERROR. ]*/
+                                                                    LogError("unable to HTTPAPIEX_ExecuteRequest");
+                                                                    result = BLOB_HTTP_ERROR;
+                                                                }
+                                                                else
+                                                                {
+                                                                    /*Codes_SRS_BLOB_02_032: [ Otherwise, Blob_UploadFromSasUri shall succeed and return BLOB_OK. ]*/
+                                                                    result = BLOB_OK;
+                                                                }
+                                                                BUFFER_delete(xmlAsBuffer);
+                                                            }
+                                                        }
+                                                        STRING_delete(newRelativePath);
+                                                    }
+                                                }
+                                            }
+                                            STRING_delete(xml);
+                                        }
+                                    }
+                                }
                             }
                             HTTPAPIEX_Destroy(httpApiExHandle);
                         }

--- a/iothub_client/src/iothub_client_ll_uploadtoblob.c
+++ b/iothub_client/src/iothub_client_ll_uploadtoblob.c
@@ -888,7 +888,7 @@ IOTHUB_CLIENT_RESULT IoTHubClient_LL_UploadToBlob_Impl(IOTHUB_CLIENT_LL_UPLOADTO
                                         {
                                             int step2success;
                                             /*Codes_SRS_IOTHUBCLIENT_LL_02_083: [ IoTHubClient_LL_UploadToBlob shall call Blob_UploadFromSasUri and capture the HTTP return code and HTTP body. ]*/
-                                            step2success = (Blob_UploadFromSasUri(STRING_c_str(sasUri), source, size, &httpResponse, responseToIoTHub, handleData->certificates) == BLOB_OK);
+                                            step2success = (Blob_UploadFromSasUri(STRING_c_str(sasUri), source, size, &httpResponse, responseToIoTHub, handleData->certificates, &(handleData->http_proxy_options)) == BLOB_OK);
                                             if (!step2success)
                                             {
                                                 /*Codes_SRS_IOTHUBCLIENT_LL_02_084: [ If Blob_UploadFromSasUri fails then IoTHubClient_LL_UploadToBlob shall fail and return IOTHUB_CLIENT_ERROR. ]*/

--- a/iothub_client/tests/blob_ut/blob_ut.c
+++ b/iothub_client/tests/blob_ut/blob_ut.c
@@ -363,7 +363,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_with_proxy_happy_path)
     {
         STRICT_EXPECTED_CALL(HTTPAPIEX_Create(TEST_HOSTNAME_1));
         {
-            STRICT_EXPECTED_CALL(HTTPAPIEX_SetOption(IGNORED_PTR_ARG, OPTION_HTTP_PROXY, IGNORED_PTR_ARG));
+            STRICT_EXPECTED_CALL(HTTPAPIEX_SetOption(IGNORED_PTR_ARG, OPTION_HTTP_PROXY, &proxyOptions));
             STRICT_EXPECTED_CALL(BUFFER_create(&c, 1));
             {
                 STRICT_EXPECTED_CALL(HTTPHeaders_Alloc());

--- a/iothub_client/tests/blob_ut/blob_ut.c
+++ b/iothub_client/tests/blob_ut/blob_ut.c
@@ -29,6 +29,7 @@ static void my_gballoc_free(void* s)
 #include "azure_c_shared_utility/base64.h"
 #include "azure_c_shared_utility/httpheaders.h"
 #include "azure_c_shared_utility/gballoc.h"
+#include "azure_c_shared_utility/shared_util_options.h"
 #undef ENABLE_MOCKS
 
 #include "blob.h"
@@ -206,7 +207,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_with_NULL_SasUri_fails)
     unsigned char c = '3';
 
     ///act
-    BLOB_RESULT result = Blob_UploadFromSasUri(NULL, &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL);
+    BLOB_RESULT result = Blob_UploadFromSasUri(NULL, &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_INVALID_ARG, result);
@@ -222,7 +223,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_with_NULL_source_and_non_zero_size_fails)
 
     ///act
 
-    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, NULL, 1, &httpResponse, testValidBufferHandle, NULL);
+    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, NULL, 1, &httpResponse, testValidBufferHandle, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_INVALID_ARG, result);
@@ -277,7 +278,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_happy_path)
     }
 
     ///act
-    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL);
+    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_OK, result);
@@ -334,7 +335,66 @@ TEST_FUNCTION(Blob_UploadFromSasUri_with_certificates_happy_path)
     }
 
     ///act
-    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, &c, sizeof(c), &httpResponse, testValidBufferHandle, "a");
+    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, &c, sizeof(c), &httpResponse, testValidBufferHandle, "a", NULL);
+
+    ///assert
+    ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_OK, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    ///cleanup
+}
+
+
+/*Tests_SRS_BLOB_02_004: [ Blob_UploadFromSasUri shall copy from SASURI the hostname to a new const char*. ]*/
+/*Tests_SRS_BLOB_02_006: [ Blob_UploadFromSasUri shall create a new HTTPAPI_EX_HANDLE by calling HTTPAPIEX_Create passing the hostname. ]*/
+/*Tests_SRS_BLOB_02_008: [ Blob_UploadFromSasUri shall compute the relative path of the request from the SASURI parameter. ]*/
+/*Tests_SRS_BLOB_02_009: [ Blob_UploadFromSasUri shall create an HTTP_HEADERS_HANDLE for the request HTTP headers carrying the following headers: ]*/
+/*Tests_SRS_BLOB_02_010: [ Blob_UploadFromSasUri shall create a BUFFER_HANDLE from source and size parameters. ]*/
+/*Tests_SRS_BLOB_02_012: [ Blob_UploadFromSasUri shall call HTTPAPIEX_ExecuteRequest passing the parameters previously build, httpStatus and httpResponse ]*/
+/*Tests_SRS_BLOB_02_015: [ Otherwise, HTTPAPIEX_ExecuteRequest shall succeed and return BLOB_OK. ]*/
+/*Tests_SRS_BLOB_32_001: [ If proxy was provided then Blob_UploadFromSasUri shall pass proxy information to HTTPAPI_EX_HANDLE by calling HTTPAPIEX_SetOption with the option name OPTION_HTTP_PROXY. ]*/
+TEST_FUNCTION(Blob_UploadFromSasUri_with_proxy_happy_path)
+{
+    ///arrange
+    unsigned char c = '3';
+	HTTP_PROXY_OPTIONS proxyOptions = { "a", 8888, NULL, NULL };
+	
+    STRICT_EXPECTED_CALL(gballoc_malloc(strlen(TEST_HOSTNAME_1) + 1));
+    {
+        STRICT_EXPECTED_CALL(HTTPAPIEX_Create(TEST_HOSTNAME_1));
+        {
+            STRICT_EXPECTED_CALL(HTTPAPIEX_SetOption(IGNORED_PTR_ARG, OPTION_HTTP_PROXY, IGNORED_PTR_ARG));
+            STRICT_EXPECTED_CALL(BUFFER_create(&c, 1));
+            {
+                STRICT_EXPECTED_CALL(HTTPHeaders_Alloc());
+                {
+                    int responseCode = 200; /*everything is good*/
+                    STRICT_EXPECTED_CALL(HTTPHeaders_AddHeaderNameValuePair(IGNORED_PTR_ARG, X_MS_BLOB_TYPE, BLOCK_BLOB))
+                        .IgnoreArgument_httpHeadersHandle();
+
+                    STRICT_EXPECTED_CALL(HTTPAPIEX_ExecuteRequest(IGNORED_PTR_ARG, HTTPAPI_REQUEST_PUT, TEST_RELATIVE_PATH_1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, &httpResponse, NULL, testValidBufferHandle))
+                        .IgnoreArgument_handle()
+                        .IgnoreArgument_requestHttpHeadersHandle()
+                        .IgnoreArgument_requestContent()
+                        .CopyOutArgumentBuffer_statusCode(&responseCode, sizeof(responseCode))
+                        .SetReturn(HTTPAPIEX_OK)
+                        ;
+
+                    STRICT_EXPECTED_CALL(HTTPHeaders_Free(IGNORED_PTR_ARG))
+                        .IgnoreArgument_httpHeadersHandle();
+                }
+                STRICT_EXPECTED_CALL(BUFFER_delete(IGNORED_PTR_ARG))
+                    .IgnoreArgument_handle();
+            }
+            STRICT_EXPECTED_CALL(HTTPAPIEX_Destroy(IGNORED_PTR_ARG))
+                .IgnoreArgument_handle();
+        }
+        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))
+            .IgnoreArgument_ptr();
+    }
+
+    ///act
+    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL, &proxyOptions);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_OK, result);
@@ -383,7 +443,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_succeeds_when_HTTP_status_code_is_404)
     }
 
     ///act
-    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL);
+    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_OK, result);
@@ -432,7 +492,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_fails_when_HTTPAPIEX_ExecuteRequest_fails)
     }
 
     ///act
-    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL);
+    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_HTTP_ERROR, result);
@@ -474,7 +534,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_fails_when_HTTPHeaders_AddHeaderNameValuePai
     }
 
     ///act
-    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL);
+    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_ERROR, result);
@@ -510,7 +570,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_fails_when_HTTPHeaders_Alloc_fails)
     }
 
     ///act
-    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL);
+    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_ERROR, result);
@@ -541,7 +601,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_fails_when_BUFFER_create_fails)
     }
 
     ///act
-    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL);
+    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_ERROR, result);
@@ -566,7 +626,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_fails_when_HTTPAPIEX_Create_fails)
     }
 
     ///act
-    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL);
+    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_ERROR, result);
@@ -586,7 +646,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_fails_when_malloc_fails)
         ;
 
     ///act
-    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL);
+    BLOB_RESULT result = Blob_UploadFromSasUri(TEST_VALID_SASURI_1, &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_ERROR, result);
@@ -602,7 +662,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_when_SasUri_is_wrong_fails_1)
     unsigned char c = '3';
 
     ///act
-    BLOB_RESULT result = Blob_UploadFromSasUri("https:/h.h/doms", &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL); /*wrong format for protocol, notice it is actually http:\h.h\doms (missing a \ from http)*/
+    BLOB_RESULT result = Blob_UploadFromSasUri("https:/h.h/doms", &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL, NULL); /*wrong format for protocol, notice it is actually http:\h.h\doms (missing a \ from http)*/
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_INVALID_ARG, result);
@@ -618,7 +678,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_when_SasUri_is_wrong_fails_2)
     unsigned char c = '3';
 
     ///act
-    BLOB_RESULT result = Blob_UploadFromSasUri("https://h.h", &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL); /*there's no relative path here*/
+    BLOB_RESULT result = Blob_UploadFromSasUri("https://h.h", &c, sizeof(c), &httpResponse, testValidBufferHandle, NULL, NULL); /*there's no relative path here*/
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_INVALID_ARG, result);
@@ -761,7 +821,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_various_sizes_happy_path)
             .IgnoreArgument_ptr();
 
         ///act
-        BLOB_RESULT result = Blob_UploadFromSasUri("https://h.h/something?a=b", content, sizes[iSize], &httpResponse, testValidBufferHandle, NULL);
+        BLOB_RESULT result = Blob_UploadFromSasUri("https://h.h/something?a=b", content, sizes[iSize], &httpResponse, testValidBufferHandle, NULL, NULL);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -895,7 +955,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_various_sizes_with_certificates_happy_path)
             .IgnoreArgument_ptr();
 
         ///act
-        BLOB_RESULT result = Blob_UploadFromSasUri("https://h.h/something?a=b", content, sizes[iSize], &httpResponse, testValidBufferHandle, "a");
+        BLOB_RESULT result = Blob_UploadFromSasUri("https://h.h/something?a=b", content, sizes[iSize], &httpResponse, testValidBufferHandle, "a", NULL);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1117,7 +1177,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_64MB_unhappy_paths)
             sprintf(temp_str, "On failed call %zu", i);
             
             ///act
-            BLOB_RESULT result = Blob_UploadFromSasUri("https://h.h/something?a=b", content, size, &httpResponse, testValidBufferHandle, NULL);
+            BLOB_RESULT result = Blob_UploadFromSasUri("https://h.h/something?a=b", content, size, &httpResponse, testValidBufferHandle, NULL, NULL);
 
             ///assert
             ASSERT_ARE_NOT_EQUAL_WITH_MSG(BLOB_RESULT, BLOB_OK, result, temp_str);
@@ -1344,7 +1404,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_64MB_with_certificate_unhappy_paths)
             sprintf(temp_str, "On failed call %zu", i);
 
             ///act
-            BLOB_RESULT result = Blob_UploadFromSasUri("https://h.h/something?a=b", content, size, &httpResponse, testValidBufferHandle, "a");
+            BLOB_RESULT result = Blob_UploadFromSasUri("https://h.h/something?a=b", content, size, &httpResponse, testValidBufferHandle, "a", NULL);
 
             ///assert
             ASSERT_ARE_NOT_EQUAL_WITH_MSG(BLOB_RESULT, BLOB_OK, result, temp_str);
@@ -1375,7 +1435,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_fails_when_size_is_exceeded)
     unsigned char c = 3;
 
     ///act
-    BLOB_RESULT result = Blob_UploadFromSasUri("https://h.h", &c, size, &httpResponse, testValidBufferHandle, NULL);
+    BLOB_RESULT result = Blob_UploadFromSasUri("https://h.h", &c, size, &httpResponse, testValidBufferHandle, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_INVALID_ARG, result);
@@ -1460,7 +1520,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_when_http_code_is_404_it_immediately_succeed
         .IgnoreArgument_ptr();
 
     ///act
-    BLOB_RESULT result = Blob_UploadFromSasUri("https://h.h/something?a=b", content, size, &httpResponse, testValidBufferHandle, NULL);
+    BLOB_RESULT result = Blob_UploadFromSasUri("https://h.h/something?a=b", content, size, &httpResponse, testValidBufferHandle, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());

--- a/iothub_client/tests/iothubclient_ll_u2b_ut/iothub_client_ll_u2b_ut.c
+++ b/iothub_client/tests/iothubclient_ll_u2b_ut/iothub_client_ll_u2b_ut.c
@@ -782,7 +782,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_SAS_token_happypath)
             .CaptureReturn(&sasUri_as_const_char)
             .IgnoreArgument(1);
 
-        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL))
+        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL, IGNORED_PTR_ARG))
             .IgnoreArgument(1)
             .IgnoreArgument(4)
             .IgnoreArgument(5)
@@ -1106,7 +1106,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_SAS_token_with_certificates_happypath
             .CaptureReturn(&sasUri_as_const_char)
             .IgnoreArgument(1);
 
-        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, "some certificates"))
+        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, "some certificates", IGNORED_PTR_ARG))
             .IgnoreArgument(1)
             .IgnoreArgument(4)
             .IgnoreArgument(5)
@@ -1592,7 +1592,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_SAS_token_when_step2_httpStatusCode_i
             .CaptureReturn(&sasUri_as_const_char)
             .IgnoreArgument(1);
 
-        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL))
+        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL, IGNORED_PTR_ARG))
             .IgnoreArgument(1)
             .IgnoreArgument(4)
             .IgnoreArgument(5)
@@ -1913,7 +1913,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_SAS_token_when_step3_httpStatusCode_i
             .CaptureReturn(&sasUri_as_const_char)
             .IgnoreArgument(1);
 
-        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL))
+        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL, IGNORED_PTR_ARG))
             .IgnoreArgument(1)
             .IgnoreArgument(4)
             .IgnoreArgument(5)
@@ -2244,7 +2244,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_SAS_token_unhappypaths)
             .CaptureReturn(&sasUri_as_const_char)
             .IgnoreArgument(1);
 
-        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL))
+        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL, NULL))
             .IgnoreArgument(1)
             .IgnoreArgument(4)
             .IgnoreArgument(5)
@@ -2733,7 +2733,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_deviceKey_happypath)
             .CaptureReturn(&sasUri_as_const_char)
             .IgnoreArgument(1);
 
-        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL))
+        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL, IGNORED_PTR_ARG))
             .IgnoreArgument(1)
             .IgnoreArgument(4)
             .IgnoreArgument(5)
@@ -2848,7 +2848,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_deviceKey_happypath)
     IOTHUB_CLIENT_RESULT result = IoTHubClient_LL_UploadToBlob_Impl(h, "text.txt", &c, 1);
 
     ///assert
-    ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
+    //ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     ///cleanup
@@ -3217,7 +3217,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_deviceKey_when_step3_httpStatusCode_i
             .CaptureReturn(&sasUri_as_const_char)
             .IgnoreArgument(1);
 
-        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL))
+        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL, IGNORED_PTR_ARG))
             .IgnoreArgument(1)
             .IgnoreArgument(4)
             .IgnoreArgument(5)
@@ -3563,7 +3563,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_deviceKey_unhappypaths)
             .CaptureReturn(&sasUri_as_const_char)
             .IgnoreArgument(1);
 
-        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL))
+        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL, NULL))
             .IgnoreArgument(1)
             .IgnoreArgument(4)
             .IgnoreArgument(5)
@@ -3950,7 +3950,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_passes_x509_information_to_HTTPAPIEX_
             .CaptureReturn(&sasUri_as_const_char)
             .IgnoreArgument(1);
 
-        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL))
+        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL, IGNORED_PTR_ARG))
             .IgnoreArgument(1)
             .IgnoreArgument(4)
             .IgnoreArgument(5)
@@ -4276,7 +4276,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_passes_x509_information_to_HTTPAPIEX_
             .CaptureReturn(&sasUri_as_const_char)
             .IgnoreArgument(1);
 
-        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL))
+        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL, NULL))
             .IgnoreArgument(1)
             .IgnoreArgument(4)
             .IgnoreArgument(5)

--- a/iothub_client/tests/iothubclient_ll_u2b_ut/iothub_client_ll_u2b_ut.c
+++ b/iothub_client/tests/iothubclient_ll_u2b_ut/iothub_client_ll_u2b_ut.c
@@ -2244,7 +2244,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_SAS_token_unhappypaths)
             .CaptureReturn(&sasUri_as_const_char)
             .IgnoreArgument(1);
 
-        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL, NULL))
+        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL, IGNORED_PTR_ARG))
             .IgnoreArgument(1)
             .IgnoreArgument(4)
             .IgnoreArgument(5)
@@ -3563,7 +3563,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_deviceKey_unhappypaths)
             .CaptureReturn(&sasUri_as_const_char)
             .IgnoreArgument(1);
 
-        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL, NULL))
+        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL, IGNORED_PTR_ARG))
             .IgnoreArgument(1)
             .IgnoreArgument(4)
             .IgnoreArgument(5)
@@ -4276,7 +4276,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_passes_x509_information_to_HTTPAPIEX_
             .CaptureReturn(&sasUri_as_const_char)
             .IgnoreArgument(1);
 
-        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL, NULL))
+        STRICT_EXPECTED_CALL(Blob_UploadFromSasUri(sasUri_as_const_char, &c, 1, IGNORED_PTR_ARG, IGNORED_PTR_ARG, NULL, IGNORED_PTR_ARG))
             .IgnoreArgument(1)
             .IgnoreArgument(4)
             .IgnoreArgument(5)

--- a/iothub_client/tests/iothubclient_ll_u2b_ut/iothub_client_ll_u2b_ut.c
+++ b/iothub_client/tests/iothubclient_ll_u2b_ut/iothub_client_ll_u2b_ut.c
@@ -2848,7 +2848,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_deviceKey_happypath)
     IOTHUB_CLIENT_RESULT result = IoTHubClient_LL_UploadToBlob_Impl(h, "text.txt", &c, 1);
 
     ///assert
-    //ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
+    ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     ///cleanup


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)
Fixes https://github.com/Azure/azure-iot-sdk-c/issues/254

# Description of the problem
The file upload consists of two round trips, one to each of two web servers. The first round trip was correctly using the web proxy whereas the second round trip did not. This was due to the fact that Blob_UploadFromSasUri was not passed the proxy information so consequently it did not set the appropriate option for the lower level.

# Description of the solution
Added an additional parameter to Blob_UploadFromSasUri that contains the proxy information. If there is no proxy information then this can be either passed as NULL or the host address in the proxy structure can be set to NULL. In either case the code will bypass using a web proxy for the upload.