### PR TITLE
add sas support without changing APIs

### DIFF
--- a/iothub_service_client/devdoc/requirement_docs/iothubserviceclient_auth_requirements.md
+++ b/iothub_service_client/devdoc/requirement_docs/iothubserviceclient_auth_requirements.md
@@ -106,6 +106,8 @@ extern IOTHUB_SERVICE_CLIENT_AUTH_HANDLE IoTHubServiceClientAuth_CreateFromConne
 
 **SRS_IOTHUBSERVICECLIENT_12_006: [** If the IOTHUB_SERVICE_CLIENT_AUTH has been populated IoTHubServiceClientAuth_CreateFromConnectionString shall do clean up and return with a IOTHUB_SERVICE_CLIENT_AUTH_HANDLE to it **]**
 
+**SRS_IOTHUBSERVICECLIENT_12_041: [** IoTHubServiceClientAuth_CreateFromConnectionString shall allocate memory and copy sharedAccessSignature to result->sharedAccessKey by prefixing it with "sas=". **]**
+
 
 ## IoTHubServiceClient_Destroy
 ```c

--- a/iothub_service_client/inc/iothub_registrymanager.h
+++ b/iothub_service_client/inc/iothub_registrymanager.h
@@ -172,7 +172,7 @@ typedef struct IOTHUB_REGISTRYMANAGER_TAG
     char* hostname;
     char* iothubName;
     char* iothubSuffix;
-    char* sharedAccessKey;
+    char* sharedAccessKey;  //field can contain "SharedAccessSignature" if prefixed with "sas="; Otherwise, a “SharedAccessKey” is expected.
     char* keyName;
     char* deviceId;
 } IOTHUB_REGISTRYMANAGER;

--- a/iothub_service_client/inc/iothub_service_client_auth.h
+++ b/iothub_service_client/inc/iothub_service_client_auth.h
@@ -49,7 +49,7 @@ typedef struct IOTHUB_SERVICE_CLIENT_AUTH_TAG
     char* hostname;
     char* iothubName;
     char* iothubSuffix;
-    char* sharedAccessKey;
+    char* sharedAccessKey;  //field can contain "SharedAccessSignature" if prefixed with "sas="; Otherwise, a “SharedAccessKey” is expected.
     char* keyName;
     char* deviceId;
 } IOTHUB_SERVICE_CLIENT_AUTH;

--- a/iothub_service_client/src/iothub_service_client_auth.c
+++ b/iothub_service_client/src/iothub_service_client_auth.c
@@ -14,6 +14,7 @@
 static const char* IOTHUBHOSTNAME = "HostName";
 static const char* IOTHUBSHAREDACESSKEYNAME = "SharedAccessKeyName";
 static const char* IOTHUBSHAREDACESSKEY = "SharedAccessKey";
+static const char* IOTHUBSHAREDACESSSIGNATURE = "SharedAccessSignature";
 static const char* IOTHUBDEVICEID = "DeviceId";
 
 static void free_service_client_auth(IOTHUB_SERVICE_CLIENT_AUTH* authInfo)
@@ -29,6 +30,60 @@ static void free_service_client_auth(IOTHUB_SERVICE_CLIENT_AUTH* authInfo)
 
 DEFINE_ENUM_STRINGS(IOTHUB_DEVICE_STATUS, IOTHUB_DEVICE_STATUS_VALUES);
 DEFINE_ENUM_STRINGS(IOTHUB_DEVICE_CONNECTION_STATE, IOTHUB_DEVICE_CONNECTION_STATE_VALUES);
+
+int mallocAndStrcpyWithPrefix_s(char** destination, const char* prefix, const char* source)
+{
+    int result;
+    int copied_result;
+
+    if ((destination == NULL) || (prefix == NULL) || (source == NULL))
+    {
+        /*If strDestination or strSource is a NULL pointer[...]these functions return EINVAL */
+        result = EINVAL;
+    }
+    else
+    {
+        size_t prefixLength = strlen(prefix);
+        size_t sourceLength = strlen(source);
+
+        size_t l = prefixLength + sourceLength;
+        char* temp = (char*)malloc(l + 1);
+
+        /*Codes_SRS_CRT_ABSTRACTIONS_99_037: [Upon failure to allocate memory for the destination, the function will return ENOMEM.]*/
+        if (temp == NULL)
+        {
+            result = ENOMEM;
+        }
+        else
+        {
+            *destination = temp;
+            /*Codes_SRS_CRT_ABSTRACTIONS_99_039: [mallocAndstrcpy_s shall copy the contents in the address source, including the terminating null character into location specified by the destination pointer after the memory allocation.]*/
+            copied_result = strcpy_s(temp, l + 1, prefix);
+            if (copied_result < 0) /*strcpy_s error*/
+            {
+                free(*destination);
+                *destination = NULL;
+                result = copied_result;
+            }
+            else
+            {
+                copied_result = strcpy_s(temp+prefixLength, l + 1 - prefixLength, source);
+                if (copied_result < 0) /*strcpy_s error*/
+                {
+                    free(*destination);
+                    *destination = NULL;
+                    result = copied_result;
+                }
+                else
+                {
+                    /*Codes_SRS_CRT_ABSTRACTIONS_99_035: [mallocAndstrcpy_s shall return Zero upon success]*/
+                    result = 0;
+                }
+            }
+        }
+    }
+    return result;
+}
 
 IOTHUB_SERVICE_CLIENT_AUTH_HANDLE IoTHubServiceClientAuth_CreateFromConnectionString(const char* connectionString)
 {
@@ -83,6 +138,7 @@ IOTHUB_SERVICE_CLIENT_AUTH_HANDLE IoTHubServiceClientAuth_CreateFromConnectionSt
                     const char* keyName;
                     const char* deviceId;
                     const char* sharedAccessKey;
+                    const char* sharedAccessSignature = NULL;
                     const char* iothubName;
                     const char* iothubSuffix;
 
@@ -111,7 +167,8 @@ IOTHUB_SERVICE_CLIENT_AUTH_HANDLE IoTHubServiceClientAuth_CreateFromConnectionSt
                         free_service_client_auth(result);
                         result = NULL;
                     }
-                    else if ((sharedAccessKey = Map_GetValueFromKey(connection_string_values_map, IOTHUBSHAREDACESSKEY)) == NULL)
+                    else if ((sharedAccessKey = Map_GetValueFromKey(connection_string_values_map, IOTHUBSHAREDACESSKEY)) == NULL &&
+                             (sharedAccessSignature = Map_GetValueFromKey(connection_string_values_map, IOTHUBSHAREDACESSSIGNATURE)) == NULL)
                     {
                         /*Codes_SRS_IOTHUBSERVICECLIENT_12_013: [** If the populating SharedAccessKey fails, IoTHubServiceClientAuth_CreateFromConnectionString shall do clean up and return NULL. **] */
                         LogError("Couldn't find %s in connection string", IOTHUBSHAREDACESSKEY);
@@ -191,10 +248,18 @@ IOTHUB_SERVICE_CLIENT_AUTH_HANDLE IoTHubServiceClientAuth_CreateFromConnectionSt
                         result = NULL;
                     }
                     /*Codes_SRS_IOTHUBSERVICECLIENT_12_028: [** IoTHubServiceClientAuth_CreateFromConnectionString shall allocate memory and copy sharedAccessKey to result->sharedAccessKey by calling mallocAndStrcpy_s. **] */
-                    else if (mallocAndStrcpy_s(&result->sharedAccessKey, sharedAccessKey) != 0)
+                    else if (sharedAccessKey != NULL && mallocAndStrcpy_s(&result->sharedAccessKey, sharedAccessKey) != 0)
                     {
                         /*Codes_SRS_IOTHUBSERVICECLIENT_12_029: [** If the mallocAndStrcpy_s fails, IoTHubServiceClientAuth_CreateFromConnectionString shall do clean up and return NULL. **] */
                         LogError("mallocAndStrcpy_s failed for sharedAccessKey");
+                        free_service_client_auth(result);
+                        result = NULL;
+                    }
+                    /*Codes_SRS_IOTHUBSERVICECLIENT_12_041: [** IoTHubServiceClientAuth_CreateFromConnectionString shall allocate memory and copy sharedAccessSignature to result->sharedAccessKey by prefixing it with "sas=". **] */
+                    else if (sharedAccessSignature != NULL && mallocAndStrcpyWithPrefix_s(&result->sharedAccessKey, "sas=", sharedAccessSignature) != 0)
+                    {
+                        /*Codes_SRS_IOTHUBSERVICECLIENT_12_029: [** If the mallocAndStrcpy_s fails, IoTHubServiceClientAuth_CreateFromConnectionString shall do clean up and return NULL. **] */
+                        LogError("mallocAndStrcpy_s failed for sharedAccessSignature");
                         free_service_client_auth(result);
                         result = NULL;
                     }


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [x] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
Currently, only to create a module, the device SharedAccessKey is required in the c SDK ... the service supports SharedAccessSignatures.

# Description of the solution
This attempts to add SharedAccessSignature support without changing any APIs (and trying not to break any backward compat).  To do this, if SharedAccessSignature is encountered, it is prefixed with "sas=" and stored where SharedAccessKeys are stored.  When it is used to create a HTTP request, if the prefix "sas=" is found, the SharedAccessSignature is used as-is rather than creating one.  In all other cases, the existing behavior persists.