### PR TITLE
Add docker support for module sender sample

### DIFF
--- a/iothub_client/samples/iothub_client_sample_module_sender/docker/linux/amd64/Dockerfile
+++ b/iothub_client/samples/iothub_client_sample_module_sender/docker/linux/amd64/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu
+
+# Add an unprivileged user account for running the module
+RUN useradd -ms /bin/bash moduleuser
+ENV ModuleUser=moduleuser
+
+RUN apt-get update && apt-get install -y libcurl3
+
+WORKDIR /app
+ADD iothub_client_sample_module_sender /app
+ADD start.sh /app
+
+CMD ["/app/start.sh"]

--- a/iothub_client/samples/iothub_client_sample_module_sender/iothub_client_sample_module_sender.c
+++ b/iothub_client/samples/iothub_client_sample_module_sender/iothub_client_sample_module_sender.c
@@ -23,13 +23,13 @@
 
 /*String containing Hostname, Device Id & Device Key, ModuleID, and GatewayHostName in the format:                          */
 /*  "HostName=<host_name>;DeviceId=<device_id>;SharedAccessKey=<device_key>;ModuleId=<Module_Id>;GatewayHostName=127.0.0.1" */
-static const char* connectionString = "[device connection string]";
+static char* connectionString = "[device connection string]";
 
 static int callbackCounter;
 static char msgText[1024];
 static char propText[1024];
 static bool g_continueRunning;
-#define MESSAGE_COUNT 5
+#define MESSAGE_COUNT 500
 #define DOWORK_LOOP_NUM     3
 
 
@@ -127,8 +127,13 @@ static void SendConfirmationCallback(IOTHUB_CLIENT_CONFIRMATION_RESULT result, v
 void iothub_client_sample_module_sender(void)
 {
     IOTHUB_CLIENT_LL_HANDLE iotHubClientHandle;
-
     EVENT_INSTANCE messages[MESSAGE_COUNT];
+
+    char *envCS = getenv("EdgeHubConnectionString");
+    if (envCS != NULL)
+    {
+        connectionString = envCS;
+    }
 
     g_continueRunning = true;
     srand((unsigned int)time(NULL));
@@ -212,7 +217,7 @@ void iothub_client_sample_module_sender(void)
 
                     }
                     IoTHubClient_LL_DoWork(iotHubClientHandle);
-                    ThreadAPI_Sleep(1);
+                    ThreadAPI_Sleep(1000);
 
                     iterator++;
                 } while (g_continueRunning);

--- a/iothub_client/samples/iothub_client_sample_module_sender/iothub_client_sample_module_sender.c
+++ b/iothub_client/samples/iothub_client_sample_module_sender/iothub_client_sample_module_sender.c
@@ -23,7 +23,7 @@
 
 /*String containing Hostname, Device Id & Device Key, ModuleID, and GatewayHostName in the format:                          */
 /*  "HostName=<host_name>;DeviceId=<device_id>;SharedAccessKey=<device_key>;ModuleId=<Module_Id>;GatewayHostName=127.0.0.1" */
-static char* connectionString = "[device connection string]";
+static const char* connectionString = "[device connection string]";
 
 static int callbackCounter;
 static char msgText[1024];
@@ -129,10 +129,10 @@ void iothub_client_sample_module_sender(void)
     IOTHUB_CLIENT_LL_HANDLE iotHubClientHandle;
     EVENT_INSTANCE messages[MESSAGE_COUNT];
 
-    char *envCS = getenv("EdgeHubConnectionString");
-    if (envCS != NULL)
+    char *connectionStringFromEnvironment = getenv("EdgeHubConnectionString");
+    if (connectionStringFromEnvironment != NULL)
     {
-        connectionString = envCS;
+        connectionString = connectionStringFromEnvironment;
     }
 
     g_continueRunning = true;

--- a/iothub_client/samples/iothub_client_sample_module_sender/start.sh
+++ b/iothub_client/samples/iothub_client_sample_module_sender/start.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+ModuleUser=$(printenv ModuleUser)
+EdgeModuleCACertificateFile=$(printenv EdgeModuleCACertificateFile)
+
+echo "Edge Chain CA Certificate File: ${EdgeModuleCACertificateFile}"
+
+# copy the CA cert into the ca cert dir
+command="cp ${EdgeModuleCACertificateFile} /usr/local/share/ca-certificates/edge-chain-ca.crt"
+echo "Executing: ${command}"
+${command}
+if [ $? -ne 0 ]; then
+    echo "Failed to Copy Edge Chain CA Certificate."
+    exit 1
+fi
+# register the newly added CA cert
+command="update-ca-certificates"
+echo "Executing: ${command}"
+${command}
+if [ $? -ne 0 ]; then
+    echo "Failed to Update CA Certificates."
+    exit 1
+fi
+echo "Certificates installed successfully!"
+
+# start service
+runuser -u "$ModuleUser" /app/iothub_client_sample_module_sender


### PR DESCRIPTION
Add Docker support for the edge module sender sample so that we can build an image for this sample and test with Azure IoT Edge.