### PR TITLE
If client is not connected (connecting times out) mqtt_client_dowork …

### DIFF
--- a/iothub_client/src/iothubtransport_mqtt_common.c
+++ b/iothub_client/src/iothubtransport_mqtt_common.c
@@ -1962,7 +1962,7 @@ static int InitializeConnection(PMQTTTRANSPORT_HANDLE_DATA transport_data)
             {
                 LogError("mqtt_client timed out waiting for CONNACK");
                 DisconnectFromClient(transport_data);
-                result = 0;
+                result = __FAILURE__;
             }
         }
         else if (transport_data->mqttClientStatus == MQTT_CLIENT_STATUS_CONNECTED)


### PR DESCRIPTION
If client is not connected (connecting times out) mqtt_client_dowork should not be called

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [X] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [X] This pull-request is submitted against the `master` branch. 
  - [X] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [X] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)
Connection time out causes Segmentation fault in iothubtransport_mqtt_common module  #446 
# Description of the problem
There is two solution for this problem, but both of them are improvements that helps libraries to meet the existing requirements. Requirement I'm referring to is SRS_IOTHUB_TRANSPORT_MQTT_COMMON_07_030 IoTHubTransport_MQTT_Common_DoWork shall call mqtt_client_dowork everytime it is called if it is connected.
Negation of that would mean, 'if it is not connected, mqtt_client_dowork does not get called'.

Other fix in umqtt library: https://github.com/Azure/azure-umqtt-c/pull/18

# Description of the solution
return `__FAIL__` when connecting fails. 