### PR TITLE
Missing variable - script fails on New-CACertsEdgeDevice

### DIFF
--- a/tools/CACertificates/ca-certs.ps1
+++ b/tools/CACertificates/ca-certs.ps1
@@ -1,5 +1,3 @@
-
-$_intermediateCertSubject = "CN=$_intermediateCertCommonName"#
 #  Routines to help *experiment* (not necessarily productize) CA certificates.
 #
 

--- a/tools/CACertificates/ca-certs.ps1
+++ b/tools/CACertificates/ca-certs.ps1
@@ -1,4 +1,5 @@
-#
+
+$_intermediateCertSubject = "CN=$_intermediateCertCommonName"#
 #  Routines to help *experiment* (not necessarily productize) CA certificates.
 #
 
@@ -15,6 +16,7 @@ $errorActionPreference    = "stop"
 $_rootCertCommonName      = "Azure IoT CA TestOnly Root CA"
 $_rootCertSubject         = "CN=$_rootCertCommonName"
 $_intermediateCertCommonName = "Azure IoT CA TestOnly Intermediate {0} CA"
+$_intermediateCertSubject = "CN=$_intermediateCertCommonName"
 $_privateKeyPassword      = "1234"
 
 $rootCACerFileName          = "./RootCA.cer"


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Description of the problem

Please add the missing variable, otherwise It will fail when creating New-CACertsEdgeDevice
