### PR TITLE
Export protocol functions

### DIFF
--- a/iothub_client/CMakeLists.txt
+++ b/iothub_client/CMakeLists.txt
@@ -378,6 +378,18 @@ if (${build_as_dynamic})
     if(NOT ${dont_use_uploadtoblob})
         set(iothub_def_file ${iothub_def_file} ./src/upload_to_blob.def)
     endif()
+	
+	if(use_amqp)
+		set(iothub_def_file ${iothub_def_file} ./src/iothub_transport_amqp.def)
+	endif()
+	
+	if(use_http)
+		set(iothub_def_file ${iothub_def_file} ./src/iothub_transport_http.def)
+	endif()
+	
+	if(use_mqtt)
+		set(iothub_def_file ${iothub_def_file} ./src/iothub_transport_mqtt.def)
+	endif()
     
     if (${use_edge_modules})
         set(iothub_def_file ${iothub_def_file} ./src/iothub_edge_modules.def)

--- a/iothub_client/src/iothub_client_dll.def
+++ b/iothub_client/src/iothub_client_dll.def
@@ -145,12 +145,6 @@ EXPORTS
     IoTHubMessage_SetInputName
     IoTHubMessage_SetMessageId
     IoTHubMessage_SetProperty
-	
-	AMQP_Protocol
-	AMQP_Protocol_over_WebSocketsTls
-	HTTP_Protocol
-	MQTT_Protocol
-	MQTT_WebSocket_Protocol
 
     IOTHUB_CLIENT_CONFIRMATION_RESULTStrings
     IOTHUB_CLIENT_FILE_UPLOAD_RESULTStrings

--- a/iothub_client/src/iothub_client_dll.def
+++ b/iothub_client/src/iothub_client_dll.def
@@ -145,6 +145,12 @@ EXPORTS
     IoTHubMessage_SetInputName
     IoTHubMessage_SetMessageId
     IoTHubMessage_SetProperty
+	
+	AMQP_Protocol
+	AMQP_Protocol_over_WebSocketsTls
+	HTTP_Protocol
+	MQTT_Protocol
+	MQTT_WebSocket_Protocol
 
     IOTHUB_CLIENT_CONFIRMATION_RESULTStrings
     IOTHUB_CLIENT_FILE_UPLOAD_RESULTStrings

--- a/iothub_client/src/iothub_transport_amqp.def
+++ b/iothub_client/src/iothub_transport_amqp.def
@@ -1,0 +1,4 @@
+LIBRARY iothub_client_dll
+EXPORTS
+	AMQP_Protocol
+	AMQP_Protocol_over_WebSocketsTls

--- a/iothub_client/src/iothub_transport_http.def
+++ b/iothub_client/src/iothub_transport_http.def
@@ -1,0 +1,3 @@
+LIBRARY iothub_client_dll
+EXPORTS
+	HTTP_Protocol

--- a/iothub_client/src/iothub_transport_mqtt.def
+++ b/iothub_client/src/iothub_transport_mqtt.def
@@ -1,0 +1,4 @@
+LIBRARY iothub_client_dll
+EXPORTS
+	MQTT_Protocol
+	MQTT_WebSocket_Protocol


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
Protocol functions are not exported in Windows dll.

# Description of the solution
Added functions to def file.