### PR TITLE
Enable custom symmetric key HSM

### DIFF
--- a/provisioning_client/src/iothub_auth_client.c
+++ b/provisioning_client/src/iothub_auth_client.c
@@ -171,7 +171,7 @@ IOTHUB_SECURITY_HANDLE iothub_device_auth_create()
             }
         }
 #endif
-#if defined(HSM_TYPE_SYMM_KEY)
+#if defined(HSM_TYPE_SYMM_KEY) || defined(HSM_AUTH_TYPE_CUSTOM)
         if (result != NULL && iothub_security_t == IOTHUB_SECURITY_TYPE_SYMMETRIC_KEY)
         {
             result->cred_type = AUTH_TYPE_SYMM_KEY;

--- a/provisioning_client/src/prov_auth_client.c
+++ b/provisioning_client/src/prov_auth_client.c
@@ -264,7 +264,7 @@ PROV_AUTH_HANDLE prov_auth_create()
         }
         else
         {
-#if defined(HSM_TYPE_SYMM_KEY)
+#if defined(HSM_TYPE_SYMM_KEY) || defined(HSM_AUTH_TYPE_CUSTOM)
             result->sec_type = PROV_AUTH_TYPE_KEY;
             const HSM_CLIENT_KEY_INTERFACE* key_interface = hsm_client_key_interface();
             if ((key_interface == NULL) ||


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)
#821
# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
Custom HSM did not work with symmetric key-types. This patch fixes this issue.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected -->
Check if `HSM_AUTH_TYPE_CUSTOM` is defined alongside `HSM_TYPE_SYMM_KEY`