### PR TITLE
Add MQTT WS Transport header files to install-target

### DIFF
--- a/iothub_client/CMakeLists.txt
+++ b/iothub_client/CMakeLists.txt
@@ -207,6 +207,7 @@ if(${use_mqtt})
     set(iothub_client_h_install_files
         ${iothub_client_h_install_files}
         ${iothub_client_mqtt_transport_h_files}
+        ${iothub_client_mqtt_ws_transport_h_files}
     )
 endif()
 


### PR DESCRIPTION
# Description of the problem

After running `make install` the file `iothubtransportmqtt_websockets.h` is not installed. However, it is needed to write a MQTT-over-WebSockets-client.

# Description of the solution

Add the file to the list of files to be installed (as it is already done with `iothubtransportmqtt.h`).