### PR TITLE
Hide parson library in .so. Version and install .so files properly

### DIFF
--- a/iothub_client/CMakeLists.txt
+++ b/iothub_client/CMakeLists.txt
@@ -18,10 +18,31 @@ set(iothub_client_ll_transport_c_files
     ./src/iothub_client_diagnostic.c
  )
 
-if(NOT ${dont_use_uploadtoblob})
-    set(iothub_client_ll_transport_c_files 
+set(iothub_client_libs)
+
+set(install_staticlibs
+    iothub_client
+)
+
+add_library(parson
+    ../deps/parson/parson.c
+)
+
+if(MSVC)
+    set_source_files_properties(../deps/parson/parson.c PROPERTIES COMPILE_FLAGS "/wd4244 /wd4232")
+endif()
+
+set(install_staticlibs ${install_staticlibs}
+    parson
+)
+
+set(iothub_client_libs ${iothub_client_libs}
+    parson
+)
+
+if(NOT dont_use_uploadtoblob)
+    set(iothub_client_ll_transport_c_files
         ${iothub_client_ll_transport_c_files}
-        ../deps/parson/parson.c
         ./src/iothub_client_ll_uploadtoblob.c
         ./src/blob.c
     )
@@ -30,15 +51,7 @@ if(NOT ${dont_use_uploadtoblob})
         ${iothub_client_ll_transport_h_files}
         ./inc/blob.h
     )
-
-    if(MSVC)
-        set_source_files_properties(../deps/parson/parson.c PROPERTIES COMPILE_FLAGS "/wd4244 /wd4232")
-    endif()
 endif()
-
-set(install_staticlibs
-    iothub_client
-)
 
 set(iothub_client_ll_transport_h_files
     ./inc/iothub_client_authorization.h
@@ -55,15 +68,14 @@ if (${use_prov_client})
         ${iothub_client_ll_transport_h_files}
         ./inc/iothub_client_hsm_ll.h
     )
-    set(iothub_client_ll_transport_c_files 
+    set(iothub_client_ll_transport_c_files
         ${iothub_client_ll_transport_c_files}
     )
 endif()
 
 if(NOT ${dont_use_uploadtoblob})
-    set(iothub_client_ll_transport_h_files 
+    set(iothub_client_ll_transport_h_files
         ${iothub_client_ll_transport_h_files}
-        ../deps/parson/parson.h
         ./inc/iothub_client_ll_uploadtoblob.h
     )
 endif()
@@ -87,8 +99,6 @@ set(iothub_client_h_install_files
     ${iothub_client_h_files}
 )
 
-set(iothub_client_libs)
-
 if(${use_http})
     set(install_staticlibs ${install_staticlibs}
         iothub_client_http_transport
@@ -103,7 +113,7 @@ if(${use_http})
         ./inc/iothubtransporthttp.h
         ./inc/iothub_transport_ll.h
     )
-    
+
     set(iothub_client_h_install_files
         ${iothub_client_h_install_files}
         ${iothub_client_http_transport_h_files}
@@ -122,9 +132,9 @@ if(${use_amqp})
         ./src/iothubtransport_amqp_device.c
         ./src/iothubtransport_amqp_cbs_auth.c
         ./src/iothubtransport_amqp_connection.c
-        ./src/iothubtransport_amqp_telemetry_messenger.c 
-        ./src/iothubtransport_amqp_twin_messenger.c 
-        ./src/iothubtransport_amqp_messenger.c 
+        ./src/iothubtransport_amqp_telemetry_messenger.c
+        ./src/iothubtransport_amqp_twin_messenger.c
+        ./src/iothubtransport_amqp_messenger.c
         ./src/iothubtransportamqp_methods.c
         ./src/iothub_client_retry_control.c
         ./src/message_queue.c
@@ -154,8 +164,8 @@ if(${use_amqp})
     set(iothub_client_amqp_transport_h_files
         ${iothub_client_amqp_transport_common_h_files}
         ./inc/iothubtransportamqp.h
-    )    
-    
+    )
+
     set(iothub_client_h_install_files
         ${iothub_client_h_install_files}
         ${iothub_client_amqp_transport_h_files}
@@ -165,7 +175,7 @@ if(${use_amqp})
         ${iothub_client_amqp_transport_common_c_files}
         ./src/iothubtransportamqp_websockets.c
     )
-        
+
     set(iothub_client_amqp_ws_transport_h_files
         ${iothub_client_amqp_transport_common_h_files}
         ./inc/iothubtransportamqp_websockets.h
@@ -201,14 +211,14 @@ if(${use_mqtt})
         ./src/iothub_client_retry_control.c
         ./src/iothubtransportmqtt.c
     )
-    
+
     set(iothub_client_mqtt_transport_h_files
         ${iothub_client_ll_transport_h_files}
         ./inc/iothubtransport_mqtt_common.h
         ./inc/iothub_client_retry_control.h
         ./inc/iothubtransportmqtt.h
     )
-    
+
     set(iothub_client_h_install_files
         ${iothub_client_h_install_files}
         ${iothub_client_mqtt_transport_h_files}
@@ -233,6 +243,7 @@ endif()
 
 set(IOTHUB_CLIENT_INC_FOLDER ${CMAKE_CURRENT_LIST_DIR}/inc CACHE INTERNAL "this is what needs to be included if using iothub_client lib" FORCE)
 
+
 if(NOT ${dont_use_uploadtoblob})
     include_directories(../deps/parson)
 endif()
@@ -242,7 +253,7 @@ include_directories(${AZURE_C_SHARED_UTILITY_INCLUDES})
 include_directories(${SHARED_UTIL_INC_FOLDER})
 
 if (WINCE)
-include_directories(${SHARED_UTIL_INC_FOLDER}/azure_c_shared_utility/windowsce) #windowsce SDK doesn't have stdbool.h
+    include_directories(${SHARED_UTIL_INC_FOLDER}/azure_c_shared_utility/windowsce) #windowsce SDK doesn't have stdbool.h
 ENDIF()
 
 include_directories(${IOTHUB_CLIENT_INC_FOLDER})
@@ -251,7 +262,7 @@ if(${memory_trace})
     add_definitions(-DGB_MEASURE_MEMORY_FOR_THIS -DGB_DEBUG_ALLOC)
 endif()
 
-IF(WIN32)  
+IF(WIN32)
     #windows needs this define
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
     if (WINCE) # Be lax with WEC 2013 compiler
@@ -263,8 +274,8 @@ ENDIF(WIN32)
 
 if(${use_http})
     include_directories(${IOTHUB_CLIENT_HTTP_TRANSPORT_INC_FOLDER})
-    add_library(iothub_client_http_transport 
-        ${iothub_client_http_transport_c_files} 
+    add_library(iothub_client_http_transport
+        ${iothub_client_http_transport_c_files}
         ${iothub_client_http_transport_h_files}
     )
     linkSharedUtil(iothub_client_http_transport)
@@ -272,13 +283,37 @@ if(${use_http})
         ${iothub_client_libs}
         iothub_client_http_transport
     )
+
+    if(build_as_dynamic)
+        add_library(iothub_client_http_transport_dll SHARED
+            ${iothub_client_http_transport_c_files}
+            ${iothub_client_http_transport_h_files}
+        )
+        linkSharedUtil(iothub_client_http_transport_dll)
+
+        if ("${CMAKE_COMPILER_ID}" STREQUAL "GNU")
+            target_link_libraries(iothub_client_http_transport_dll
+                "-Wl,--exclude-libs,libparson.a"
+            )
+        endif()
+        set_target_properties(iothub_client_http_transport_dll PROPERTIES
+            OUTPUT_NAME "iothub_client_http_transport"
+            ARCHIVE_OUTPUT_NAME "iothub_client_http_transport_dll_import"
+            ENABLE_EXPORTS YES
+            WINDOWS_EXPORT_ALL_SYMBOLS YES
+            VERSION ${IOT_SDK_VERSION}
+            SOVERSION ${IOT_SDK_VERION_MAJOR}
+            BUILD_WITH_INSTALL_RPATH TRUE
+        )
+        set(install_staticlibs ${install_staticlibs} iothub_client_http_transport_dll)
+    endif(build_as_dynamic)
 endif()
 
 if(${use_amqp})
     include_directories(${UAMQP_INCLUDES})
     include_directories(${IOTHUB_CLIENT_AMQP_TRANSPORT_INC_FOLDER} ${UAMQP_INC_FOLDER})
-    add_library(iothub_client_amqp_transport 
-        ${iothub_client_amqp_transport_c_files} 
+    add_library(iothub_client_amqp_transport
+        ${iothub_client_amqp_transport_c_files}
         ${iothub_client_amqp_transport_h_files}
     )
     linkSharedUtil(iothub_client_amqp_transport)
@@ -286,10 +321,10 @@ if(${use_amqp})
         ${iothub_client_libs}
         iothub_client_amqp_transport
     )
-    
+
     include_directories(${iothub_client_amqp_ws_transport_INC_FOLDER} ${UAMQP_INC_FOLDER})
-    add_library(iothub_client_amqp_ws_transport 
-        ${iothub_client_amqp_ws_transport_c_files} 
+    add_library(iothub_client_amqp_ws_transport
+        ${iothub_client_amqp_ws_transport_c_files}
         ${iothub_client_amqp_ws_transport_h_files}
     )
     linkSharedUtil(iothub_client_amqp_ws_transport)
@@ -297,13 +332,51 @@ if(${use_amqp})
         ${iothub_client_libs}
         iothub_client_amqp_ws_transport
     )
+
+    if (build_as_dynamic)
+        add_library(iothub_client_amqp_transport_dll SHARED
+            ${iothub_client_amqp_transport_c_files}
+            ${iothub_client_amqp_transport_h_files}
+        )
+        linkSharedUtil(iothub_client_amqp_transport_dll)
+        target_link_libraries(iothub_client_amqp_transport_dll uamqp)
+
+        set_target_properties(iothub_client_amqp_transport_dll PROPERTIES
+            OUTPUT_NAME "iothub_client_amqp_transport"
+            ARCHIVE_OUTPUT_NAME "iothub_client_amqp_transport_dll_import"
+            ENABLE_EXPORTS YES
+            WINDOWS_EXPORT_ALL_SYMBOLS YES
+            VERSION ${IOT_SDK_VERSION}
+            SOVERSION ${IOT_SDK_VERION_MAJOR}
+            BUILD_WITH_INSTALL_RPATH TRUE
+        )
+        set(install_staticlibs ${install_staticlibs} iothub_client_amqp_transport_dll)
+
+        add_library(iothub_client_amqp_ws_transport_dll SHARED
+            ${iothub_client_amqp_ws_transport_c_files}
+            ${iothub_client_amqp_ws_transport_h_files}
+        )
+        linkSharedUtil(iothub_client_amqp_ws_transport_dll)
+        target_link_libraries(iothub_client_amqp_transport_dll uamqp)
+
+        set_target_properties(iothub_client_amqp_ws_transport_dll PROPERTIES
+            OUTPUT_NAME "iothub_client_amqp_ws_transport"
+            ARCHIVE_OUTPUT_NAME "iothub_client_amqp_ws_transport_dll_import"
+            ENABLE_EXPORTS YES
+            WINDOWS_EXPORT_ALL_SYMBOLS YES
+            VERSION ${IOT_SDK_VERSION}
+            SOVERSION ${IOT_SDK_VERION_MAJOR}
+            BUILD_WITH_INSTALL_RPATH TRUE
+        )
+        set(install_staticlibs ${install_staticlibs} iothub_client_amqp_ws_transport_dll)
+    endif(build_as_dynamic)
 endif()
 
 if(${use_mqtt})
     include_directories(${UMQTT_INCLUDES})
     include_directories(${IOTHUB_CLIENT_MQTT_TRANSPORT_INC_FOLDER} ${MQTT_INC_FOLDER})
-    add_library(iothub_client_mqtt_transport 
-        ${iothub_client_mqtt_transport_c_files} 
+    add_library(iothub_client_mqtt_transport
+        ${iothub_client_mqtt_transport_c_files}
         ${iothub_client_mqtt_transport_h_files}
     )
     linkSharedUtil(iothub_client_mqtt_transport)
@@ -314,8 +387,8 @@ if(${use_mqtt})
         iothub_client_mqtt_transport
     )
     include_directories(${IOTHUB_CLIENT_MQTT_TRANSPORT_INC_FOLDER} ${MQTT_INC_FOLDER})
-    add_library(iothub_client_mqtt_ws_transport 
-        ${iothub_client_mqtt_ws_transport_c_files} 
+    add_library(iothub_client_mqtt_ws_transport
+        ${iothub_client_mqtt_ws_transport_c_files}
         ${iothub_client_mqtt_ws_transport_h_files}
     )
     linkSharedUtil(iothub_client_mqtt_ws_transport)
@@ -324,6 +397,54 @@ if(${use_mqtt})
         ${iothub_client_libs}
         iothub_client_mqtt_ws_transport
     )
+
+    if (build_as_dynamic)
+        add_library(iothub_client_mqtt_transport_dll SHARED
+            ${iothub_client_mqtt_transport_c_files}
+            ${iothub_client_mqtt_transport_h_files}
+        )
+        linkSharedUtil(iothub_client_mqtt_transport_dll)
+
+        # if ("${CMAKE_COMPILER_ID}" STREQUAL "GNU")
+            # target_link_libraries(iothub_client_mqtt_transport_dll
+                # "-Wl,--exclude-libs,libparson.a"
+            # )
+        # endif()
+
+        set_target_properties(iothub_client_mqtt_transport_dll PROPERTIES
+            OUTPUT_NAME "iothub_client_mqtt_transport"
+            ARCHIVE_OUTPUT_NAME "iothub_client_mqtt_transport_dll_import"
+            ENABLE_EXPORTS YES
+            WINDOWS_EXPORT_ALL_SYMBOLS YES
+            VERSION ${IOT_SDK_VERSION}
+            SOVERSION ${IOT_SDK_VERION_MAJOR}
+            BUILD_WITH_INSTALL_RPATH TRUE
+        )
+        set(install_staticlibs ${install_staticlibs} iothub_client_mqtt_transport_dll)
+
+        add_library(iothub_client_mqtt_ws_transport_dll SHARED
+            ${iothub_client_mqtt_ws_transport_c_files}
+            ${iothub_client_mqtt_ws_transport_h_files}
+        )
+        linkSharedUtil(iothub_client_mqtt_ws_transport_dll)
+
+        # if ("${CMAKE_COMPILER_ID}" STREQUAL "GNU")
+            # target_link_libraries(iothub_client_mqtt_transport_dll
+                # "-Wl,--exclude-libs,libparson.a"
+            # )
+        # endif()
+
+        set_target_properties(iothub_client_mqtt_ws_transport_dll PROPERTIES
+            OUTPUT_NAME "iothub_client_mqtt_ws_transport"
+            ARCHIVE_OUTPUT_NAME "iothub_client_mqtt_ws_transport_dll_import"
+            ENABLE_EXPORTS YES
+            WINDOWS_EXPORT_ALL_SYMBOLS YES
+            VERSION ${IOT_SDK_VERSION}
+            SOVERSION ${IOT_SDK_VERION_MAJOR}
+            BUILD_WITH_INSTALL_RPATH TRUE
+        )
+        set(install_staticlibs ${install_staticlibs} iothub_client_mqtt_ws_transport_dll)
+    endif(build_as_dynamic)
 endif()
 
 include_directories(${IOTHUB_CLIENT_INC_FOLDER})
@@ -342,7 +463,7 @@ endif()
 
 if (${build_as_dynamic})
     add_library(iothub_client_dll SHARED
-        ${iothub_client_c_files} 
+        ${iothub_client_c_files}
         ${iothub_client_h_files}
         ${iothub_def_file}
     )
@@ -351,6 +472,13 @@ if (${build_as_dynamic})
         set_target_properties(iothub_client_dll PROPERTIES OUTPUT_NAME "iothub_client")
     endif()
 
+    set_target_properties(iothub_client_dll PROPERTIES
+        ARCHIVE_OUTPUT_NAME "iothub_client_dll_import"
+        ENABLE_EXPORTS YES
+        VERSION ${IOT_SDK_VERSION}
+        SOVERSION ${IOT_SDK_VERION_MAJOR}
+        BUILD_WITH_INSTALL_RPATH TRUE
+    )
     set(iothub_client_libs
         iothub_client_dll
         ${iothub_client_libs}
@@ -358,10 +486,12 @@ if (${build_as_dynamic})
     if (${use_prov_client})
         target_link_libraries(iothub_client_dll hsm_security_client prov_auth_client)
     endif()
+
+    set(install_staticlibs ${install_staticlibs} iothub_client_dll)
 endif()
 
 add_library(iothub_client
-    ${iothub_client_c_files} 
+    ${iothub_client_c_files}
     ${iothub_client_h_files}
 )
 target_link_libraries(iothub_client ${iothub_client_libs})
@@ -372,21 +502,21 @@ endif()
 
 linkSharedUtil(iothub_client)
 set(iothub_client_libs
-    iothub_client 
+    iothub_client
     ${iothub_client_libs}
 )
 # Don't build samples under Win32 ARM for now
 if(NOT ${skip_samples})
 if(WIN32)
 # Build samples for WEC 2013 for both ARM and x86 processsor types
-  if(WINCE) 
+  if(WINCE)
     add_subdirectory(samples)
   else()
     if (NOT ${ARCHITECTURE} STREQUAL "ARM")
     add_subdirectory(samples)
     endif()
   endif()
-    
+
 else()
     add_subdirectory(samples)
 endif()
@@ -403,21 +533,21 @@ if(${use_installed_dependencies})
         set(CMAKE_INSTALL_LIBDIR "lib")
     endif()
 
-    if(NOT DEFINED CMAKE_INSTALL_INCLUDEDIR)    
-        set(CMAKE_INSTALL_INCLUDEDIR "include") 
-    endif()                                     
+    if(NOT DEFINED CMAKE_INSTALL_INCLUDEDIR)
+        set(CMAKE_INSTALL_INCLUDEDIR "include")
+    endif()
 
     install(TARGETS ${iothub_client_libs} EXPORT azure_iot_sdksTargets
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/../bin
-        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot 
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot
     )
     install(FILES ${iothub_client_h_install_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot)
 else()
-    install(FILES ${iothub_client_h_install_files} 
+    install(FILES ${iothub_client_h_install_files}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot)
-    install(TARGETS ${install_staticlibs} 
+    install(TARGETS ${install_staticlibs}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()

--- a/iothub_service_client/CMakeLists.txt
+++ b/iothub_service_client/CMakeLists.txt
@@ -11,7 +11,6 @@ endif()
 compileAsC99()
 
 set(iothub_service_client_c_files
-../deps/parson/parson.c
 ./src/iothub_registrymanager.c
 ./src/iothub_messaging.c
 ./src/iothub_messaging_ll.c
@@ -23,7 +22,6 @@ set(iothub_service_client_c_files
 )
 
 set(iothub_service_client_h_files
-../deps/parson/parson.h
 ./inc/iothub_registrymanager.h
 ./inc/iothub_messaging.h
 ./inc/iothub_messaging_ll.h
@@ -33,10 +31,6 @@ set(iothub_service_client_h_files
 ./inc/iothub_sc_version.h
 ../iothub_client/inc/iothub_message.h
 )
-
-if(MSVC)
-set_source_files_properties(../deps/parson/parson.c PROPERTIES COMPILE_FLAGS "/wd4244 /wd4232")
-endif()
 
 include_directories(${SHARED_UTIL_INC_FOLDER})
 
@@ -56,15 +50,30 @@ ENDIF(WIN32)
 if (${build_as_dynamic})
     add_library(iothub_service_client SHARED ${iothub_service_client_c_files} ${iothub_service_client_h_files} ./src/iothub_service_client.def)
     linkSharedUtil(iothub_service_client)
+    
+    if ("${CMAKE_COMPILER_ID}" STREQUAL "GNU")
+        target_link_libraries(iothub_service_client
+            "-Wl,--exclude-libs,libparson.a"
+        )
+    endif()
 
+    set_target_properties(iothub_service_client PROPERTIES
+        OUTPUT_NAME "iothub_service_client"
+        ARCHIVE_OUTPUT_NAME "iothub_service_client_dll_import"
+        ENABLE_EXPORTS YES
+        WINDOWS_EXPORT_ALL_SYMBOLS YES
+        VERSION ${IOT_SDK_VERSION}
+        SOVERSION ${IOT_SDK_VERION_MAJOR}
+        BUILD_WITH_INSTALL_RPATH TRUE
+    )
 else()
     add_library(iothub_service_client ${iothub_service_client_c_files} ${iothub_service_client_h_files})
 endif()
 
 if(NOT ${nuget_e2e_tests})
-    target_link_libraries(iothub_service_client uamqp)
+    target_link_libraries(iothub_service_client uamqp parson)
 else()
-    target_link_libraries(iothub_service_client)
+    target_link_libraries(iothub_service_client parson)
 endif()
 
 if (NOT ${ARCHITECTURE} STREQUAL "ARM")

--- a/serializer/CMakeLists.txt
+++ b/serializer/CMakeLists.txt
@@ -32,7 +32,6 @@ set(serializer_c_files
 ./src/schema.c
 ./src/schemalib.c
 ./src/schemaserializer.c
-../deps/parson/parson.c
 ./src/methodreturn.c
 )
 
@@ -55,10 +54,6 @@ set(serializer_h_files
 ./inc/methodreturn.h
 )
 
-if(MSVC)
-    set_source_files_properties(../deps/parson/parson.c PROPERTIES COMPILE_FLAGS "/wd4244 /wd4232")
-endif()
-
 #these are the include folders
 #the following "set" statetement exports across the project a global variable called SHARED_UTIL_INC_FOLDER that expands to whatever needs to included when using COMMON library
 set(SERIALIZER_INC_FOLDER ${CMAKE_CURRENT_LIST_DIR}/inc CACHE INTERNAL "this is what needs to be included if using serializer lib" FORCE)
@@ -77,11 +72,23 @@ if (${build_as_dynamic})
     serializer SHARED ${serializer_c_files} ${serializer_h_files} ./src/serializer.def
     )
     linkSharedUtil(serializer)
+
+    set_target_properties(serializer PROPERTIES
+        ARCHIVE_OUTPUT_NAME "serializer_dll_import"
+        ENABLE_EXPORTS YES
+        VERSION ${IOT_SDK_VERSION}
+        SOVERSION ${IOT_SDK_VERION_MAJOR}
+        BUILD_WITH_INSTALL_RPATH TRUE
+    )
 else()
     add_library(
     serializer ${serializer_c_files} ${serializer_h_files} 
     )
 endif()
+
+target_link_libraries(serializer
+    parson
+)
 
 if (NOT ${skip_samples})
 if(WIN32)


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-c/issues/229

# Description of the problem
Use of the Parson JSON library can cause customer's issues. The exposed function names in the library are identical to those in other JSON libraries. This can cause the customer's code to erroneously link to the Parson library instead of the desired library.

# Description of the solution
This will only work on Linux and you must build against the shared object files. 
Linux has the ability to "hide" entry points that are only used within the shared object itself. This will resolve the the externs that the shared object has but will not expose them to the clients of the shared object. This change converts the Parson inline compilation into its own library. This is then included in the shared objects that require it. Along with this, I also made sure the shared objects are properly versioned and installed. Many were not built at all which would have rendered the Parson change moot.