### PR TITLE
Allow digits in spec IDs in traceability tool

### DIFF
--- a/tools/traceabilitytool/traceability_tool/reportgenerator.cs
+++ b/tools/traceabilitytool/traceability_tool/reportgenerator.cs
@@ -263,7 +263,7 @@ namespace TraceabilityTool
             string text = body.InnerText;
 
             wordprocessingDocument.Close();
-            string pattern = @"SRS_[A-Z_]+_\d{2}_\d{3}";
+            string pattern = @"SRS_[A-Z_\d]+_\d{2}_\d{3}";
 
             ExtractRequirements(filePath, pattern, text, ref reqLookup);
         }
@@ -274,7 +274,7 @@ namespace TraceabilityTool
             System.IO.StreamReader fileAsStream = new System.IO.StreamReader(filePath);
             string fileAsString = fileAsStream.ReadToEnd();
             fileAsStream.Close();
-            string pattern = @"SRS_[A-Z_]+_\d{2}_\d{3}";
+            string pattern = @"SRS_[A-Z_\d]+_\d{2}_\d{3}";
 
             ExtractRequirements(filePath, pattern, fileAsString, ref reqLookup);
         }
@@ -335,7 +335,7 @@ namespace TraceabilityTool
 
             // Look for requirement references in the format something_SRS_something_123 or SRS_something_123
             // or _something_SRS_something_123 and _SRS_something_123
-            string pattern = @"\b[A-Za-z_]*_?SRS_\w+_\d{2}_\d{3}";
+            string pattern = @"\b[A-Za-z_\d]*_?SRS_\w+_\d{2}_\d{3}";
             int lineNum = 1;  // Start counting lines from 1.
             int pos = 0;      // First character index for a regular expression match is 0.
             foreach (Match m in Regex.Matches(fileAsString, pattern))


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
Traceabilitytool does not allow digits in the spec IDs

# Description of the solution
Added digits to be allowed in the pattern match in traceability tool