### PR TITLE
Adding cleaner error messages and other minor fixes when using OpenSS…

### DIFF
--- a/tools/CACertificates/openssl_device_intermediate_ca.cnf
+++ b/tools/CACertificates/openssl_device_intermediate_ca.cnf
@@ -5,7 +5,7 @@ default_ca = CA_default
 
 [ CA_default ]
 # Directory and file locations.
-dir               = ${ENV::PWD}
+dir               = .
 certs             = $dir/certs
 crl_dir           = $dir/crl
 new_certs_dir     = $dir/newcerts

--- a/tools/CACertificates/openssl_root_ca.cnf
+++ b/tools/CACertificates/openssl_root_ca.cnf
@@ -5,7 +5,7 @@ default_ca = CA_default
 
 [ CA_default ]
 # Directory and file locations.
-dir               = ${ENV::PWD}
+dir               = .
 certs             = $dir/certs
 crl_dir           = $dir/crl
 new_certs_dir     = $dir/newcerts


### PR DESCRIPTION
…L using VCPKG

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
1) The script error messages were not very clear.
2) When using OpenSSL installed using VCPKG on Windows and using the *.cnf files. ENV:PWD did not work.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
1) Improved error messaging
2) Made the cnf files more "cross plat"
3) Inadvertent dead space cleanup