### PR TITLE
Add explanatory comment to code

### DIFF
--- a/serializer/samples/devicetwin_simplesample/devicetwin_simplesample.c
+++ b/serializer/samples/devicetwin_simplesample/devicetwin_simplesample.c
@@ -36,8 +36,8 @@ DECLARE_MODEL(CarState,
     WITH_REPORTED_PROPERTY(ascii_char_ptr, vanityPlate)
 );
 
-// NOTE: In order for the callback to be invoked you will need to comment out the
-//       call to IoTHubClient_SetDeviceTwinCallback further down.
+// NOTE: For callbacks defined in the serializer model to be fired for desired properties, IoTHubClient_SetDeviceTwinCallback must not be invoked.
+//       Please comment out the call to IoTHubClient_SetDeviceTwinCallback further down to enable the callbacks defined in the model below. 
 DECLARE_MODEL(CarSettings,
     WITH_DESIRED_PROPERTY(uint8_t, desired_maxSpeed, onDesiredMaxSpeed),
     WITH_DESIRED_PROPERTY(Geo, location)

--- a/serializer/samples/devicetwin_simplesample/devicetwin_simplesample.c
+++ b/serializer/samples/devicetwin_simplesample/devicetwin_simplesample.c
@@ -36,6 +36,8 @@ DECLARE_MODEL(CarState,
     WITH_REPORTED_PROPERTY(ascii_char_ptr, vanityPlate)
 );
 
+// NOTE: In order for the callback to be invoked you will need to comment out the
+//       call to IoTHubClient_SetDeviceTwinCallback further down.
 DECLARE_MODEL(CarSettings,
     WITH_DESIRED_PROPERTY(uint8_t, desired_maxSpeed, onDesiredMaxSpeed),
     WITH_DESIRED_PROPERTY(Geo, location)


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
It is easy to overlook the fact that the device twin callback functions are not invoked unless one comments out the call to IoTHubClient_SetDeviceTwinCallback.

# Description of the solution
No code changes. Added a comment above the callback declaration in DECLARE_MODEL indicating that the callback would be ignored unless the call to IoTHubClient_SetDeviceTwinCallback is commented out. I did this since I missed this, my colleague missed this and so did the customer.