### PR TITLE
Fix #587: avoid new GCC 8.2 warning (s/strncpy/memcpy/)

### DIFF
--- a/serializer/src/commanddecoder.c
+++ b/serializer/src/commanddecoder.c
@@ -191,7 +191,7 @@ static EXECUTE_COMMAND_RESULT DecodeAndExecuteModelAction(COMMAND_DECODER_HANDLE
 #ifdef _MSC_VER
 #pragma warning(suppress: 6324) /* We intentionally use here strncpy */ 
 #endif
-        if (strncpy(tempStr, actionName, strLength - 1) == NULL)
+        if (memcpy(tempStr, actionName, strLength - 1) == NULL)
         {
             /* Codes_SRS_COMMAND_DECODER_99_021:[ If the parsing of the command fails for any other reason the command shall not be dispatched.] */
             LogError("Invalid action name.");


### PR DESCRIPTION
GCC 8.2 is not able to determine that the length is OK for dst
and thus moans about the usage of strncpy.

How it is done, memcpy seems more appropriate to be used.

Maybe in the future this code can be even more simplified.

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 