### PR TITLE
add support for enabling e2e diagnostic using device twin

### DIFF
--- a/iothub_client/devdoc/requirement_docs/iothubclient_diagnostic_requirements.md
+++ b/iothub_client/devdoc/requirement_docs/iothubclient_diagnostic_requirements.md
@@ -6,17 +6,27 @@ The IoTHubClient_Diagnostic component is used to add predefined diagnostic prope
 ##Exposed API
 
 ```c
+#define E2E_DIAG_SETTING_METHOD_VALUE  \
+    E2E_DIAG_SETTING_UNKNOWN,          \
+    E2E_DIAG_SETTING_USE_LOCAL,        \
+    E2E_DIAG_SETTING_USE_REMOTE
+
+DEFINE_ENUM(E2E_DIAG_SETTING_METHOD, E2E_DIAG_SETTING_METHOD_VALUE);
+
+/** @brief diagnostic related setting */
 typedef struct IOTHUB_DIAGNOSTIC_SETTING_DATA_TAG
 {
     uint32_t diagSamplingPercentage;
     uint32_t currentMessageNumber;
+    E2E_DIAG_SETTING_METHOD diagSettingMethod;
 } IOTHUB_DIAGNOSTIC_SETTING_DATA;
- 
+
 extern int IoTHubClient_Diagnostic_AddIfNecessary(IOTHUB_DIAGNOSTIC_SETTING_DATA* diagSetting, IOTHUB_MESSAGE_HANDLE messageHandle);
 
+extern int IoTHubClient_Diagnostic_UpdateFromTwin(IOTHUB_DIAGNOSTIC_SETTING_DATA* diagSetting, bool isPartialUpdate, const unsigned char* payLoad, STRING_HANDLE message);
 ```
 
-##IoTHubClient_Diagnostic_AddIfNecessary 
+## IoTHubClient_Diagnostic_AddIfNecessary 
 ```c
 extern int IoTHubClient_Diagnostic_AddIfNecessary(IOTHUB_DIAGNOSTIC_SETTING_DATA* diagSetting, IOTHUB_MESSAGE_HANDLE messageHandle);
 ```
@@ -30,3 +40,26 @@ extern int IoTHubClient_Diagnostic_AddIfNecessary(IOTHUB_DIAGNOSTIC_SETTING_DATA
 **SRS_IOTHUB_DIAGNOSTIC_13_004: [**If IoTHubMessage_SetDiagnosticPropertyData finishes successfully it shall return IOTHUB_MESSAGE_OK.**]**
 
 **SRS_IOTHUB_DIAGNOSTIC_13_005: [**If diagSamplingPercentage is between(0, 100), diagnostic properties should be added based on percentage.**]**
+
+## IoTHubClient_Diagnostic_UpdateFromTwin
+```c
+extern int IoTHubClient_Diagnostic_UpdateFromTwin(IOTHUB_DIAGNOSTIC_SETTING_DATA* diagSetting, bool isPartialUpdate, const unsigned char* payLoad, STRING_HANDLE message)
+```
+
+**SRS_IOTHUB_DIAGNOSTIC_13_006: [**IoTHubClient_Diagnostic_UpdateFromTwin should return nonezero if arguments are NULL.**]**
+
+**SRS_IOTHUB_DIAGNOSTIC_13_007: [**IoTHubClient_Diagnostic_UpdateFromTwin should return nonezero if payLoad is not a valid json string.**]**
+
+**SRS_IOTHUB_DIAGNOSTIC_13_008: [**IoTHubClient_Diagnostic_UpdateFromTwin should return nonezero if device twin json doesn't contains a valid desired property.**]**
+
+**SRS_IOTHUB_DIAGNOSTIC_13_009: [**IoTHubClient_Diagnostic_UpdateFromTwin should set diagSamplingPercentage = 0 when sampling rate in twin is null.**]**
+
+**SRS_IOTHUB_DIAGNOSTIC_13_010: [**IoTHubClient_Diagnostic_UpdateFromTwin should set diagSamplingPercentage = 0 when cannot parse sampling rate from twin.**]**
+
+**SRS_IOTHUB_DIAGNOSTIC_13_011: [**IoTHubClient_Diagnostic_UpdateFromTwin should set diagSamplingPercentage = 0 if sampling rate parsed from twin is not between [0,100].**]**
+
+**SRS_IOTHUB_DIAGNOSTIC_13_012: [**IoTHubClient_Diagnostic_UpdateFromTwin should set diagSamplingPercentage correctly if sampling rate is valid.**]**
+
+**SRS_IOTHUB_DIAGNOSTIC_13_013: [**IoTHubClient_Diagnostic_UpdateFromTwin should report diagnostic property not existed if there is no sampling rate in complete twin.**]**
+
+**SRS_IOTHUB_DIAGNOSTIC_13_014: [**IoTHubClient_Diagnostic_UpdateFromTwin should return nonzero if STRING_sprintf failed.**]**

--- a/iothub_client/devdoc/requirement_docs/iothubclient_ll_requirements.md
+++ b/iothub_client/devdoc/requirement_docs/iothubclient_ll_requirements.md
@@ -121,6 +121,9 @@ extern IOTHUB_CLIENT_RESULT IoTHubClient_LL_SendReportedState(IOTHUB_CLIENT_LL_H
 extern IOTHUB_CLIENT_RESULT IoTHubClient_LL_SetDeviceMethodCallback(IOTHUB_CLIENT_LL_HANDLE iotHubClientHandle, IOTHUB_CLIENT_DEVICE_METHOD_CALLBACK_ASYNC deviceMethodCallback, void* userContextCallback);
 extern IOTHUB_CLIENT_RESULT IoTHubClient_LL_SetDeviceMethodCallback_Ex(IOTHUB_CLIENT_LL_HANDLE iotHubClientHandle, IOTHUB_CLIENT_INBOUND_DEVICE_METHOD_CALLBACK inboundDeviceMethodCallback, void* userContextCallback);
 extern IOTHUB_CLIENT_RESULT IoTHubClient_LL_DeviceMethodResponse(IOTHUB_CLIENT_LL_HANDLE iotHubClientHandle, uint32_t methodId, unsigned char* response, size_t responeSize);
+
+extern IOTHUB_CLIENT_RESULT IoTHubClient_LL_EnableE2EDiagnosticWithCloudSetting(IOTHUB_CLIENT_LL_HANDLE iotHubClientHandle);
+
 ```
 
 ## IoTHubClient_LL_CreateFromConnectionString
@@ -883,3 +886,18 @@ static IOTHUB_CLIENT_LL_HANDLE_DATA* create_iothub_client_data(IOTHUB_CLIENT_CON
 **SRS_IOTHUBCLIENT_LL_07_039: [** `create_iothub_client_data` shall call the transport _Register function with a populated structure of type IOTHUB_DEVICE_CONFIG and waitingToSend list. **]**
 
 **SRS_IOTHUBCLIENT_LL_07_040: [** `create_iothub_client_data` shall set the default retry policy as Exponential backoff with jitter and if succeed and return a `non-NULL` handle. **]**
+
+## IoTHubClient_LL_EnableE2EDiagnosticWithCloudSetting
+```c
+IOTHUB_CLIENT_RESULT IoTHubClient_LL_EnableE2EDiagnosticWithCloudSetting(IOTHUB_CLIENT_LL_HANDLE iotHubClientHandle);
+```
+
+**SRS_IOTHUBCLIENT_LL_18_002: [**EnableE2EDiagnosticWithCloudSetting should return `IOTHUB_CLIENT_INVALID_ARG` if argument handle is NULL.**]**
+
+**SRS_IOTHUBCLIENT_LL_18_003: [**EnableE2EDiagnosticWithCloudSetting should return `IOTHUB_CLIENT_ERROR` if calling EnableE2EDiagnosticWithCloudSetting twice.**]**
+
+**SRS_IOTHUBCLIENT_LL_18_004: [**EnableE2EDiagnosticWithCloudSetting should return `IOTHUB_CLIENT_ERROR` if diagnostic has been enabled with local setting.**]**
+
+**SRS_IOTHUBCLIENT_LL_18_005: [**EnableE2EDiagnosticWithCloudSetting should return `IOTHUB_CLIENT_ERROR` if IoTHubTransport_Subscribe_DeviceTwin failed.**]**
+
+**SRS_IOTHUBCLIENT_LL_18_006: [**EnableE2EDiagnosticWithCloudSetting should return `IOTHUB_CLIENT_OK` upon success.**]**

--- a/iothub_client/inc/iothub_client_diagnostic.h
+++ b/iothub_client/inc/iothub_client_diagnostic.h
@@ -14,6 +14,7 @@
 #include "azure_c_shared_utility/umock_c_prod.h"
 
 #include "iothub_message.h"
+#include "parson.h"
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -23,11 +24,21 @@ extern "C" {
 #include <stddef.h>
 #endif
 
+#define DEVICE_TWIN_SAMPLING_RATE_KEY "__e2e_diag_sample_rate"
+
+#define E2E_DIAG_SETTING_METHOD_VALUE  \
+    E2E_DIAG_SETTING_UNKNOWN,          \
+    E2E_DIAG_SETTING_USE_LOCAL,        \
+    E2E_DIAG_SETTING_USE_REMOTE
+
+DEFINE_ENUM(E2E_DIAG_SETTING_METHOD, E2E_DIAG_SETTING_METHOD_VALUE);
+
 /** @brief diagnostic related setting */
 typedef struct IOTHUB_DIAGNOSTIC_SETTING_DATA_TAG
 {
     uint32_t diagSamplingPercentage;
     uint32_t currentMessageNumber;
+    E2E_DIAG_SETTING_METHOD diagSettingMethod;
 } IOTHUB_DIAGNOSTIC_SETTING_DATA;
 
 /**
@@ -42,6 +53,21 @@ typedef struct IOTHUB_DIAGNOSTIC_SETTING_DATA_TAG
     * @return	0 upon success
     */
 MOCKABLE_FUNCTION(, int, IoTHubClient_Diagnostic_AddIfNecessary, IOTHUB_DIAGNOSTIC_SETTING_DATA *, diagSetting, IOTHUB_MESSAGE_HANDLE, messageHandle);
+
+/**
+    * @brief	Update diagnostic settings from device twin
+    *
+    * @param	diagSetting		Pointer to an @c IOTHUB_DIAGNOSTIC_SETTING_DATA structure
+    *
+    * @param    isPartialUpdate Whether device twin is complete or partial update
+    *
+    * @param	payLoad			Received device twin
+    *
+    * @param	message			Record some messages when updating diagnostic settings
+    *
+    * @return	0 upon success
+    */
+MOCKABLE_FUNCTION(, int, IoTHubClient_Diagnostic_UpdateFromTwin, IOTHUB_DIAGNOSTIC_SETTING_DATA*, diagSetting, bool, isPartialUpdate, const unsigned char*, payLoad, STRING_HANDLE, message);
 
 #ifdef __cplusplus
 }

--- a/iothub_client/inc/iothub_client_ll.h
+++ b/iothub_client/inc/iothub_client_ll.h
@@ -25,6 +25,7 @@
 
 #include "azure_c_shared_utility/macro_utils.h"
 #include "azure_c_shared_utility/umock_c_prod.h"
+#include "parson.h"
 
 #define IOTHUB_CLIENT_FILE_UPLOAD_RESULT_VALUES \
     FILE_UPLOAD_OK, \
@@ -559,6 +560,15 @@ extern "C"
      * @return	IOTHUB_CLIENT_OK upon success or an error code upon failure.
      */
      MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_LL_DeviceMethodResponse, IOTHUB_CLIENT_LL_HANDLE, iotHubClientHandle, METHOD_HANDLE, methodId, const unsigned char*, response, size_t, respSize, int, statusCode);
+
+     /**
+     * @brief    This API can enable E2E diagnostics for the device
+     *
+     * @param    iotHubClientHandle      The handle created by a call to the create function.
+     *
+     * @return   IOTHUB_CLIENT_OK upon success or an error code upon failure.
+     */
+     MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_LL_EnableE2EDiagnosticWithCloudSetting, IOTHUB_CLIENT_LL_HANDLE, iotHubClientHandle);
 
 #ifndef DONT_USE_UPLOADTOBLOB
     /**

--- a/iothub_client/tests/iothubclient_diagnostic_ut/CMakeLists.txt
+++ b/iothub_client/tests/iothubclient_diagnostic_ut/CMakeLists.txt
@@ -16,9 +16,11 @@ include_directories(${SHARED_UTIL_REAL_TEST_FOLDER})
 
 set(${theseTestsName}_c_files
     ../../src/iothub_client_diagnostic.c
+	../../../deps/parson/parson.c
 )
 
 set(${theseTestsName}_h_files
+	../../../deps/parson/parson.h
 )
 
 build_c_test_artifacts(${theseTestsName} ON "tests/UnitTests")

--- a/iothub_client/tests/iothubclient_ll_ut/iothubclient_ll_ut.c
+++ b/iothub_client/tests/iothubclient_ll_ut/iothubclient_ll_ut.c
@@ -130,6 +130,7 @@ static TEST_MUTEX_HANDLE g_dllByDll;
 bool g_fail_string_construct_sprintf;
 bool g_fail_platform_get_platform_info;
 bool g_fail_string_concat_with_string;
+bool g_fail_string_sprintf;
 
 static const char* TEST_STRING_VALUE = "Test string value";
 
@@ -265,6 +266,13 @@ static STRING_HANDLE my_STRING_construct(const char* psz)
 {
     (void)psz;
     return (STRING_HANDLE)my_gballoc_malloc(1);
+}
+
+int STRING_sprintf(STRING_HANDLE handle, const char* psz, ...)
+{
+    (void)handle;
+    (void)psz;
+    return g_fail_string_sprintf ? -1 : 0;
 }
 
 STRING_HANDLE STRING_construct_sprintf(const char* psz, ...)
@@ -686,6 +694,7 @@ TEST_FUNCTION_INITIALIZE(method_init)
     g_fail_string_construct_sprintf = false;
     g_fail_platform_get_platform_info = false;
     g_fail_string_concat_with_string = false;
+    g_fail_string_sprintf = false;
 }
 
 TEST_FUNCTION_CLEANUP(TestMethodCleanup)
@@ -4989,5 +4998,126 @@ TEST_FUNCTION(IoTHubClient_LL_SetOption_diag_sampling_percentage_fails)
     IoTHubClient_LL_Destroy(h);
 }
 
+/*Tests_SRS_IOTHUBCLIENT_LL_18_001: [If diagnostic has been enabled with could setting, calling IoTHubClient_LL_SetOption to enable local diagnostic setting shall return `IOTHUB_CLIENT_ERROR`. ]*/
+TEST_FUNCTION(IoTHubClient_LL_SetOption_diag_sampling_percentage_when_already_enable_cloud_fails)
+{
+    //arrange
+    IOTHUB_CLIENT_LL_HANDLE h = IoTHubClient_LL_Create(&TEST_CONFIG);
+
+    //act
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_LL_EnableE2EDiagnosticWithCloudSetting(h);
+
+    umock_c_reset_all_calls();
+
+    uint32_t diagPercentage = 100;
+    result = IoTHubClient_LL_SetOption(h, OPTION_DIAGNOSTIC_SAMPLING_PERCENTAGE, &diagPercentage);
+
+    //assert
+    ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_ERROR, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    //cleanup
+    IoTHubClient_LL_Destroy(h);
+}
+
+/* Tests_SRS_IOTHUBCLIENT_LL_18_002: [ EnableE2EDiagnosticWithCloudSetting should return `IOTHUB_CLIENT_INVALID_ARG` if argument handle is NULL. ]*/
+TEST_FUNCTION(IoTHubClient_LL_EnableE2EDiagnosticWithCloudSetting_null_handle_fails)
+{
+    //arrange
+
+    //act
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_LL_EnableE2EDiagnosticWithCloudSetting(NULL);
+
+    //assert
+    ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
+}
+
+/* Tests_SRS_IOTHUBCLIENT_LL_18_003: [ EnableE2EDiagnosticWithCloudSetting should return `IOTHUB_CLIENT_ERROR` if calling EnableE2EDiagnosticWithCloudSetting twice. ]*/
+TEST_FUNCTION(IoTHubClient_LL_EnableE2EDiagnosticWithCloudSetting_call_twice_fails)
+{
+    //arrange
+    IOTHUB_CLIENT_LL_HANDLE h = IoTHubClient_LL_Create(&TEST_CONFIG);
+    umock_c_reset_all_calls();
+
+    //act
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_LL_EnableE2EDiagnosticWithCloudSetting(h);
+    
+    ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
+
+    result = IoTHubClient_LL_EnableE2EDiagnosticWithCloudSetting(h);
+
+    ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_ERROR, result);
+
+    //cleanup
+    IoTHubClient_LL_Destroy(h);
+}
+
+/* Tests_SRS_IOTHUBCLIENT_LL_18_004: [ EnableE2EDiagnosticWithCloudSetting should return `IOTHUB_CLIENT_ERROR` if diagnostic has been enabled with local setting. ]*/
+TEST_FUNCTION(IoTHubClient_LL_EnableE2EDiagnosticWithCloudSetting_already_enable_diag_with_local_fails)
+{
+    //arrange
+    IOTHUB_CLIENT_LL_HANDLE h = IoTHubClient_LL_Create(&TEST_CONFIG);
+    umock_c_reset_all_calls();
+
+    //act
+    uint32_t diagPercentage = 100;
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_LL_SetOption(h, OPTION_DIAGNOSTIC_SAMPLING_PERCENTAGE, &diagPercentage);
+
+    ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
+
+    result = IoTHubClient_LL_EnableE2EDiagnosticWithCloudSetting(h);
+
+    ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_ERROR, result);
+
+    //cleanup
+    IoTHubClient_LL_Destroy(h);
+}
+
+/* Tests_SRS_IOTHUBCLIENT_LL_18_005: [ EnableE2EDiagnosticWithCloudSetting should return `IOTHUB_CLIENT_ERROR` if IoTHubTransport_Subscribe_DeviceTwin failed.]*/
+TEST_FUNCTION(IoTHubClient_LL_EnableE2EDiagnosticWithCloudSetting_negative_fails)
+{
+    //arrange
+    IOTHUB_CLIENT_LL_HANDLE h = IoTHubClient_LL_Create(&TEST_CONFIG);
+
+    int negativeTestsInitResult = umock_c_negative_tests_init();
+    ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
+    umock_c_reset_all_calls();
+
+    STRICT_EXPECTED_CALL(FAKE_IoTHubTransport_Subscribe_DeviceTwin(IGNORED_PTR_ARG));
+
+    umock_c_negative_tests_snapshot();
+
+    // act
+    size_t count = umock_c_negative_tests_call_count();
+    for (size_t index = 0; index < count; index++)
+    {
+        umock_c_negative_tests_reset();
+        umock_c_negative_tests_fail_call(index);
+
+        int result = IoTHubClient_LL_EnableE2EDiagnosticWithCloudSetting(h);
+
+        //assert
+        ASSERT_IS_FALSE(result == 0);
+    }
+
+    //cleanup
+    umock_c_negative_tests_deinit();
+}
+
+/* Tests_SRS_IOTHUBCLIENT_LL_18_006: [ EnableE2EDiagnosticWithCloudSetting should return `IOTHUB_CLIENT_OK` upon success. ]*/
+TEST_FUNCTION(IoTHubClient_LL_EnableE2EDiagnosticWithCloudSetting_success)
+{
+    //arrange
+    IOTHUB_CLIENT_LL_HANDLE h = IoTHubClient_LL_Create(&TEST_CONFIG);
+    umock_c_reset_all_calls();
+
+    //act
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_LL_EnableE2EDiagnosticWithCloudSetting(h);
+
+    ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
+
+    //cleanup
+    IoTHubClient_LL_Destroy(h);
+}
 
 END_TEST_SUITE(iothubclient_ll_ut)


### PR DESCRIPTION
This is P1 scenario for E2E diagnostic.
Please refer to design doc [E2E Diagnostics Design Using Device Twin](https://microsoft.sharepoint.com/:w:/r/teams/Azure_IoT/Shared%20Documents/SDKs/Specifications/E2E%20Diagnostics%20Design%20Using%20Device%20Twin.docx?d=we399724bc0a1492785ab278fd91aaeb6&csf=1)