### PR TITLE
Fix #83: Python 3.6 support when building SDK

### DIFF
--- a/build_all/linux/build.sh
+++ b/build_all/linux/build.sh
@@ -74,7 +74,7 @@ process_args ()
       then
         # save the arg to python version
         build_python="$arg"
-        if [ $build_python != "2.7" ] && [ $build_python != "3.4" ] && [ $build_python != "3.5" ] && [$build_python != "3.6"]
+        if [ $build_python != "2.7" ] && [ $build_python != "3.4" ] && [ $build_python != "3.5" ] && [ $build_python != "3.6" ]
         then
           echo "Supported python versions are 2.7, 3.4 or 3.5 or 3.6"
           exit 1


### PR DESCRIPTION
Fix issue when --build-python 3.6 is specified:

./c/build_all/linux/build.sh: line 77: [3.6: command not found
./c/build_all/linux/build.sh: line 77: [3.6: command not found

Bash conditionals require spaces between the brackets.

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-python/issues/83

# Description of the problem
```
$ cd build_all/linux
$ ./build.sh --build-python 3.6
...
./c/build_all/linux/build.sh: line 77: [3.6: command not found
./c/build_all/linux/build.sh: line 77: [3.6: command not found
```

# Description of the solution
Fixed typo in build.sh.