### PR TITLE
Fix/test potential copy past buffer error.

### DIFF
--- a/provisioning_client/tests/hsm_client_tpm_ut/hsm_client_tpm_ut.c
+++ b/provisioning_client/tests/hsm_client_tpm_ut/hsm_client_tpm_ut.c
@@ -181,6 +181,9 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
         REGISTER_GLOBAL_MOCK_FAIL_RETURN(TSS_Create, TPM_RC_FAILURE);
         REGISTER_GLOBAL_MOCK_RETURN(TSS_GetTpmProperty, 1028);
 
+        REGISTER_GLOBAL_MOCK_RETURN(TPM2B_PUBLIC_Marshal, 1);
+        REGISTER_GLOBAL_MOCK_FAIL_RETURN(TPM2B_PUBLIC_Marshal, 1025);
+
         REGISTER_GLOBAL_MOCK_HOOK(TSS_CreatePersistentKey, my_TSS_CreatePersistentKey);
         REGISTER_GLOBAL_MOCK_FAIL_RETURN(TSS_CreatePersistentKey, 0);
 
@@ -585,17 +588,10 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
         setup_hsm_client_tpm_get_endorsement_key_mocks();
 
         umock_c_negative_tests_snapshot();
-
-        size_t calls_cannot_fail[] = { 0, 2, 4 };
-
         //act
         size_t count = umock_c_negative_tests_call_count();
         for (size_t index = 0; index < count; index++)
         {
-            if (should_skip_index(index, calls_cannot_fail, sizeof(calls_cannot_fail) / sizeof(calls_cannot_fail[0])) != 0)
-            {
-                continue;
-            }
 
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
@@ -603,7 +599,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
             char tmp_msg[64];
             sprintf(tmp_msg, "hsm_client_tpm_get_endorsement_key failure in test %zu/%zu", index, count);
 
-            int result = hsm_client_tpm_get_endorsement_key(NULL, &key, &key_len);
+            int result = hsm_client_tpm_get_endorsement_key(sec_handle, &key, &key_len);
 
             //assert
             ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, tmp_msg);
@@ -693,24 +689,17 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
 
         umock_c_negative_tests_snapshot();
 
-        size_t calls_cannot_fail[] = { 0, 2, 4 };
-
         //act
         size_t count = umock_c_negative_tests_call_count();
         for (size_t index = 0; index < count; index++)
         {
-            if (should_skip_index(index, calls_cannot_fail, sizeof(calls_cannot_fail) / sizeof(calls_cannot_fail[0])) != 0)
-            {
-                continue;
-            }
-
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
 
             char tmp_msg[64];
             sprintf(tmp_msg, "hsm_client_tpm_get_storage_key failure in test %zu/%zu", index, count);
 
-            int result = hsm_client_tpm_get_storage_key(NULL, &key, &key_len);
+            int result = hsm_client_tpm_get_storage_key(sec_handle, &key, &key_len);
 
             //assert
             ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, tmp_msg);


### PR DESCRIPTION

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem

hsm_client_tpm_get_endorsement_key and hsm_client_tpm_get_storage_key were flagged 
during a security audit as a potential copy past a predefined buffer length. Since I blatantly 
copied the code from this repo, I felt I should backport my fixes.

# Description of the solution

Check that we don't copy past the buffer length, then fix the unit tests
so that they work and test this code.