### PR TITLE
Fix 3 bugs in ca-certs.ps1

### DIFF
--- a/tools/CACertificates/ca-certs.ps1
+++ b/tools/CACertificates/ca-certs.ps1
@@ -282,7 +282,7 @@ function Write-CACertsCertificatesForEdgeDevice([string]$deviceName)
 
     Copy-Item $originalDevicePublicPem $edgeDeviceCertificate
     Copy-Item $originalDevicePrivatePem $edgeDevicePrivateKey
-    Get-Content $rootCAPemFileName, $intermediate1CAPemFileName, $originalDevicePublicPem | Set-Content $edgeDeviceFullCertChain
+    Get-Content $originalDevicePublicPem, $intermediate1CAPemFileName, $rootCAPemFileName | Set-Content $edgeDeviceFullCertChain    
     Copy-Item $rootCAPemFileName $edgeIotHubOwnerCA
     Write-Host "Success"
 }

--- a/tools/CACertificates/ca-certs.ps1
+++ b/tools/CACertificates/ca-certs.ps1
@@ -15,6 +15,7 @@ $errorActionPreference    = "stop"
 $_rootCertCommonName      = "Azure IoT CA TestOnly Root CA"
 $_rootCertSubject         = "CN=$_rootCertCommonName"
 $_intermediateCertCommonName = "Azure IoT CA TestOnly Intermediate {0} CA"
+$_intermediateCertSubject    = "CN=$_intermediateCertCommonName"
 $_privateKeyPassword      = "1234"
 
 $rootCACerFileName          = "./RootCA.cer"
@@ -281,7 +282,7 @@ function Write-CACertsCertificatesForEdgeDevice([string]$deviceName)
 
     Copy-Item $originalDevicePublicPem $edgeDeviceCertificate
     Copy-Item $originalDevicePrivatePem $edgeDevicePrivateKey
-    Get-Content $rootCACerFileName, $intermediate1CAPemFileName, $originalDevicePublicPem | Set-Content $edgeDeviceFullCertChain
+    Get-Content $rootCAPemFileName, $intermediate1CAPemFileName, $originalDevicePublicPem | Set-Content $edgeDeviceFullCertChain
     Copy-Item $rootCAPemFileName $edgeIotHubOwnerCA
     Write-Host "Success"
 }


### PR DESCRIPTION
The file chnages are meant to fix:
- The global variable $_intermediateCertSubject was missing and is used as a default parameter value.
- When generating the full chain .pem file, a wrong filename was being picked for the RootCA. The CER file was used instead of the PEM file.

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 