### PR TITLE
Do not add /WX compile flag for MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,20 +31,20 @@ endif()
 include (CTest)
 
 if (MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /wd4232")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4 /wd4232")
-endif()
-
-if (WIN32)
-    # windows needs this define
-    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /wd4232")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4 /wd4232")
     # Make warning as error
     add_definitions(/WX)
 else()
     # Make warning as error
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
-endif(WIN32)
+endif()
+
+IF(WIN32)
+    # windows needs this define
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+endif()
 
 set(hsm_type_x509 OFF CACHE BOOL "x509 type of hsm used with the Provisioning client")
 set(hsm_type_sastoken OFF CACHE BOOL "tpm type of hsm used with the Provisioning client")


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
Azure IoT SDK does not compile in Windows using MinGW-W64 compiler with the following error:
gcc.exe: error: /WX: No such file or directory

# Description of the solution
Amended CMakeLists.txt to not add /WX to compile flags for MinGW (which follows Unix-style command line options formatting), and instead use -Werror.