### PR TITLE
Fixes to powershell script for generation of Edge device certificates

### DIFF
--- a/tools/CACertificates/ca-certs.ps1
+++ b/tools/CACertificates/ca-certs.ps1
@@ -218,17 +218,7 @@ function New-CACertsDevice([string]$deviceName, [string]$signingCertSubject=$_ro
         $isASigner = $false
     }
 
-    # Certificates for edge devices need to be able to sign other certs.
-    if ($isEdgeDevice -eq $true)
-    {
-        $isASigner = $true
-    }
-    else
-    {
-        $isASigner = $false
-    }
-
-    $newDeviceCertPfx = New-CACertsSelfSignedCertificate $deviceName $signingCert $false
+    $newDeviceCertPfx = New-CACertsSelfSignedCertificate $deviceName $signingCert $isASigner
 
     $certSecureStringPwd = ConvertTo-SecureString -String $_privateKeyPassword -Force -AsPlainText
 
@@ -256,11 +246,6 @@ function New-CACertsDevice([string]$deviceName, [string]$signingCertSubject=$_ro
     openssl x509 -in $newDevicePemAllFileName -out $newDevicePemPublicFileName
 
     Write-Host ("Certificate with subject CN={0} has been output to {1}" -f $deviceName, (Join-Path (get-location).path $newDevicePemPublicFileName))
-}
-
-function New-CACertsEdgeDevice([string]$deviceName, [string]$signingCertSubject=($_intermediateCertSubject -f "1"))
-{
-    New-CACertsDevice $deviceName $signingCertSubject $true
 }
 
 function New-CACertsEdgeDevice([string]$deviceName, [string]$signingCertSubject=($_intermediateCertSubject -f "1"))


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
Device CA certificates was not marked as a signing certificate.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Ensured that the correct flags get set when creating the Edge device CA certificate and misc cleanups.