### PR TITLE
Urls from old repository will now point to the current repository's file

### DIFF
--- a/serializer/samples/simplesample_amqp/windows/readme.md
+++ b/serializer/samples/simplesample_amqp/windows/readme.md
@@ -1,3 +1,3 @@
 # To build the simplesample_amqp sample
 
-Follow the instructions [here](https://github.com/Azure/azure-iot-sdks/blob/master/c/doc/devbox_setup.md).
+Follow the instructions [here](../../../../doc/devbox_setup.md).

--- a/serializer/samples/temp_sensor_anomaly/windows/readme.md
+++ b/serializer/samples/temp_sensor_anomaly/windows/readme.md
@@ -1,3 +1,3 @@
 # To build the Windows Vending Machine sample
  
-Follow the instructions [here](https://github.com/Azure/azure-iot-sdks/blob/master/c/doc/devbox_setup.md).
+Follow the instructions [here](../../../../doc/devbox_setup.md).


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.


# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
Readme URLs were pointing to the old repository.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Updated the URLs to the new repository using relative paths.