### PR TITLE
fix issue which shows up when the SDK is uses as a submodule

### DIFF
--- a/configs/azure_iot_sdksFunctions.cmake
+++ b/configs/azure_iot_sdksFunctions.cmake
@@ -2,32 +2,32 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 function(getIoTSDKVersion)
-	# First find the applicable line in the file
-	file (STRINGS "${CMAKE_SOURCE_DIR}/iothub_client/inc/iothub_client_version.h" iotsdkverstr
-		REGEX "^[\t ]*#[\t ]*define[\t ]*IOTHUB_SDK_VERSION[\t ]*\"([0-9]+)[.]([0-9]+)[.]([0-9]+)\"")
-		
-	if (!MATCHES)
-		message(FATAL_ERROR "Unable to find version in ${CMAKE_SOURCE_DIR}/iothub_client/inc/iothub_client_version.h")
-	else(!MATCHES)
-		# Parse out the three version identifiers
-		set(CMAKE_MATCH_3 "")
+    # First find the applicable line in the file
+    file (STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/iothub_client/inc/iothub_client_version.h" iotsdkverstr
+        REGEX "^[\t ]*#[\t ]*define[\t ]*IOTHUB_SDK_VERSION[\t ]*\"([0-9]+)[.]([0-9]+)[.]([0-9]+)\"")
 
-		string(REGEX MATCH "^[\t ]*#[\t ]*define[\t ]*IOTHUB_SDK_VERSION[\t ]*\"([0-9]+)[.]([0-9]+)[.]([0-9]+)\"" temp "${iotsdkverstr}")
+    if (!MATCHES)
+        message(FATAL_ERROR "Unable to find version in ${CMAKE_SOURCE_DIR}/iothub_client/inc/iothub_client_version.h")
+    else(!MATCHES)
+        # Parse out the three version identifiers
+        set(CMAKE_MATCH_3 "")
 
-		if (CMAKE_MATCH_3)
-			set (IOT_SDK_VERION_MAJOR "${CMAKE_MATCH_1}" PARENT_SCOPE)
-			set (IOT_SDK_VERION_MINOR "${CMAKE_MATCH_2}" PARENT_SCOPE)
-			set (IOT_SDK_VERION_FIX "${CMAKE_MATCH_3}" PARENT_SCOPE)
-			set (IOT_SDK_VERSION "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}" PARENT_SCOPE)
-		else (CMAKE_MATCH_3)
-			message(FATAL_ERROR "Unable to find version in ${iotsdkverstr}")
-		endif(CMAKE_MATCH_3)
-	endif(!MATCHES)
+        string(REGEX MATCH "^[\t ]*#[\t ]*define[\t ]*IOTHUB_SDK_VERSION[\t ]*\"([0-9]+)[.]([0-9]+)[.]([0-9]+)\"" temp "${iotsdkverstr}")
+
+        if (CMAKE_MATCH_3)
+            set (IOT_SDK_VERION_MAJOR "${CMAKE_MATCH_1}" PARENT_SCOPE)
+            set (IOT_SDK_VERION_MINOR "${CMAKE_MATCH_2}" PARENT_SCOPE)
+            set (IOT_SDK_VERION_FIX "${CMAKE_MATCH_3}" PARENT_SCOPE)
+            set (IOT_SDK_VERSION "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}" PARENT_SCOPE)
+        else (CMAKE_MATCH_3)
+            message(FATAL_ERROR "Unable to find version in ${iotsdkverstr}")
+        endif(CMAKE_MATCH_3)
+    endif(!MATCHES)
 endfunction(getIoTSDKVersion)
 
 function(linkUAMQP whatExecutableIsBuilding)
     include_directories(${UAMQP_INC_FOLDER})
-    
+
     if(WIN32)
         #windows needs this define
         add_definitions(-D_CRT_SECURE_NO_WARNINGS)
@@ -37,7 +37,7 @@ function(linkUAMQP whatExecutableIsBuilding)
 
         if(${use_openssl})
             target_link_libraries(${whatExecutableIsBuilding} $ENV{OpenSSLDir}/lib/ssleay32.lib $ENV{OpenSSLDir}/lib/libeay32.lib)
-        
+
             file(COPY $ENV{OpenSSLDir}/bin/libeay32.dll DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/Debug)
             file(COPY $ENV{OpenSSLDir}/bin/ssleay32.dll DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/Debug)
 


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 