### PR TITLE
Fix issue with enable e2e test without provisioning client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,7 +313,7 @@ if (${use_prov_client_core})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_PROV_MODULE")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_PROV_MODULE")
 
-    if (${build_provisioning_service_client})
+    if (${build_provisioning_service_client} AND ${use_prov_client})
         add_subdirectory(provisioning_service_client)
     endif()
 

--- a/jenkins/linux_c_option_test.sh
+++ b/jenkins/linux_c_option_test.sh
@@ -55,6 +55,7 @@ declare -a arr=(
     "-Dbuild_as_dynamic:BOOL=ON -Ddont_use_uploadtoblob:BOOL=ON -Duse_edge_modules:BOOL=ON"
     "-Drun_longhaul_tests=ON"
     "-Duse_prov_client=ON -Dhsm_custom_lib=$custom_hsm_lib"
+    "-Drun_e2e_tests=ON -Drun_sfc_tests=ON -Duse_edge_modules=ON"
 )
 
 for item in "${arr[@]}"

--- a/provisioning_client/CMakeLists.txt
+++ b/provisioning_client/CMakeLists.txt
@@ -39,7 +39,7 @@ if (${hsm_type_custom})
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHSM_AUTH_TYPE_CUSTOM")
 
     set(HSM_CLIENT_LIBRARY ${CUSTOM_HSM_LIB})
-else ()
+elseif (${use_prov_client})
     if (${run_e2e_tests})
         # For e2e test we need to run a custom HSM to handle testing
         if (${hsm_type_x509})


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 