### PR TITLE
Wrong name for edgeDevicePrivateKey

### DIFF
--- a/tools/CACertificates/ca-certs.ps1
+++ b/tools/CACertificates/ca-certs.ps1
@@ -27,7 +27,7 @@ $intermediate3CAPemFileName = "./Intermediate3.pem"
 $edgePublicCertDir          = "certs"
 $edgePrivateCertDir         = "private"
 $edgeDeviceCertificate      = Join-Path $edgePublicCertDir "new-edge-device.cert.pem"
-$edgeDevicePrivateKey       = Join-Path $edgePrivateCertDir "new-edge-device.cert.pem"
+$edgeDevicePrivateKey       = Join-Path $edgePrivateCertDir "new-edge-device.key.pem"
 $edgeDeviceFullCertChain    = Join-Path $edgePublicCertDir "new-edge-device-full-chain.cert.pem"
 $edgeIotHubOwnerCA          = Join-Path $edgePublicCertDir "azure-iot-test-only.root.ca.cert.pem"
 


### PR DESCRIPTION
In order to map this script to the how-to-create-transparent-gateway from docs.microsoft.com we need to change it accordingly.

How-to guide here: https://docs.microsoft.com/en-us/azure/iot-edge/how-to-create-transparent-gateway

iotedgectl setup --connection-string {device connection string}
     --edge-hostname {gateway hostname, e.g. mygateway.contoso.com}
     --device-ca-cert-file {full path}/certs/new-edge-device.cert.pem
     --device-ca-chain-cert-file {full path}/certs/new-edge-device-full-chain.cert.pem
     --device-ca-private-key-file {full path}/private/new-edge-device.key.pem
     --owner-ca-cert-file {full path}/RootCA.pem

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 