### PR TITLE
demo link failure using a linux dockerfile and an independent cmakelists

### DIFF
--- a/Dockerfile.out_of_tree_build_example
+++ b/Dockerfile.out_of_tree_build_example
@@ -1,0 +1,27 @@
+from ubuntu:18.04
+
+# see https://github.com/Azure/azure-iot-sdk-c/blob/master/doc/devbox_setup.md#linux
+RUN apt-get update && apt-get install -y \
+  git \
+  cmake \
+  build-essential \
+  curl \
+  libcurl4-openssl-dev \
+  libssl-dev \
+  uuid-dev
+
+ADD . /azure-iot-sdk-c
+
+RUN cd /azure-iot-sdk-c \
+  && mkdir cmake-build \
+  && cd cmake-build \
+  && cmake .. \
+  && make -j4 \
+  && make install \
+  && ldconfig
+
+RUN cd /azure-iot-sdk-c/iothub_client/samples/out_of_tree_build_example/ \
+  && mkdir build \
+  && cd build \
+  && cmake .. \
+  && make -j4 \

--- a/Dockerfile.out_of_tree_build_example_apt_get
+++ b/Dockerfile.out_of_tree_build_example_apt_get
@@ -1,0 +1,23 @@
+from ubuntu:18.04
+
+# see https://github.com/Azure/azure-iot-sdk-c/blob/master/doc/ubuntu_apt-get_sample_setup.md
+RUN apt-get update && apt-get install -y software-properties-common \
+ && add-apt-repository ppa:aziotsdklinux/ppa-azureiot
+
+# see https://github.com/Azure/azure-iot-sdk-c/blob/master/doc/devbox_setup.md#linux
+RUN apt-get update && apt-get install -y \
+  git \
+  cmake \
+  build-essential \
+  curl \
+  libcurl4-openssl-dev \
+  libssl-dev \
+  uuid-dev \
+  azure-iot-sdk-c-dev
+
+ADD . /azure-iot-sdk-c
+RUN cd /azure-iot-sdk-c/iothub_client/samples/out_of_tree_build_example/ \
+  && mkdir build \
+  && cd build \
+  && cmake .. \
+  && make -j4 \

--- a/iothub_client/samples/out_of_tree_build_example/CMakeLists.txt
+++ b/iothub_client/samples/out_of_tree_build_example/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 project(build-example C)
 
-include_directories(/usr/local/include/azureiot/)
+include_directories(/usr/local/include/azureiot/ /usr/include/azureiot /usr/include/azureiot/inc ../../../deps/parson/)
 
 # uses one of the other samples to demonstrate building (this cmake file is independent of the others in this tree)
 add_executable(build-example ../iothub_client_device_twin_and_methods_sample/iothub_client_device_twin_and_methods_sample.c)
@@ -9,17 +9,17 @@ add_executable(build-example ../iothub_client_device_twin_and_methods_sample/iot
 target_link_libraries(build-example
         iothub_client
         iothub_client_mqtt_transport
+        # see issue https://github.com/Azure/azure-iot-sdk-c/issues/550
+		 prov_auth_client # causes conflicts on source-built sdk, oct 2018
+		 hsm_security_client # causes conflicts on source-built sdk, oct 2018
+        umqtt
+        uhttp
         aziotsharedutil
         pthread
         curl
         ssl
         crypto
         m
-        umqtt
-        # see issue https://github.com/Azure/azure-iot-sdk-c/issues/550
-		# prov_auth_client # causes conflicts on source-built sdk, oct 2018
-		# hsm_security_client # causes conflicts on source-built sdk, oct 2018
-        uhttp
         uuid
         parson
         )

--- a/iothub_client/samples/out_of_tree_build_example/CMakeLists.txt
+++ b/iothub_client/samples/out_of_tree_build_example/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+project(build-example C)
+
+include_directories(/usr/local/include/azureiot/)
+
+# uses one of the other samples to demonstrate building (this cmake file is independent of the others in this tree)
+add_executable(build-example ../iothub_client_device_twin_and_methods_sample/iothub_client_device_twin_and_methods_sample.c)
+
+target_link_libraries(build-example
+        iothub_client
+        iothub_client_mqtt_transport
+        aziotsharedutil
+        pthread
+        curl
+        ssl
+        crypto
+        m
+        umqtt
+        # see issue https://github.com/Azure/azure-iot-sdk-c/issues/550
+		# prov_auth_client # causes conflicts on source-built sdk, oct 2018
+		# hsm_security_client # causes conflicts on source-built sdk, oct 2018
+        uhttp
+        uuid
+        parson
+        )


### PR DESCRIPTION
demonstrates link failure reported in #732 

also is a good example of an out of tree build which would be nice to include in tests or documentation so users can more easily start dependent projects