### PR TITLE
Setoption sleep timeout

### DIFF
--- a/iothub_client/inc/iothub_client_options.h
+++ b/iothub_client/inc/iothub_client_options.h
@@ -76,6 +76,8 @@ extern "C"
     //diagnostic sampling percentage value, [0-100]
     static STATIC_VAR_UNUSED const char* OPTION_DIAGNOSTIC_SAMPLING_PERCENTAGE = "diag_sampling_percentage";
 
+static STATIC_VAR_UNUSED const char* OPTION_CONVENIENCE_LOOP_TIME = "convenience_loop_timeout";
+
 #ifdef __cplusplus
 }
 #endif

--- a/iothub_client/src/iothub_client_core.c
+++ b/iothub_client/src/iothub_client_core.c
@@ -19,6 +19,9 @@
 #include "azure_c_shared_utility/xlogging.h"
 #include "azure_c_shared_utility/singlylinkedlist.h"
 #include "azure_c_shared_utility/vector.h"
+#include "iothub_client_options.h"
+
+#define LOOP_TIMEOUT_DEFAULT 1
 
 struct IOTHUB_QUEUE_CONTEXT_TAG;
 
@@ -43,6 +46,7 @@ typedef struct IOTHUB_CLIENT_CORE_INSTANCE_TAG
     struct IOTHUB_QUEUE_CONTEXT_TAG* connection_status_user_context;
     struct IOTHUB_QUEUE_CONTEXT_TAG* message_user_context;
     struct IOTHUB_QUEUE_CONTEXT_TAG* method_user_context;
+    uint16_t loop_timeout;
 } IOTHUB_CLIENT_CORE_INSTANCE;
 
 typedef enum HTTPWORKER_THREAD_TYPE_TAG
@@ -1691,13 +1695,20 @@ IOTHUB_CLIENT_RESULT IoTHubClientCore_SetOption(IOTHUB_CLIENT_CORE_HANDLE iotHub
         }
         else
         {
-            /*Codes_SRS_IOTHUBCLIENT_02_038: [If optionName doesn't match one of the options handled by this module then IoTHubClient_SetOption shall call IoTHubClientCore_LL_SetOption passing the same parameters and return what IoTHubClientCore_LL_SetOption returns.] */
-            result = IoTHubClientCore_LL_SetOption(iotHubClientInstance->IoTHubClientLLHandle, optionName, value);
-            if (result != IOTHUB_CLIENT_OK)
+            if (strcmp(OPTION_CONVENIENCE_LOOP_TIME, optionName) == 0)
             {
-                LogError("IoTHubClientCore_LL_SetOption failed");
+                iotHubClientInstance->loop_timeout = *((uint16_t *)value);
+                result = IOTHUB_CLIENT_OK;
             }
-
+            else
+            {
+                /*Codes_SRS_IOTHUBCLIENT_02_038: [If optionName doesn't match one of the options handled by this module then IoTHubClient_SetOption shall call IoTHubClientCore_LL_SetOption passing the same parameters and return what IoTHubClientCore_LL_SetOption returns.] */
+                result = IoTHubClientCore_LL_SetOption(iotHubClientInstance->IoTHubClientLLHandle, optionName, value);
+                if (result != IOTHUB_CLIENT_OK)
+                {
+                    LogError("IoTHubClientCore_LL_SetOption failed");
+                }
+            }
             (void)Unlock(iotHubClientInstance->LockHandle);
         }
     }

--- a/iothub_client/src/iothub_client_core.c
+++ b/iothub_client/src/iothub_client_core.c
@@ -817,7 +817,7 @@ static int ScheduleWork_Thread(void* threadArgument)
             /*Codes_SRS_IOTHUBCLIENT_01_040: [If acquiring the lock fails, IoTHubClientCore_LL_DoWork shall not be called.]*/
             /*no code, shall retry*/
         }
-        (void)ThreadAPI_Sleep(1);
+        (void)ThreadAPI_Sleep(iotHubClientInstance->loop_timeout);
     }
 
     ThreadAPI_Exit(0);


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [NO] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

See Github #758 

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

Currently it is not possible to adjust the ThreadAPI_Sleep time for the convenience layer. This change proposes a adding an option to set this value, which is defaulted to 1ms.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 