### PR TITLE
Fix ca-certs.ps1

### DIFF
--- a/tools/CACertificates/ca-certs.ps1
+++ b/tools/CACertificates/ca-certs.ps1
@@ -225,7 +225,7 @@ function New-CACertsDevice([string]$deviceName, [string]$signingCertSubject=$_ro
     Write-Host ("Certificate with subject CN={0} has been output to {1}" -f $deviceName, (Join-Path (get-location).path $newDevicePemPublicFileName)) 
 }
 
-function New-CACertsEdgeDevice([string]$deviceName, [string]$signingCertSubject=($_intermediateCertSubject -f "1"))
+function New-CACertsEdgeDevice([string]$deviceName, [string]$signingCertSubject=($_rootCertSubject -f "1"))
 {
     New-CACertsDevice $deviceName $signingCertSubject $true
 }


### PR DESCRIPTION
I hit this bug when following the steps in [Create an IoT Edge device that acts as a transparent gateway - preview](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-create-transparent-gateway#powershell). Turns out it has already been reported by a customer at MicrosoftDocs/azure-docs#5474.

The function `New-CACertsEdgeDevice` was attempting to generate a default value for an argument from an orphaned variable. I updated the arg logic to use the correct variable, and confirmed that the get the certs I expect.