### PR TITLE
Update convenience sample to be used by customers learning from the quickstarts

### DIFF
--- a/iothub_client/readme.md
+++ b/iothub_client/readme.md
@@ -28,7 +28,8 @@ For a list of tested configurations [click here][device-catalog].
 ### apt-get packages for Linux devices
 
 To make it simpler to use the IoT Hub device SDK on Linux, we have created [apt-get packages][apt-get-packages] that are published on the Launchpad platform.
-At this point you can use the packages on Ubuntu 14.04, 15.04, 15.10, 16.04 using the following CPU architectures amd64, arm64, armhf and i386. Currently the packages are not published on Ubuntu 18.04.
+
+At this point you can use the packages on Ubuntu 16.04 and 18.04 using the following CPU architectures: amd64, arm64, armhf and i386.
 
 [Here][apt-get-instructions] you can find a detailed guide on how to install the packages to develop your device application.
 

--- a/iothub_client/samples/iothub_convenience_sample/iothub_convenience_sample.c
+++ b/iothub_client/samples/iothub_convenience_sample/iothub_convenience_sample.c
@@ -7,6 +7,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "iothub.h"
 #include "iothub_device_client.h"
@@ -52,6 +53,7 @@ static const char* connectionString = "[device connection string]";
 
 #define MESSAGE_COUNT        5
 static bool g_continueRunning = true;
+int g_interval = 10000;  // 10 sec send interval initially
 static size_t g_message_count_send_confirmations = 0;
 
 static const char* proxy_host = NULL;    // "Web proxy name here"
@@ -106,6 +108,60 @@ static IOTHUBMESSAGE_DISPOSITION_RESULT receive_msg_callback(IOTHUB_MESSAGE_HAND
     return IOTHUBMESSAGE_ACCEPTED;
 }
 
+
+static int device_method_callback(const char* method_name, const unsigned char* payload, size_t size, unsigned char** response, size_t* resp_size, void* userContextCallback)
+{
+    const char* SetTelemetryIntervalMethod = "SetTelemetryInterval";
+    const char* device_id = (const char*)userContextCallback;
+    char* end = NULL;
+    int newInterval;
+
+    int status = 501;
+    const char* RESPONSE_STRING = "{ \"Response\": \"Unknown method requested.\" }";
+
+    (void)printf("\r\nDevice Method called for device %s\r\n", device_id);
+    (void)printf("Device Method name:    %s\r\n", method_name);
+    (void)printf("Device Method payload: %.*s\r\n", (int)size, (const char*)payload);
+
+    if (strcmp(method_name, SetTelemetryIntervalMethod) == 0)
+    {
+        if (payload)
+        {
+            newInterval = (int)strtol((char*)payload, &end, 10);
+
+            // Interval must be greater than zero.
+            if (newInterval > 0)
+            {
+                // expect sec and covert to ms
+                g_interval = 1000 * (int)strtol((char*)payload, &end, 10);
+                status = 200;
+                RESPONSE_STRING = "{ \"Response\": \"Telemetry reporting interval updated.\" }";
+            }
+            else
+            {
+                status = 500;
+                RESPONSE_STRING = "{ \"Response\": \"Invalid telemetry reporting interval.\" }";
+            }
+        }
+    }
+
+    (void)printf("\r\nResponse status: %d\r\n", status);
+    (void)printf("Response payload: %s\r\n\r\n", RESPONSE_STRING);
+
+    *resp_size = strlen(RESPONSE_STRING);
+    if ((*response = malloc(*resp_size)) == NULL)
+    {
+        status = -1;
+    }
+    else
+    {
+        memcpy(*response, RESPONSE_STRING, *resp_size);
+    }
+	
+    return status;
+}
+
+
 static void connection_status_callback(IOTHUB_CLIENT_CONNECTION_STATUS result, IOTHUB_CLIENT_CONNECTION_STATUS_REASON reason, void* user_context)
 {
     (void)reason;
@@ -129,13 +185,20 @@ static void send_confirm_callback(IOTHUB_CLIENT_CONFIRMATION_RESULT result, void
     (void)printf("Confirmation callback received for message %zu with result %s\r\n", g_message_count_send_confirmations, ENUM_TO_STRING(IOTHUB_CLIENT_CONFIRMATION_RESULT, result));
 }
 
+
 int main(void)
 {
     IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol;
-    IOTHUB_MESSAGE_HANDLE message_handle;
-    const char* telemetry_msg = "test_message";
 
-    printf("This sample will send %d messages and wait for any C2D messages.\r\nPress the enter key to end the sample\r\n\r\n", MESSAGE_COUNT);
+    IOTHUB_MESSAGE_HANDLE message_handle;
+    float telemetry_temperature;
+    float telemetry_humidity;
+    const char* telemetry_scale = "Celcius";
+    char telemetry_msg_buffer[80];
+
+    int messagecount = 0;
+
+    printf("\r\nThis sample will send messages continuously and accept C2D messages.\r\nPress Ctrl+C to terminate the sample.\r\n\r\n");
 
     // Select the Protocol to use with the connection
 #ifdef SAMPLE_MQTT
@@ -170,6 +233,9 @@ int main(void)
     {
         // Setting message callback to get C2D messages
         (void)IoTHubDeviceClient_SetMessageCallback(device_handle, receive_msg_callback, NULL);
+        // Setting method callback to handle a SetTelemetryInterval method to control
+        //   how often telemetry messages are sent from the simulated device.
+        (void)IoTHubDeviceClient_SetDeviceMethodCallback(device_handle, device_method_callback, NULL);
         // Setting connection status callback to get indication of connection to iothub
         (void)IoTHubDeviceClient_SetConnectionStatusCallback(device_handle, connection_status_callback, NULL);
 
@@ -205,13 +271,18 @@ int main(void)
             {
                 (void)printf("failure to set proxy\n");
             }
-        }
+        }		
 
-        for (size_t index = 0; index < MESSAGE_COUNT; index++)
+        while(g_continueRunning)
         {
-            // Construct the iothub message from a string or a byte array
-            message_handle = IoTHubMessage_CreateFromString(telemetry_msg);
-            //message_handle = IoTHubMessage_CreateFromByteArray((const unsigned char*)telemetry_msg, strlen(telemetry_msg)));
+            // Construct the iothub message
+            telemetry_temperature = 20.0f + ((float)rand() / RAND_MAX) * 15.0f;
+            telemetry_humidity = 60.0f + ((float)rand() / RAND_MAX) * 20.0f;
+
+            sprintf(telemetry_msg_buffer, "{\"temperature\":%.3f,\"humidity\":%.3f,\"scale\":\"%s\"}", 
+                telemetry_temperature, telemetry_humidity, telemetry_scale);
+
+            message_handle = IoTHubMessage_CreateFromString(telemetry_msg_buffer);
 
             // Set Message property
             (void)IoTHubMessage_SetMessageId(message_handle, "MSG_ID");
@@ -222,15 +293,15 @@ int main(void)
             // Add custom properties to message
             (void)IoTHubMessage_SetProperty(message_handle, "property_key", "property_value");
 
-            (void)printf("Sending message %d to IoTHub\r\n", (int)(index + 1));
+            (void)printf("\r\nSending message %d to IoTHub\r\nMessage: %s\r\n", (int)(messagecount + 1), telemetry_msg_buffer);
             IoTHubDeviceClient_SendEventAsync(device_handle, message_handle, send_confirm_callback, NULL);
 
             // The message is copied to the sdk so the we can destroy it
             IoTHubMessage_Destroy(message_handle);
-        }
+            messagecount = messagecount + 1;
 
-        printf("\r\nPress any key to continue\r\n");
-        getchar();
+            ThreadAPI_Sleep(g_interval);
+        }
 
         // Clean up the iothub sdk handle
         IoTHubDeviceClient_Destroy(device_handle);


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

@yzhong94 

This PR updates the convenience IoTHub_Client sample to provide customers with a sample that support the new [Quickstart: Send telemetry (C)](https://review.docs.microsoft.com/en-us/azure/iot-hub/quickstart-send-telemetry-c?branch=pr-en-us-50085). This quickstart is written in line with the following existing quickstarts:

* [Quickstart: Send telemetry (Node.js)](https://docs.microsoft.com/en-us/azure/iot-hub/quickstart-send-telemetry-node)
* [Quickstart: Send telemetry (.NET)](https://docs.microsoft.com/en-us/azure/iot-hub/quickstart-send-telemetry-dotnet)
* [Quickstart: Send telemetry (Java)](https://docs.microsoft.com/en-us/azure/iot-hub/quickstart-send-telemetry-java)
* [Quickstart: Send telemetry (Python)](https://docs.microsoft.com/en-us/azure/iot-hub/quickstart-send-telemetry-python)
* [Quickstart: Send telemetry (iOS)](https://docs.microsoft.com/en-us/azure/iot-hub/quickstart-send-telemetry-ios)

The sample reports temperature and humidity continuously based on the interval. That interval is configurable using the device method `SetTelemetryInterval`. By having parity with the other quickstarts, customers who are working with multiple languages and platforms should benefit from the consistency.








# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 