### PR TITLE
CMAKE_SOURCE_DIR -> CMAKE_CURRENT_SOURCE_DIR to ensure SDK compiles w…

### DIFF
--- a/configs/azure_iot_sdksFunctions.cmake
+++ b/configs/azure_iot_sdksFunctions.cmake
@@ -3,7 +3,7 @@
 
 function(getIoTSDKVersion)
 	# First find the applicable line in the file
-	file (STRINGS "${CMAKE_SOURCE_DIR}/iothub_client/inc/iothub_client_version.h" iotsdkverstr
+	file (STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/iothub_client/inc/iothub_client_version.h" iotsdkverstr
 		REGEX "^[\t ]*#[\t ]*define[\t ]*IOTHUB_SDK_VERSION[\t ]*\"([0-9]+)[.]([0-9]+)[.]([0-9]+)\"")
 		
 	if (!MATCHES)


### PR DESCRIPTION
…hen added as a git submodule

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [X] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
When azure-iot-sdk-c is added as a submodule it will fail to compile due to incorrect CMAKE_SOURCE_DIR macro in configs/azure_iot_sdksFunctions.cmake

# Description of the solution
Replaced CMAKE_SOURCE_DIR with CMAKE_CURRENT_SOURCE_DIR to pass a correct submodule parent source dir.