### PR TITLE
Enable sas access to module creation

### DIFF
--- a/iothub_client/src/iothub_client_ll_uploadtoblob.c
+++ b/iothub_client/src/iothub_client_ll_uploadtoblob.c
@@ -388,7 +388,7 @@ static int IoTHubClient_LL_UploadToBlob_step1and2(IOTHUB_CLIENT_LL_UPLOADTOBLOB_
                                             else
                                             {
                                                 /*Codes_SRS_IOTHUBCLIENT_LL_02_089: [ If creating the HTTPAPIEX_SAS_HANDLE fails then IoTHubClient_LL_UploadMultipleBlocksToBlob(Ex) shall fail and return IOTHUB_CLIENT_ERROR. ]*/
-                                                HTTPAPIEX_SAS_HANDLE sasHandle = HTTPAPIEX_SAS_Create(handleData->credentials.deviceKey, uriResource, empty);
+                                                HTTPAPIEX_SAS_HANDLE sasHandle = HTTPAPIEX_SAS_Create(handleData->credentials.deviceKey, NULL, uriResource, empty);
                                                 if (sasHandle == NULL)
                                                 {
                                                     LogError("unable to HTTPAPIEX_SAS_Create");
@@ -693,7 +693,7 @@ static int IoTHubClient_LL_UploadToBlob_step3(IOTHUB_CLIENT_LL_UPLOADTOBLOB_HAND
                         }
                         else
                         {
-                            HTTPAPIEX_SAS_HANDLE sasHandle = HTTPAPIEX_SAS_Create(handleData->credentials.deviceKey, uriResource, empty);
+                            HTTPAPIEX_SAS_HANDLE sasHandle = HTTPAPIEX_SAS_Create(handleData->credentials.deviceKey, NULL, uriResource, empty);
                             if (sasHandle == NULL)
                             {
                                 LogError("unable to HTTPAPIEX_SAS_Create");

--- a/iothub_client/src/iothubtransporthttp.c
+++ b/iothub_client/src/iothubtransporthttp.c
@@ -372,7 +372,7 @@ static bool create_deviceSASObject(HTTPTRANSPORT_PERDEVICE_DATA* handleData, STR
                     {
                         /*Codes_SRS_TRANSPORTMULTITHTTP_17_036: [IoTHubTransportHttp_Create shall invoke HTTPAPIEX_SAS_Create with arguments key, uriResource, and zero length keyName.]*/
                         /*Codes_SRS_TRANSPORTMULTITHTTP_17_037: [If the HTTPAPIEX_SAS_Create fails then IoTHubTransportHttp_Create shall fail and return NULL.]*/
-                        handleData->sasObject = HTTPAPIEX_SAS_Create(key, uriResource, keyName);
+                        handleData->sasObject = HTTPAPIEX_SAS_Create(key, NULL, uriResource, keyName);
                         result = (handleData->sasObject != NULL) ? (true) : (false);
                     }
                     STRING_delete(key);

--- a/iothub_client/tests/iothubclient_ll_u2b_ut/iothub_client_ll_u2b_ut.c
+++ b/iothub_client/tests/iothubclient_ll_u2b_ut/iothub_client_ll_u2b_ut.c
@@ -139,9 +139,10 @@ static void my_HTTPAPIEX_Destroy(HTTPAPIEX_HANDLE handle)
     free(handle);
 }
 
-static HTTPAPIEX_SAS_HANDLE my_HTTPAPIEX_SAS_Create(STRING_HANDLE key, STRING_HANDLE uriResource, STRING_HANDLE keyName)
+static HTTPAPIEX_SAS_HANDLE my_HTTPAPIEX_SAS_Create(STRING_HANDLE key, STRING_HANDLE signature, STRING_HANDLE uriResource, STRING_HANDLE keyName)
 {
     (void)key;
+    (void)signature;
     (void)uriResource;
     (void)keyName;
     return (HTTPAPIEX_SAS_HANDLE)malloc(1);
@@ -3118,7 +3119,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadMultipleBlocksToBlob_deviceKey_happypath)
             .IgnoreArgument_s2();
         STRICT_EXPECTED_CALL(STRING_new());/*this is needed for HTTPAPIEX_SAS_Create -it needs an empty STRING_HANDLE*/
 
-        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
             .IgnoreAllArguments();
         STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG))
             .IgnoreArgument_handle();
@@ -3314,7 +3315,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadMultipleBlocksToBlob_deviceKey_happypath)
             .IgnoreArgument(1);
 
         STRICT_EXPECTED_CALL(STRING_new());
-        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
             .IgnoreAllArguments();
         STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG))
             .IgnoreArgument_handle();
@@ -3472,8 +3473,8 @@ TEST_FUNCTION(IoTHubClient_LL_UploadMultipleBlocksToBlob_deviceKey_with_timeout_
         .IgnoreArgument_s1()
         .IgnoreArgument_s2();
         STRICT_EXPECTED_CALL(STRING_new());/*this is needed for HTTPAPIEX_SAS_Create -it needs an empty STRING_HANDLE*/
-
-        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        
+        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .IgnoreAllArguments();
         STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG))
         .IgnoreArgument_handle();
@@ -3669,7 +3670,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadMultipleBlocksToBlob_deviceKey_with_timeout_
         .IgnoreArgument(1);
 
         STRICT_EXPECTED_CALL(STRING_new());
-        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .IgnoreAllArguments();
         STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG))
         .IgnoreArgument_handle();
@@ -3817,7 +3818,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_deviceKey_when_step1_httpStatusCode_i
             .IgnoreArgument_s2();
         STRICT_EXPECTED_CALL(STRING_new());/*this is needed for HTTPAPIEX_SAS_Create -it needs an empty STRING_HANDLE*/
 
-        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
             .IgnoreAllArguments();
         STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG))
             .IgnoreArgument_handle();
@@ -3961,7 +3962,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_deviceKey_when_step3_httpStatusCode_i
             .IgnoreArgument_s2();
         STRICT_EXPECTED_CALL(STRING_new());/*this is needed for HTTPAPIEX_SAS_Create -it needs an empty STRING_HANDLE*/
 
-        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
             .IgnoreAllArguments();
         STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG))
             .IgnoreArgument_handle();
@@ -4157,7 +4158,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_deviceKey_when_step3_httpStatusCode_i
             .IgnoreArgument(1);
 
         STRICT_EXPECTED_CALL(STRING_new());
-        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
             .IgnoreAllArguments();
         STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG))
             .IgnoreArgument_handle();
@@ -4312,7 +4313,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadMultipleBlocksToBlob_deviceKey_unhappypaths)
             .IgnoreArgument_s2();
         STRICT_EXPECTED_CALL(STRING_new());/*this is needed for HTTPAPIEX_SAS_Create -it needs an empty STRING_HANDLE*/
 
-        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
             .IgnoreAllArguments();
         STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG))
             .IgnoreArgument_handle();
@@ -4508,7 +4509,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadMultipleBlocksToBlob_deviceKey_unhappypaths)
             .IgnoreArgument(1);
 
         STRICT_EXPECTED_CALL(STRING_new());
-        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
             .IgnoreAllArguments();
         STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG))
             .IgnoreArgument_handle();

--- a/iothub_client/tests/iothubtransporthttp_ut/iothubtransporthttp_ut.c
+++ b/iothub_client/tests/iothubtransporthttp_ut/iothubtransporthttp_ut.c
@@ -549,9 +549,10 @@ static void my_HTTPHeaders_Free(HTTP_HEADERS_HANDLE httpHeadersHandle)
     my_gballoc_free(httpHeadersHandle);
 }
 
-static HTTPAPIEX_SAS_HANDLE my_HTTPAPIEX_SAS_Create(STRING_HANDLE key, STRING_HANDLE uriResource, STRING_HANDLE keyName)
+static HTTPAPIEX_SAS_HANDLE my_HTTPAPIEX_SAS_Create(STRING_HANDLE key, STRING_HANDLE signature, STRING_HANDLE uriResource, STRING_HANDLE keyName)
 {
     (void)key;
+    (void)signature;
     (void)uriResource;
     (void)keyName;
     return (HTTPAPIEX_SAS_HANDLE)my_gballoc_malloc(1);
@@ -1040,7 +1041,7 @@ static void setupRegisterHappyPathsasObject(bool deallocateCreated, bool is_x509
         STRICT_EXPECTED_CALL(STRING_concat_with_STRING(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
         STRICT_EXPECTED_CALL(STRING_construct(TEST_DEVICE_KEY));
         STRICT_EXPECTED_CALL(STRING_empty(IGNORED_PTR_ARG));
-        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
         if (deallocateCreated)
         {
             STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Destroy(IGNORED_PTR_ARG));

--- a/iothub_service_client/devdoc/requirement_docs/iothubserviceclient_auth_requirements.md
+++ b/iothub_service_client/devdoc/requirement_docs/iothubserviceclient_auth_requirements.md
@@ -18,6 +18,7 @@ typedef struct IOTHUB_SERVICE_CLIENT_AUTH_TAG
     const char* iothubName;
     const char* iothubSuffix;
     const char* sharedAccessKey;
+    const char* sharedAccessSignature;
     const char* keyName;
 } IOTHUB_SERVICE_CLIENT_AUTH;
 
@@ -42,7 +43,7 @@ extern IOTHUB_SERVICE_CLIENT_AUTH_HANDLE IoTHubServiceClientAuth_CreateFromConne
 
 **SRS_IOTHUBSERVICECLIENT_12_010: [** If the STRING_construct fails, IoTHubServiceClientAuth_CreateFromConnectionString shall do clean up and return NULL. **]**
 
-**SRS_IOTHUBSERVICECLIENT_12_004: [** IoTHubServiceClientAuth_CreateFromConnectionString shall populate hostName, iotHubName, iotHubSuffix, sharedAccessKeyName, sharedAccessKeyValue from the given connection string by calling connectionstringparser_parse **]**
+**SRS_IOTHUBSERVICECLIENT_12_004: [** IoTHubServiceClientAuth_CreateFromConnectionString shall populate hostName, iotHubName, iotHubSuffix, sharedAccessKeyName, sharedAccessKeyValue, sharedAccessSignature from the given connection string by calling connectionstringparser_parse **]**
 
 **SRS_IOTHUBSERVICECLIENT_12_005: [** If populating the IOTHUB_SERVICE_CLIENT_AUTH fails, IoTHubServiceClientAuth_CreateFromConnectionString shall do clean up and return NULL **]**
 
@@ -50,7 +51,7 @@ extern IOTHUB_SERVICE_CLIENT_AUTH_HANDLE IoTHubServiceClientAuth_CreateFromConne
 
 **SRS_IOTHUBSERVICECLIENT_12_012: [** If the populating SharedAccessKeyName fails, IoTHubServiceClientAuth_CreateFromConnectionString shall do clean up and return NULL. **]**
 
-**SRS_IOTHUBSERVICECLIENT_12_013: [** If the populating SharedAccessKey fails, IoTHubServiceClientAuth_CreateFromConnectionString shall do clean up and return NULL. **]**
+**SRS_IOTHUBSERVICECLIENT_12_013: [** If the populating SharedAccessKey or SharedAccessSignature fails, IoTHubServiceClientAuth_CreateFromConnectionString shall do clean up and return NULL. **]**
 
 **SRS_IOTHUBSERVICECLIENT_12_038: [** IoTHubServiceClientAuth_CreateFromConnectionString shall create a STRING_handle from hostName by calling STRING_construct. **]**
 
@@ -105,6 +106,10 @@ extern IOTHUB_SERVICE_CLIENT_AUTH_HANDLE IoTHubServiceClientAuth_CreateFromConne
 **SRS_IOTHUBSERVICECLIENT_12_033: [** If the mallocAndStrcpy_s fails, IoTHubServiceClientAuth_CreateFromConnectionString shall do clean up and return NULL. **]**
 
 **SRS_IOTHUBSERVICECLIENT_12_006: [** If the IOTHUB_SERVICE_CLIENT_AUTH has been populated IoTHubServiceClientAuth_CreateFromConnectionString shall do clean up and return with a IOTHUB_SERVICE_CLIENT_AUTH_HANDLE to it **]**
+
+**SRS_IOTHUBSERVICECLIENT_12_040: [** IoTHubServiceClientAuth_CreateFromConnectionString shall allocate memory and copy sharedAccessSignature to result->sharedAccessSignature by calling mallocAndStrcpy_s. **]**
+
+**SRS_IOTHUBSERVICECLIENT_12_041: [** If the mallocAndStrcpy_s fails, IoTHubServiceClientAuth_CreateFromConnectionString shall do clean up and return NULL. **]**
 
 
 ## IoTHubServiceClient_Destroy

--- a/iothub_service_client/devdoc/requirement_docs/iothubserviceclient_registrymanager_requirements.md
+++ b/iothub_service_client/devdoc/requirement_docs/iothubserviceclient_registrymanager_requirements.md
@@ -97,6 +97,7 @@ typedef struct IOTHUB_REGISTRYMANAGER_TAG
     char* iothubName;
     char* iothubSuffix;
     char* sharedAccessKey;
+    char* sharedAccessSignature;
     char* keyName;
 } IOTHUB_REGISTRYMANAGER;
 
@@ -146,6 +147,8 @@ extern IOTHUB_REGISTRYMANAGER_HANDLE IoTHubRegistryManager_Create(IOTHUB_REGISTR
 **SRS_IOTHUBREGISTRYMANAGER_12_093: [** IoTHubRegistryManager_Create shall allocate memory and copy keyName to result->keyName by calling mallocAndStrcpy_s. **]**
 
 **SRS_IOTHUBREGISTRYMANAGER_12_094: [** If the mallocAndStrcpy_s fails, IoTHubRegistryManager_Create shall do clean up and return NULL. **]**
+
+**SRS_IOTHUBREGISTRYMANAGER_12_095: [** IoTHubRegistryManager_Create shall allocate memory and copy sharedAccessSignature to result->sharedAccessSignature by calling mallocAndStrcpy_s. **]**
 
 
 ## IoTHubRegistryManager_Destroy

--- a/iothub_service_client/inc/iothub_registrymanager.h
+++ b/iothub_service_client/inc/iothub_registrymanager.h
@@ -173,6 +173,7 @@ typedef struct IOTHUB_REGISTRYMANAGER_TAG
     char* iothubName;
     char* iothubSuffix;
     char* sharedAccessKey;
+    char* sharedAccessSignature;
     char* keyName;
     char* deviceId;
 } IOTHUB_REGISTRYMANAGER;

--- a/iothub_service_client/inc/iothub_service_client_auth.h
+++ b/iothub_service_client/inc/iothub_service_client_auth.h
@@ -49,6 +49,7 @@ typedef struct IOTHUB_SERVICE_CLIENT_AUTH_TAG
     char* hostname;
     char* iothubName;
     char* iothubSuffix;
+    char* sharedAccessSignature;
     char* sharedAccessKey;
     char* keyName;
     char* deviceId;

--- a/iothub_service_client/src/iothub_devicemethod.c
+++ b/iothub_service_client/src/iothub_devicemethod.c
@@ -280,7 +280,7 @@ static IOTHUB_DEVICE_METHOD_RESULT sendHttpRequestDeviceMethod(IOTHUB_SERVICE_CL
         STRING_delete(uriResource);
         result = IOTHUB_DEVICE_METHOD_ERROR;
     }
-    else if ((httpExApiSasHandle = HTTPAPIEX_SAS_Create(accessKey, uriResource, keyName)) == NULL)
+    else if ((httpExApiSasHandle = HTTPAPIEX_SAS_Create(accessKey, NULL, uriResource, keyName)) == NULL)
     {
         LogError("HTTPAPIEX_SAS_Create failed");
         HTTPHeaders_Free(httpHeader);

--- a/iothub_service_client/src/iothub_devicetwin.c
+++ b/iothub_service_client/src/iothub_devicetwin.c
@@ -199,7 +199,7 @@ static IOTHUB_DEVICE_TWIN_RESULT sendHttpRequestTwin(IOTHUB_SERVICE_CLIENT_DEVIC
         result = IOTHUB_DEVICE_TWIN_ERROR;
     }
     /*Codes_SRS_IOTHUBDEVICETWIN_12_021: [ IoTHubDeviceTwin_GetTwin shall create an HTTPAPIEX_SAS_HANDLE handle by calling HTTPAPIEX_SAS_Create ]*/
-    else if ((httpExApiSasHandle = HTTPAPIEX_SAS_Create(accessKey, uriResource, keyName)) == NULL)
+    else if ((httpExApiSasHandle = HTTPAPIEX_SAS_Create(accessKey, NULL, uriResource, keyName)) == NULL)
     {
         /*Codes_SRS_IOTHUBDEVICETWIN_12_025: [ If any of the HTTPAPI call fails IoTHubDeviceTwin_GetTwin shall fail and return IOTHUB_DEVICE_TWIN_HTTPAPI_ERROR ]*/
         LogError("HTTPAPIEX_SAS_Create failed");

--- a/iothub_service_client/tests/iothub_deviceconfiguration_ut/iothub_deviceconfiguration_ut.c
+++ b/iothub_service_client/tests/iothub_deviceconfiguration_ut/iothub_deviceconfiguration_ut.c
@@ -167,9 +167,10 @@ void my_HTTPAPIEX_Destroy(HTTPAPIEX_HANDLE handle)
     my_gballoc_free(handle);
 }
 
-HTTPAPIEX_SAS_HANDLE my_HTTPAPIEX_SAS_Create(STRING_HANDLE key, STRING_HANDLE uriResource, STRING_HANDLE keyName)
+HTTPAPIEX_SAS_HANDLE my_HTTPAPIEX_SAS_Create(STRING_HANDLE key, STRING_HANDLE signature, STRING_HANDLE uriResource, STRING_HANDLE keyName)
 {
     (void)key;
+    (void)signature;
     (void)uriResource;
     (void)keyName;
     return (HTTPAPIEX_SAS_HANDLE)my_gballoc_malloc(1);
@@ -200,6 +201,7 @@ typedef struct IOTHUB_SERVICE_CLIENT_DEVICE_CONFIGURATION_TAG
 {
     char* hostname;
     char* sharedAccessKey;
+    char* sharedAccessSignature;
     char* keyName;
 } IOTHUB_SERVICE_CLIENT_DEVICE_CONFIGURATION;
 
@@ -233,6 +235,7 @@ static char* TEST_HOSTNAME = "theHostName";
 static char* TEST_IOTHUBNAME = "theIotHubName";
 static char* TEST_IOTHUBSUFFIX = "theIotHubSuffix";
 static char* TEST_SHAREDACCESSKEY = "theSharedAccessKey";
+static char* TEST_SHAREDACCESSSIGNATURE = "theSharedAccessSignature";
 static char* TEST_SHAREDACCESSKEYNAME = "theSharedAccessKeyName";
 
 static const HTTP_HEADERS_HANDLE TEST_HTTP_HEADERS_HANDLE = (HTTP_HEADERS_HANDLE)0x4545;
@@ -614,6 +617,7 @@ TEST_FUNCTION_INITIALIZE(TestMethodInitialize)
     TEST_IOTHUB_SERVICE_CLIENT_AUTH.iothubName = TEST_IOTHUBNAME;
     TEST_IOTHUB_SERVICE_CLIENT_AUTH.iothubSuffix = TEST_IOTHUBSUFFIX;
     TEST_IOTHUB_SERVICE_CLIENT_AUTH.sharedAccessKey = TEST_SHAREDACCESSKEY;
+    TEST_IOTHUB_SERVICE_CLIENT_AUTH.sharedAccessSignature = NULL;
     TEST_IOTHUB_SERVICE_CLIENT_AUTH.keyName = TEST_SHAREDACCESSKEYNAME;
 }
 
@@ -708,6 +712,7 @@ TEST_FUNCTION(IoTHubDeviceConfiguration_Create_return_null_if_input_parameter_se
 /*Tests_SRS_IOTHUBDEVICECONFIGURATION_38_008: [ IoTHubDeviceConfiguration_Create shall allocate memory and copy iothubName to result->iothubName by calling mallocAndStrcpy_s. ]*/
 /*Tests_SRS_IOTHUBDEVICECONFIGURATION_38_010: [ IoTHubDeviceConfiguration_Create shall allocate memory and copy iothubSuffix to result->iothubSuffix by calling mallocAndStrcpy_s. ]*/
 /*Tests_SRS_IOTHUBDEVICECONFIGURATION_38_012: [ IoTHubDeviceConfiguration_Create shall allocate memory and copy sharedAccessKey to result->sharedAccessKey by calling mallocAndStrcpy_s. ]*/
+/*Tests_SRS_IOTHUBDEVICECONFIGURATION_38_012: [ IoTHubDeviceConfiguration_Create shall allocate memory and copy sharedAccessSignature to result->sharedAccessSignature by calling mallocAndStrcpy_s. ]*/
 /*Tests_SRS_IOTHUBDEVICECONFIGURATION_38_014: [ IoTHubDeviceConfiguration_Create shall allocate memory and copy keyName to `result->keyName` by calling mallocAndStrcpy_s. ]*/
 TEST_FUNCTION(IoTHubDeviceConfiguration_Create_happy_path)
 {
@@ -734,6 +739,7 @@ TEST_FUNCTION(IoTHubDeviceConfiguration_Create_happy_path)
         free(result->hostname);
         free(result->keyName);
         free(result->sharedAccessKey);
+        free(result->sharedAccessSignature);
         free(result);
         result = NULL;
     }
@@ -911,7 +917,7 @@ static void set_expected_calls_for_sendHttpRequestDeviceConfiguration(const unsi
 
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
-    EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+    EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .IgnoreAllArguments();
     EXPECTED_CALL(HTTPAPIEX_Create(TEST_HOSTNAME));
 

--- a/iothub_service_client/tests/iothub_devicemethod_ut/iothub_devicemethod_ut.c
+++ b/iothub_service_client/tests/iothub_devicemethod_ut/iothub_devicemethod_ut.c
@@ -162,9 +162,10 @@ void my_HTTPAPIEX_Destroy(HTTPAPIEX_HANDLE handle)
     my_gballoc_free(handle);
 }
 
-HTTPAPIEX_SAS_HANDLE my_HTTPAPIEX_SAS_Create(STRING_HANDLE key, STRING_HANDLE uriResource, STRING_HANDLE keyName)
+HTTPAPIEX_SAS_HANDLE my_HTTPAPIEX_SAS_Create(STRING_HANDLE key, STRING_HANDLE signature, STRING_HANDLE uriResource, STRING_HANDLE keyName)
 {
     (void)key;
+    (void)signature;
     (void)uriResource;
     (void)keyName;
     return (HTTPAPIEX_SAS_HANDLE)my_gballoc_malloc(1);
@@ -932,7 +933,7 @@ static void IoTHubDeviceMethod_InvokeDeviceOrModule_happy_path_impl(bool testing
 
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
-    EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+    EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .IgnoreAllArguments();
     EXPECTED_CALL(HTTPAPIEX_Create(TEST_HOSTNAME));
 
@@ -1067,7 +1068,7 @@ static void IoTHubDeviceMethod_Invoke_happy_path_http_return_not_equal_200_impl(
 
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
-    EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+    EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .IgnoreAllArguments();
     EXPECTED_CALL(HTTPAPIEX_Create(TEST_HOSTNAME));
 
@@ -1174,7 +1175,7 @@ static void IoTHubDeviceMethod_Invoke_non_happy_path_impl(bool testing_module)
 
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
-    EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+    EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .IgnoreAllArguments();
     EXPECTED_CALL(HTTPAPIEX_Create(TEST_HOSTNAME));
 

--- a/iothub_service_client/tests/iothub_devicetwin_ut/iothub_devicetwin_ut.c
+++ b/iothub_service_client/tests/iothub_devicetwin_ut/iothub_devicetwin_ut.c
@@ -129,9 +129,10 @@ void my_HTTPAPIEX_Destroy(HTTPAPIEX_HANDLE handle)
     my_gballoc_free(handle);
 }
 
-HTTPAPIEX_SAS_HANDLE my_HTTPAPIEX_SAS_Create(STRING_HANDLE key, STRING_HANDLE uriResource, STRING_HANDLE keyName)
+HTTPAPIEX_SAS_HANDLE my_HTTPAPIEX_SAS_Create(STRING_HANDLE key, STRING_HANDLE signature, STRING_HANDLE uriResource, STRING_HANDLE keyName)
 {
     (void)key;
+    (void)signature;
     (void)uriResource;
     (void)keyName;
     return (HTTPAPIEX_SAS_HANDLE)my_gballoc_malloc(1);
@@ -574,7 +575,7 @@ static void set_expected_calls_for_sendHttpRequestTwin(const unsigned int httpSt
 
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
-    EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+    EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .IgnoreAllArguments();
     EXPECTED_CALL(HTTPAPIEX_Create(TEST_HOSTNAME));
 

--- a/iothub_service_client/tests/iothub_rm_ut/iothub_rm_ut.c
+++ b/iothub_service_client/tests/iothub_rm_ut/iothub_rm_ut.c
@@ -105,9 +105,10 @@ void my_HTTPAPIEX_Destroy(HTTPAPIEX_HANDLE handle)
     free(handle);
 }
 
-HTTPAPIEX_SAS_HANDLE my_HTTPAPIEX_SAS_Create(STRING_HANDLE key, STRING_HANDLE uriResource, STRING_HANDLE keyName)
+HTTPAPIEX_SAS_HANDLE my_HTTPAPIEX_SAS_Create(STRING_HANDLE key, STRING_HANDLE signature, STRING_HANDLE uriResource, STRING_HANDLE keyName)
 {
     (void)key;
+    (void)signature;
     (void)uriResource;
     (void)keyName;
     return (HTTPAPIEX_SAS_HANDLE)malloc(1);
@@ -621,7 +622,7 @@ static void setupHttpMockCalls(bool updateIfMatch, const unsigned int httpStatus
             .IgnoreArgument(1);
     }
 
-    STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+    STRICT_EXPECTED_CALL(HTTPAPIEX_SAS_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .IgnoreAllArguments();
     STRICT_EXPECTED_CALL(HTTPAPIEX_Create(TEST_HOSTNAME));
 
@@ -987,6 +988,7 @@ BEGIN_TEST_SUITE(iothub_registrymanager_ut)
         TEST_IOTHUB_SERVICE_CLIENT_AUTH.iothubSuffix = TEST_IOTHUBSUFFIX;
         TEST_IOTHUB_SERVICE_CLIENT_AUTH.keyName = TEST_SHAREDACCESSKEYNAME;
         TEST_IOTHUB_SERVICE_CLIENT_AUTH.sharedAccessKey = TEST_SHAREDACCESSKEY;
+        TEST_IOTHUB_SERVICE_CLIENT_AUTH.sharedAccessSignature = NULL;
 
         TEST_IOTHUB_REGISTRYMANAGER.hostname = TEST_HOSTNAME;
         TEST_IOTHUB_REGISTRYMANAGER.iothubName = TEST_IOTHUBNAME;
@@ -1261,6 +1263,8 @@ BEGIN_TEST_SUITE(iothub_registrymanager_ut)
 
         umock_c_reset_all_calls();
 
+        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))
+            .IgnoreArgument(1);
         STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))
             .IgnoreArgument(1);
         STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))

--- a/iothub_service_client/tests/iothub_srv_client_auth_ut/iothub_service_client_auth_ut.cpp
+++ b/iothub_service_client/tests/iothub_srv_client_auth_ut/iothub_service_client_auth_ut.cpp
@@ -58,6 +58,9 @@ static STRING_HANDLE TEST_VALUE_STRING_HANDLE = (STRING_HANDLE)0x4646;
 
 static const char* TEST_CHAR_PTR = "TestString";
 static const char* TEST_CONNECTION_STRING = "HostName=aaa.bbb.net;SharedAccessKeyName=xxx;SharedAccessKey=yyy";
+static const char* TEST_CONNECTION_STRING_NO_KEY_OR_SIG = "HostName=aaa.bbb.net;SharedAccessKeyName=xxx";
+static const char* TEST_CONNECTION_STRING_NO_SIG_NO_KEY = "HostName=aaa.bbb.net;SharedAccessKeyName=xxx;SharedAccessSignature=yyy";
+static const char* TEST_CONNECTION_STRING_KEY_AND_SIG = "HostName=aaa.bbb.net;SharedAccessKeyName=xxx;SharedAccessKey=yyy;SharedAccessSignature=zzz";
 static size_t currentmalloc_call;
 static size_t whenShallmalloc_fail;
 
@@ -157,6 +160,8 @@ DECLARE_GLOBAL_MOCK_METHOD_1(CIoTHubServiceClientAuthMocks, , MAP_HANDLE, connec
 static void set_expected_calls_for_free_service_client_auth(CIoTHubServiceClientAuthMocks &mocks)
 {
     (void)mocks;
+    STRICT_EXPECTED_CALL(mocks, gballoc_free(IGNORED_PTR_ARG))
+        .IgnoreArgument(1);
     STRICT_EXPECTED_CALL(mocks, gballoc_free(IGNORED_PTR_ARG))
         .IgnoreArgument(1);
     STRICT_EXPECTED_CALL(mocks, gballoc_free(IGNORED_PTR_ARG))
@@ -324,6 +329,12 @@ TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_do_clean_up_if_
     STRICT_EXPECTED_CALL(mocks, connectionstringparser_parse(TEST_STRING_HANDLE))
         .SetReturn(TEST_MAP_HANDLE);
 
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKey"))
+        .SetReturn(TEST_CONST_CHAR_PTR);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessSignature"))
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKeyName"))
         .SetReturn(TEST_CONST_CHAR_PTR);
 
@@ -366,6 +377,12 @@ TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_do_clean_up_if_
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"DeviceId"))
         .SetReturn(TEST_CONST_CHAR_PTR_NULL);
     
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKey"))
+        .SetReturn(TEST_CONST_CHAR_PTR);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessSignature"))
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
     set_expected_calls_for_free_service_client_auth(mocks);
     set_expected_calls_for_CreateFromConnectionString_cleanup(mocks);
 
@@ -399,12 +416,15 @@ TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_do_clean_up_if_
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"DeviceId"))
         .SetReturn(TEST_CONST_CHAR_PTR_NULL);
     
-    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
-        .SetReturn(TEST_CONST_CHAR_PTR);
-   
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKey"))
         .SetReturn(TEST_CONST_CHAR_PTR_NULL);
 
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessSignature"))
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
+        .SetReturn(TEST_CONST_CHAR_PTR);
+   
     set_expected_calls_for_free_service_client_auth(mocks);
     set_expected_calls_for_CreateFromConnectionString_cleanup(mocks);
 
@@ -438,12 +458,15 @@ TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_do_clean_up_if_
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"DeviceId"))
         .SetReturn(TEST_CONST_CHAR_PTR_NULL);
     
-    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
-        .SetReturn(TEST_CONST_CHAR_PTR);
-   
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKey"))
         .SetReturn(TEST_CONST_CHAR_PTR);
 
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessSignature"))
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
+        .SetReturn(TEST_CONST_CHAR_PTR);
+   
 
     STRICT_EXPECTED_CALL(mocks, STRING_construct(TEST_CONST_CHAR_PTR))
         .SetReturn(TEST_STRING_HANDLE_NULL);
@@ -481,12 +504,15 @@ TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_do_clean_up_if_
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"DeviceId"))
         .SetReturn(TEST_CONST_CHAR_PTR_NULL);
     
-    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
-        .SetReturn(TEST_CONST_CHAR_PTR);
-   
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKey"))
         .SetReturn(TEST_CONST_CHAR_PTR);
 
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessSignature"))
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
+        .SetReturn(TEST_CONST_CHAR_PTR);
+   
     STRICT_EXPECTED_CALL(mocks, STRING_construct(TEST_CONST_CHAR_PTR));
 
     STRICT_EXPECTED_CALL(mocks, STRING_TOKENIZER_create(TEST_STRING_HANDLE))
@@ -525,12 +551,15 @@ TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_do_clean_up_if_
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"DeviceId"))
         .SetReturn(TEST_CONST_CHAR_PTR_NULL);
     
-    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
-        .SetReturn(TEST_CONST_CHAR_PTR);
-   
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKey"))
         .SetReturn(TEST_CONST_CHAR_PTR);
 
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessSignature"))
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
+        .SetReturn(TEST_CONST_CHAR_PTR);
+   
     STRICT_EXPECTED_CALL(mocks, STRING_construct(TEST_CONST_CHAR_PTR));
 
     STRICT_EXPECTED_CALL(mocks, STRING_TOKENIZER_create(TEST_STRING_HANDLE))
@@ -572,12 +601,15 @@ TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_do_clean_up_if_
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"DeviceId"))
         .SetReturn(TEST_CONST_CHAR_PTR_NULL);
     
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKey"))
+        .SetReturn(TEST_CONST_CHAR_PTR);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessSignature"))
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
         .SetReturn(TEST_CONST_CHAR_PTR);
    
-    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKey"))
-        .SetReturn(TEST_CONST_CHAR_PTR);
-    
     STRICT_EXPECTED_CALL(mocks, STRING_construct(TEST_CONST_CHAR_PTR));
 
     STRICT_EXPECTED_CALL(mocks, STRING_TOKENIZER_create(TEST_STRING_HANDLE))
@@ -622,12 +654,15 @@ TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_do_clean_up_if_
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"DeviceId"))
         .SetReturn(TEST_CONST_CHAR_PTR_NULL);
     
-    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
-        .SetReturn(TEST_CONST_CHAR_PTR);
-   
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKey"))
         .SetReturn(TEST_CONST_CHAR_PTR);
 
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessSignature"))
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
+        .SetReturn(TEST_CONST_CHAR_PTR);
+   
     STRICT_EXPECTED_CALL(mocks, STRING_construct(TEST_CONST_CHAR_PTR));
 
     STRICT_EXPECTED_CALL(mocks, STRING_TOKENIZER_create(TEST_STRING_HANDLE))
@@ -675,12 +710,15 @@ TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_do_clean_up_if_
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"DeviceId"))
         .SetReturn(TEST_CONST_CHAR_PTR_NULL);
     
-    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
-        .SetReturn(TEST_CONST_CHAR_PTR);
-   
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKey"))
         .SetReturn(TEST_CONST_CHAR_PTR);
 
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessSignature"))
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
+        .SetReturn(TEST_CONST_CHAR_PTR);
+   
     STRICT_EXPECTED_CALL(mocks, STRING_construct(TEST_CONST_CHAR_PTR));
 
     STRICT_EXPECTED_CALL(mocks, STRING_TOKENIZER_create(TEST_STRING_HANDLE))
@@ -731,12 +769,15 @@ TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_do_clean_up_if_
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"DeviceId"))
         .SetReturn(TEST_CONST_CHAR_PTR_NULL);
     
-    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
-        .SetReturn(TEST_CONST_CHAR_PTR);
-   
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKey"))
         .SetReturn(TEST_CONST_CHAR_PTR);
 
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessSignature"))
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
+        .SetReturn(TEST_CONST_CHAR_PTR);
+   
     STRICT_EXPECTED_CALL(mocks, STRING_construct(TEST_CONST_CHAR_PTR));
 
     STRICT_EXPECTED_CALL(mocks, STRING_TOKENIZER_create(TEST_STRING_HANDLE))
@@ -790,12 +831,15 @@ TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_do_clean_up_if_
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"DeviceId"))
         .SetReturn(TEST_CONST_CHAR_PTR_NULL);
     
-    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
-        .SetReturn(TEST_CONST_CHAR_PTR);
-   
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKey"))
         .SetReturn(TEST_CONST_CHAR_PTR);
 
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessSignature"))
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
+        .SetReturn(TEST_CONST_CHAR_PTR);
+   
     STRICT_EXPECTED_CALL(mocks, STRING_construct(TEST_CONST_CHAR_PTR));
 
     STRICT_EXPECTED_CALL(mocks, STRING_TOKENIZER_create(TEST_STRING_HANDLE))
@@ -852,12 +896,15 @@ TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_do_clean_up_if_
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"DeviceId"))
         .SetReturn(TEST_CONST_CHAR_PTR_NULL);
     
-    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
-        .SetReturn(TEST_CONST_CHAR_PTR);
-   
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKey"))
         .SetReturn(TEST_CONST_CHAR_PTR);
 
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessSignature"))
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
+        .SetReturn(TEST_CONST_CHAR_PTR);
+   
     STRICT_EXPECTED_CALL(mocks, STRING_construct(TEST_CONST_CHAR_PTR));
 
     STRICT_EXPECTED_CALL(mocks, STRING_TOKENIZER_create(TEST_STRING_HANDLE))
@@ -917,12 +964,15 @@ TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_do_clean_up_if_
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"DeviceId"))
         .SetReturn(TEST_CONST_CHAR_PTR_NULL);
     
-    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
-        .SetReturn(TEST_CONST_CHAR_PTR);
-   
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKey"))
         .SetReturn(TEST_CONST_CHAR_PTR);
 
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessSignature"))
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
+        .SetReturn(TEST_CONST_CHAR_PTR);
+   
     STRICT_EXPECTED_CALL(mocks, STRING_construct(TEST_CONST_CHAR_PTR));
 
     STRICT_EXPECTED_CALL(mocks, STRING_TOKENIZER_create(TEST_STRING_HANDLE))
@@ -991,12 +1041,15 @@ TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_do_clean_up_if_
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"DeviceId"))
         .SetReturn(TEST_CONST_CHAR_PTR_NULL);
     
-    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
-        .SetReturn(TEST_CONST_CHAR_PTR);
-   
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKey"))
         .SetReturn(TEST_CONST_CHAR_PTR);
 
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessSignature"))
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
+        .SetReturn(TEST_CONST_CHAR_PTR);
+   
     STRICT_EXPECTED_CALL(mocks, STRING_construct(TEST_CONST_CHAR_PTR));
 
     STRICT_EXPECTED_CALL(mocks, STRING_TOKENIZER_create(TEST_STRING_HANDLE))
@@ -1068,12 +1121,15 @@ TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_do_clean_up_if_
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"DeviceId"))
         .SetReturn(TEST_CONST_CHAR_PTR_NULL);
     
-    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
-        .SetReturn(TEST_CONST_CHAR_PTR);
-   
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKey"))
         .SetReturn(TEST_CONST_CHAR_PTR);
 
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessSignature"))
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
+        .SetReturn(TEST_CONST_CHAR_PTR);
+   
     STRICT_EXPECTED_CALL(mocks, STRING_construct(TEST_CONST_CHAR_PTR));
 
     STRICT_EXPECTED_CALL(mocks, STRING_TOKENIZER_create(TEST_STRING_HANDLE))
@@ -1136,12 +1192,15 @@ TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_do_clean_up_if_
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"DeviceId"))
         .SetReturn(TEST_CONST_CHAR_PTR_NULL);
     
-    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
-        .SetReturn(TEST_CONST_CHAR_PTR);
-   
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKey"))
         .SetReturn(TEST_CONST_CHAR_PTR);
 
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessSignature"))
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
+        .SetReturn(TEST_CONST_CHAR_PTR);
+   
     STRICT_EXPECTED_CALL(mocks, STRING_construct(TEST_CONST_CHAR_PTR));
 
     STRICT_EXPECTED_CALL(mocks, STRING_TOKENIZER_create(TEST_STRING_HANDLE))
@@ -1206,10 +1265,13 @@ static void test_IoTHubServiceClientAuth_CreateFromConnectionString_impl(bool se
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"DeviceId"))
         .SetReturn(set_deviceid ? TEST_CONST_CHAR_PTR : TEST_CONST_CHAR_PTR_NULL);
     
-    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
-        .SetReturn(TEST_CONST_CHAR_PTR);
-   
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKey"))
+        .SetReturn(TEST_CONST_CHAR_PTR);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessSignature"))
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"HostName"))
         .SetReturn(TEST_CONST_CHAR_PTR);
    
     STRICT_EXPECTED_CALL(mocks, STRING_construct(TEST_CONST_CHAR_PTR));
@@ -1299,6 +1361,12 @@ TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_sharedaccesskey
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"DeviceId"))
         .SetReturn(TEST_CHAR_PTR);
     
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessKey"))
+        .SetReturn(TEST_CHAR_PTR);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(TEST_MAP_HANDLE, (const char*)"SharedAccessSignature"))
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
     set_expected_calls_for_free_service_client_auth(mocks);
     set_expected_calls_for_CreateFromConnectionString_cleanup(mocks);
 
@@ -1345,6 +1413,11 @@ TEST_FUNCTION(IoTHubServiceClient_Destroy_do_clean_up_and_return_if_input_parame
         .IgnoreArgument(1)
         .IgnoreArgument(2)
         .SetReturn(TEST_CONST_CHAR_PTR);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .IgnoreArgument(2)
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
 
     STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .IgnoreArgument(1)
@@ -1416,6 +1489,214 @@ TEST_FUNCTION(IoTHubServiceClient_Destroy_do_clean_up_and_return_if_input_parame
 
     // act
     IOTHUB_SERVICE_CLIENT_AUTH_HANDLE handle = IoTHubServiceClientAuth_CreateFromConnectionString(TEST_CONNECTION_STRING);
+    IoTHubServiceClientAuth_Destroy(handle);
+
+    // assert
+    mocks.AssertActualAndExpectedCalls();
+}
+
+/* Tests_SRS_IOTHUBSERVICECLIENT_12_013: [ If the populating SharedAccessKey or SharedAccessSignature fails, IoTHubServiceClientAuth_CreateFromConnectionString shall do clean up and return NULL **]*/
+TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_return_null_if_input_parameter_connectionString_has_no_key_or_signature)
+{
+    // arrange
+    CIoTHubServiceClientAuthMocks mocks;
+
+    STRICT_EXPECTED_CALL(mocks, gballoc_malloc(IGNORED_NUM_ARG))
+        .IgnoreArgument(1);
+
+    STRICT_EXPECTED_CALL(mocks, STRING_construct(IGNORED_PTR_ARG))
+        .IgnoreArgument(1);
+
+    STRICT_EXPECTED_CALL(mocks, connectionstringparser_parse(IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .SetReturn(TEST_MAP_HANDLE);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .IgnoreArgument(2)
+        .SetReturn(TEST_CONST_CHAR_PTR);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .IgnoreArgument(2)
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .IgnoreArgument(2)
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .IgnoreArgument(2)
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .IgnoreArgument(2)
+        .SetReturn(TEST_CONST_CHAR_PTR);
+
+    set_expected_calls_for_free_service_client_auth(mocks);
+    set_expected_calls_for_CreateFromConnectionString_cleanup(mocks);
+
+    // act
+    IOTHUB_SERVICE_CLIENT_AUTH_HANDLE result = IoTHubServiceClientAuth_CreateFromConnectionString(TEST_CONNECTION_STRING_NO_KEY_OR_SIG);
+
+    // assert
+    ASSERT_IS_NULL(result);
+    mocks.AssertActualAndExpectedCalls();
+}
+
+/* Tests_SRS_IOTHUBSERVICECLIENT_12_013: [ If the populating SharedAccessKey or SharedAccessSignature fails, IoTHubServiceClientAuth_CreateFromConnectionString shall do clean up and return NULL **]*/
+TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_return_null_if_input_parameter_connectionString_has_key_and_signature)
+{
+    // arrange
+    CIoTHubServiceClientAuthMocks mocks;
+
+    STRICT_EXPECTED_CALL(mocks, gballoc_malloc(IGNORED_NUM_ARG))
+        .IgnoreArgument(1);
+
+    STRICT_EXPECTED_CALL(mocks, STRING_construct(IGNORED_PTR_ARG))
+        .IgnoreArgument(1);
+
+    STRICT_EXPECTED_CALL(mocks, connectionstringparser_parse(IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .SetReturn(TEST_MAP_HANDLE);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .IgnoreArgument(2)
+        .SetReturn(TEST_CONST_CHAR_PTR);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .IgnoreArgument(2)
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .IgnoreArgument(2)
+        .SetReturn(TEST_CONST_CHAR_PTR);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .IgnoreArgument(2)
+        .SetReturn(TEST_CONST_CHAR_PTR);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .IgnoreArgument(2)
+        .SetReturn(TEST_CONST_CHAR_PTR);
+
+    set_expected_calls_for_free_service_client_auth(mocks);
+    set_expected_calls_for_CreateFromConnectionString_cleanup(mocks);
+
+    // act
+    IOTHUB_SERVICE_CLIENT_AUTH_HANDLE result = IoTHubServiceClientAuth_CreateFromConnectionString(TEST_CONNECTION_STRING_KEY_AND_SIG);
+
+    // assert
+    ASSERT_IS_NULL(result);
+    mocks.AssertActualAndExpectedCalls();
+}
+
+/* Tests_SRS_IOTHUBSERVICECLIENT_12_013: [ If the populating SharedAccessKey or SharedAccessSignature fails, IoTHubServiceClientAuth_CreateFromConnectionString shall do clean up and return NULL **]*/
+TEST_FUNCTION(IoTHubServiceClientAuth_CreateFromConnectionString_has_signature_no_key_set_succeed)
+{
+    // arrange
+
+    CIoTHubServiceClientAuthMocks mocks;
+
+    whenShallmalloc_fail = 0;
+    STRICT_EXPECTED_CALL(mocks, gballoc_malloc(IGNORED_NUM_ARG))
+        .IgnoreArgument(1);
+
+    STRICT_EXPECTED_CALL(mocks, STRING_construct(IGNORED_PTR_ARG))
+        .IgnoreArgument(1);
+
+    STRICT_EXPECTED_CALL(mocks, connectionstringparser_parse(IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .SetReturn(TEST_MAP_HANDLE);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .IgnoreArgument(2)
+        .SetReturn(TEST_CONST_CHAR_PTR);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .IgnoreArgument(2)
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .IgnoreArgument(2)
+        .SetReturn(TEST_CONST_CHAR_PTR_NULL);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .IgnoreArgument(2)
+        .SetReturn(TEST_CONST_CHAR_PTR);
+
+    STRICT_EXPECTED_CALL(mocks, Map_GetValueFromKey(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .IgnoreArgument(2)
+        .SetReturn(TEST_CONST_CHAR_PTR);
+
+    STRICT_EXPECTED_CALL(mocks, STRING_construct(IGNORED_PTR_ARG))
+        .IgnoreArgument(1);
+
+    STRICT_EXPECTED_CALL(mocks, STRING_TOKENIZER_create(IGNORED_PTR_ARG))
+        .IgnoreArgument(1)
+        .SetReturn(TEST_STRING_TOKENIZER_HANDLE);
+
+    STRICT_EXPECTED_CALL(mocks, STRING_new())
+        .SetReturn(TEST_STRING_HANDLE);
+
+    STRICT_EXPECTED_CALL(mocks, STRING_new())
+        .SetReturn(TEST_STRING_HANDLE);
+
+    STRICT_EXPECTED_CALL(mocks, STRING_TOKENIZER_get_next_token(IGNORED_PTR_ARG, IGNORED_PTR_ARG, "."))
+        .IgnoreAllArguments()
+        .SetReturn(0);
+
+    STRICT_EXPECTED_CALL(mocks, STRING_TOKENIZER_get_next_token(IGNORED_PTR_ARG, IGNORED_PTR_ARG, "0"))
+        .IgnoreAllArguments()
+        .SetReturn(0);
+
+    EXPECTED_CALL(mocks, mallocAndStrcpy_s(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreAllArguments()
+        .SetReturn(0);
+
+    EXPECTED_CALL(mocks, mallocAndStrcpy_s(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreAllArguments()
+        .SetReturn(0);
+
+    EXPECTED_CALL(mocks, mallocAndStrcpy_s(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreAllArguments()
+        .SetReturn(0);
+
+    EXPECTED_CALL(mocks, STRING_c_str(IGNORED_PTR_ARG))
+        .IgnoreAllArguments()
+        .SetReturn(TEST_CHAR_PTR);
+
+    EXPECTED_CALL(mocks, STRING_c_str(IGNORED_PTR_ARG))
+        .IgnoreAllArguments()
+        .SetReturn(TEST_CHAR_PTR);
+
+    EXPECTED_CALL(mocks, mallocAndStrcpy_s(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreAllArguments()
+        .SetReturn(0);
+
+    EXPECTED_CALL(mocks, mallocAndStrcpy_s(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        .IgnoreAllArguments()
+        .SetReturn(0);
+
+
+    set_expected_calls_for_free_service_client_auth(mocks);
+    set_expected_calls_for_CreateFromConnectionString_cleanup(mocks);
+
+    // act
+    IOTHUB_SERVICE_CLIENT_AUTH_HANDLE handle = IoTHubServiceClientAuth_CreateFromConnectionString(TEST_CONNECTION_STRING_NO_SIG_NO_KEY);
     IoTHubServiceClientAuth_Destroy(handle);
 
     // assert


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [x] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
Connection strings that contain SharedAccessSignatures are not supported by the SDK for creating modules.

# Description of the solution
In places along the module creation path, where only SharedAccessKey is supported, allow SharedAccessSignature to be supported as well (but not both at the same time).