### PR TITLE
Remove non-ascii chars from iothubtransporthttp.c

### DIFF
--- a/iothub_client/src/iothubtransporthttp.c
+++ b/iothub_client/src/iothubtransporthttp.c
@@ -2200,7 +2200,7 @@ static void DoMessages(HTTPTRANSPORT_HANDLE_DATA* handleData, HTTPTRANSPORT_PERD
                                                             }
                                                         }
                                                     }
-                                                    // Codes_SRS_TRANSPORTMULTITHTTP_09_003: [ The HTTP header value of `ContentType` shall be set in the `IoTHubMessage_SetContentTypeSystemProperty`.  ]   
+                                                    // Codes_SRS_TRANSPORTMULTITHTTP_09_003: [ The HTTP header value of `ContentType` shall be set in the `IoTHubMessage_SetContentTypeSystemProperty`. ] 
                                                     else if (strncmp(IOTHUB_CONTENT_TYPE_C2D, completeHeader, strlen(IOTHUB_CONTENT_TYPE_C2D)) == 0)
                                                     {
                                                         char* whereIsColon = strchr(completeHeader, ':');
@@ -2215,7 +2215,7 @@ static void DoMessages(HTTPTRANSPORT_HANDLE_DATA* handleData, HTTPTRANSPORT_PERD
                                                             }
                                                         }
                                                     }
-                                                    // Codes_SRS_TRANSPORTMULTITHTTP_09_004: [ The HTTP header value of `ContentEncoding` shall be set in the `IoTHub_SetContentEncoding`.  ]   
+                                                    // Codes_SRS_TRANSPORTMULTITHTTP_09_004: [ The HTTP header value of `ContentEncoding` shall be set in the `IoTHub_SetContentEncoding`. ] 
                                                     else if (strncmp(IOTHUB_CONTENT_ENCODING_C2D, completeHeader, strlen(IOTHUB_CONTENT_ENCODING_C2D)) == 0)
                                                     {
                                                         char* whereIsColon = strchr(completeHeader, ':');


### PR DESCRIPTION
Customers on ja-JP Windows get errors when compiling the SDK, because their codepage doesn't support some of the Unicode chars that have made their way into the code comments. This change removes the Unicode chars.

This will fix Azure/iot-edge#493.
