### PR TITLE
linker options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@ include("configs/azure_iot_sdksFunctions.cmake")
 
 getIoTSDKVersion()
 message(STATUS "IoT Client SDK Version = ${IOT_SDK_VERSION}")
-message("C FLAGS: ${CMAKE_C_FLAGS}")
-message("CXX FLAGS: ${CMAKE_CXX_FLAGS}")
 
 
 if (POLICY CMP0042)
@@ -323,7 +321,6 @@ if (${use_prov_client_core})
     add_subdirectory(provisioning_client)
 endif()
 
-message("UPDATED CMAKE FLAGS: ${CMAKE_C_FLAGS}")
 
 if (${build_service_client})
     add_subdirectory(iothub_service_client)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ include("configs/azure_iot_sdksFunctions.cmake")
 getIoTSDKVersion()
 message(STATUS "IoT Client SDK Version = ${IOT_SDK_VERSION}")
 
-
 if (POLICY CMP0042)
     cmake_policy(SET CMP0042 NEW)
 endif()
@@ -320,7 +319,6 @@ if (${use_prov_client_core})
 
     add_subdirectory(provisioning_client)
 endif()
-
 
 if (${build_service_client})
     add_subdirectory(iothub_service_client)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ include("configs/azure_iot_sdksFunctions.cmake")
 
 getIoTSDKVersion()
 message(STATUS "IoT Client SDK Version = ${IOT_SDK_VERSION}")
+message("C FLAGS: ${CMAKE_C_FLAGS}")
+message("CXX FLAGS: ${CMAKE_CXX_FLAGS}")
+
 
 if (POLICY CMP0042)
     cmake_policy(SET CMP0042 NEW)
@@ -65,6 +68,7 @@ option(run_longhaul_tests "set run_longhaul_tests to ON to run longhaul tests (d
 option(skip_samples "set skip_samples to ON to skip building samples (default is OFF)[if possible, they are always build]" OFF)
 option(compileOption_C "passes a string to the command line of the C compiler" OFF)
 option(compileOption_CXX "passes a string to the command line of the C++ compiler" OFF)
+option(linkerOption "passes a string to the shared and exe linker options of the C compiler" OFF)
 option(build_service_client "controls whether the iothub_service_client is built or not" ON)
 option(build_provisioning_service_client "controls whether the provisioning_service_client is built or not" ON)
 option(build_python "builds the Python native iothub_client module" OFF)
@@ -186,6 +190,12 @@ endif()
 
 if (NOT "${compileOption_CXX}" STREQUAL "OFF")
     set(CMAKE_CXX_FLAGS "${compileOption_CXX} ${CMAKE_CXX_FLAGS}")
+endif()
+
+if (NOT "${linkerOption}" STREQUAL "OFF")
+    message("linkerOption: ${CMAKE_SHARED_LINKER_FLAGS}")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /guard:cf /DYNAMICBASE")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /guard:cf /DYNAMICBASE")
 endif()
 
 include("configs/azure_iot_sdksFunctions.cmake")
@@ -312,6 +322,8 @@ if (${use_prov_client_core})
 
     add_subdirectory(provisioning_client)
 endif()
+
+message("UPDATED CMAKE FLAGS: ${CMAKE_C_FLAGS}")
 
 if (${build_service_client})
     add_subdirectory(iothub_service_client)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,8 +194,8 @@ endif()
 
 if (NOT "${linkerOption}" STREQUAL "OFF")
     message("linkerOption: ${CMAKE_SHARED_LINKER_FLAGS}")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /guard:cf /DYNAMICBASE")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /guard:cf /DYNAMICBASE")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${linkerOption}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} {linkerOption}")
 endif()
 
 include("configs/azure_iot_sdksFunctions.cmake")


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Description of the solution

Created linkerOptions compiler option to pass in arbitrary linker options using CMAKE. Useful for providing Linker Options such as those needed to enable Control Flow Guard for security mitigations.