### PR TITLE
Fix compilation errors if build_as_dynamic and use_prov_client are ON

### DIFF
--- a/provisioning_service_client/CMakeLists.txt
+++ b/provisioning_service_client/CMakeLists.txt
@@ -57,7 +57,7 @@ IF(WIN32)
 ENDIF(WIN32)
 
 if (${build_as_dynamic})
-    add_library(provisioning_service_client SHARED ${provisioning_service_client_c_files} ${provisioning_service_client_h_files} ./src/provisioning_service_client.def)
+    add_library(provisioning_service_client SHARED ${provisioning_service_client_c_files} ${provisioning_service_client_h_files} ./src/provisioning_service_client_dll.def)
     linkSharedUtil(provisioning_service_client)
 
 else()


### PR DESCRIPTION
fix #413

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
#413

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 