### PR TITLE
Appending a CA suffix for Edge device certificates

### DIFF
--- a/tools/CACertificates/certGen.sh
+++ b/tools/CACertificates/certGen.sh
@@ -351,7 +351,13 @@ function generate_edge_device_certificate()
     rm -f ./certs/new-edge-device.cert.pem
     rm -f ./certs/new-edge-device-full-chain.cert.pem
 
-    generate_device_certificate_common "${1}" ${device_prefix} \
+    # Note: Appending a '.ca' to the common name is useful in situations
+    # where a user names their hostname as the edge device name.
+    # By doing so we avoid TLS validation errors where we have a server or
+    # client certificate where the hostname is used as the common name
+    # which essentially results in "loop" for validation purposes.
+    generate_device_certificate_common "${1}.ca" \
+                                       ${device_prefix} \
                                        ${intermediate_ca_dir} \
                                        ${intermediate_ca_password} \
                                        ${openssl_intermediate_config_file} \


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
When generating Edge device CA certificate,  a user could name their hostname as the edge device name. By doing so there is a high probability that a user can run into TLS validation errors when a have a sever or client certificate created where the hostname is used as the common name. This essentially results in "loop" for validation purposes.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Appended a string literal ".ca" to the CN field of the Edge certificate in order to distinguish it from other subsequent leaf certificates.