### PR TITLE
Remove redundant explicit tls12 setting

### DIFF
--- a/provisioning_client/src/iothub_auth_client.c
+++ b/provisioning_client/src/iothub_auth_client.c
@@ -64,33 +64,33 @@ static int sign_sas_data(IOTHUB_SECURITY_INFO* security_info, const char* payloa
     }
     else
     {
+        BUFFER_HANDLE decoded_key = NULL;
+        BUFFER_HANDLE output_hash = NULL;
+
         char* symmetrical_key = security_info->hsm_client_get_symm_key(security_info->hsm_client_handle);
         if (symmetrical_key == NULL)
         {
             LogError("Failed getting asymmetrical key");
             result = __FAILURE__;
         }
+        else if ((decoded_key = Base64_Decoder(symmetrical_key)) == NULL)
+        {
+            LogError("Failed decoding symmetrical key");
+            result = __FAILURE__;
+        }
+        else if ((output_hash = BUFFER_new()) == NULL)
+        {
+            LogError("Failed allocating output hash buffer");
+            result = __FAILURE__;
+        }
         else
         {
-            BUFFER_HANDLE decoded_key;
-            BUFFER_HANDLE output_hash;
+            size_t decoded_key_len = BUFFER_length(decoded_key);
+            const unsigned char* decoded_key_bytes = BUFFER_u_char(decoded_key);
 
-            if ((decoded_key = Base64_Decoder(symmetrical_key)) == NULL)
-            {
-                LogError("Failed decoding symmetrical key");
-                result = __FAILURE__;
-            }
-            else if ((output_hash = BUFFER_new()) == NULL)
-            {
-                LogError("Failed allocating output hash buffer");
-                BUFFER_delete(decoded_key);
-                result = __FAILURE__;
-            }
-            else if (HMACSHA256_ComputeHash(BUFFER_u_char(decoded_key), BUFFER_length(decoded_key), (const unsigned char*)payload, payload_len, output_hash) != HMACSHA256_OK)
+            if (HMACSHA256_ComputeHash(decoded_key_bytes, decoded_key_len, (const unsigned char*)payload, payload_len, output_hash) != HMACSHA256_OK)
             {
                 LogError("Failed computing HMAC Hash");
-                BUFFER_delete(decoded_key);
-                BUFFER_delete(output_hash);
                 result = __FAILURE__;
             }
             else
@@ -107,12 +107,15 @@ static int sign_sas_data(IOTHUB_SECURITY_INFO* security_info, const char* payloa
                     memcpy(*output, output_data, *len);
                     result = 0;
                 }
-                BUFFER_delete(decoded_key);
-                BUFFER_delete(output_hash);
+
             }
-            free(symmetrical_key);
         }
+
+        BUFFER_delete(decoded_key);
+        BUFFER_delete(output_hash);
+        free(symmetrical_key);
     }
+
     return result;
 }
 

--- a/provisioning_client/src/prov_auth_client.c
+++ b/provisioning_client/src/prov_auth_client.c
@@ -160,33 +160,33 @@ static int sign_sas_data(PROV_AUTH_INFO* auth_info, const char* payload, unsigne
     }
     else
     {
+        BUFFER_HANDLE decoded_key = NULL;
+        BUFFER_HANDLE output_hash = NULL;
+
         char* symmetrical_key = auth_info->hsm_client_get_symm_key(auth_info->hsm_client_handle);
         if (symmetrical_key == NULL)
         {
             LogError("Failed getting asymmetrical key");
             result = __FAILURE__;
         }
+        else if ((decoded_key = Base64_Decoder(symmetrical_key)) == NULL)
+        {
+            LogError("Failed decoding symmetrical key");
+            result = __FAILURE__;
+        }
+        else if ((output_hash = BUFFER_new()) == NULL)
+        {
+            LogError("Failed allocating output hash buffer");
+            result = __FAILURE__;
+        }
         else
         {
-            BUFFER_HANDLE decoded_key;
-            BUFFER_HANDLE output_hash;
+            size_t decoded_key_len = BUFFER_length(decoded_key);
+            const unsigned char* decoded_key_bytes = BUFFER_u_char(decoded_key);
 
-            if ((decoded_key = Base64_Decoder(symmetrical_key)) == NULL)
-            {
-                LogError("Failed decoding symmetrical key");
-                result = __FAILURE__;
-            }
-            else if ((output_hash = BUFFER_new()) == NULL)
-            {
-                LogError("Failed allocating output hash buffer");
-                BUFFER_delete(decoded_key);
-                result = __FAILURE__;
-            }
-            else if (HMACSHA256_ComputeHash(BUFFER_u_char(decoded_key), BUFFER_length(decoded_key), (const unsigned char*)payload, payload_len, output_hash) != HMACSHA256_OK)
+            if (HMACSHA256_ComputeHash(decoded_key_bytes, decoded_key_len, (const unsigned char*)payload, payload_len, output_hash) != HMACSHA256_OK)
             {
                 LogError("Failed computing HMAC Hash");
-                BUFFER_delete(decoded_key);
-                BUFFER_delete(output_hash);
                 result = __FAILURE__;
             }
             else
@@ -203,11 +203,13 @@ static int sign_sas_data(PROV_AUTH_INFO* auth_info, const char* payload, unsigne
                     memcpy(*output, output_data, *len);
                     result = 0;
                 }
-                BUFFER_delete(decoded_key);
-                BUFFER_delete(output_hash);
+
             }
-            free(symmetrical_key);
         }
+
+        BUFFER_delete(decoded_key);
+        BUFFER_delete(output_hash);
+        free(symmetrical_key);
     }
     return result;
 }

--- a/provisioning_client/src/prov_transport_amqp_client.c
+++ b/provisioning_client/src/prov_transport_amqp_client.c
@@ -68,10 +68,6 @@ static PROV_TRANSPORT_IO_INFO* amqp_transport_io(const char* fqdn, SASL_MECHANIS
         }
         else
         {
-            // provisioning requires tls 1.2
-            int tls_version = 12;
-            xio_setoption(result->transport_handle, OPTION_TLS_VERSION, &tls_version);
-
             if (sasl_mechanism != NULL)
             {
                 const IO_INTERFACE_DESCRIPTION* saslio_interface;

--- a/provisioning_client/src/prov_transport_amqp_ws_client.c
+++ b/provisioning_client/src/prov_transport_amqp_ws_client.c
@@ -85,12 +85,6 @@ static PROV_TRANSPORT_IO_INFO* amqp_transport_ws_io(const char* fqdn, SASL_MECHA
             }
             else
             {
-#ifdef USE_OPENSSL
-                // Default to tls 1.2
-                int tls_version = 12;
-                xio_setoption(result->transport_handle, OPTION_TLS_VERSION, &tls_version);
-#endif
-
                 if (sasl_mechanism != NULL)
                 {
                     const IO_INTERFACE_DESCRIPTION* saslio_interface;

--- a/provisioning_client/src/prov_transport_mqtt_client.c
+++ b/provisioning_client/src/prov_transport_mqtt_client.c
@@ -53,14 +53,6 @@ static XIO_HANDLE mqtt_transport_io(const char* fqdn, const HTTP_PROXY_OPTIONS* 
             LogError("failed calling xio_create on underlying io");
             result = NULL;
         }
-        else
-        {
-#ifdef USE_OPENSSL
-            // requires tls 1.2
-            int tls_version = 12;
-            xio_setoption(result, OPTION_TLS_VERSION, &tls_version);
-#endif
-        }
     }
     /* Codes_PROV_TRANSPORT_MQTT_CLIENT_07_014: [ On success mqtt_transport_io shall return allocated XIO_HANDLE. ] */
     return result;

--- a/provisioning_client/src/prov_transport_mqtt_ws_client.c
+++ b/provisioning_client/src/prov_transport_mqtt_ws_client.c
@@ -69,14 +69,6 @@ static XIO_HANDLE mqtt_transport_ws_io(const char* fqdn, const HTTP_PROXY_OPTION
         {
             LogError("failed calling xio_create on underlying io");
         }
-        else
-        {
-#ifdef USE_OPENSSL
-            // requires tls 1.2
-            int tls_version = 12;
-            xio_setoption(result, OPTION_TLS_VERSION, &tls_version);
-#endif
-        }
     }
     /* Codes_PROV_TRANSPORT_MQTT_WS_CLIENT_07_014: [ On success mqtt_transport_ws_io shall return an allocated XIO_HANDLE. ] */
     return result;

--- a/provisioning_client/tests/prov_transport_amqp_client_ut/prov_transport_amqp_client_ut.c
+++ b/provisioning_client/tests/prov_transport_amqp_client_ut/prov_transport_amqp_client_ut.c
@@ -240,7 +240,6 @@ BEGIN_TEST_SUITE(prov_transport_amqp_client_ut)
         STRICT_EXPECTED_CALL(platform_get_default_tlsio());
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
-        STRICT_EXPECTED_CALL(xio_setoption(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
         STRICT_EXPECTED_CALL(saslclientio_get_interface_description());
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
 
@@ -266,7 +265,6 @@ BEGIN_TEST_SUITE(prov_transport_amqp_client_ut)
         STRICT_EXPECTED_CALL(platform_get_default_tlsio());
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
-        STRICT_EXPECTED_CALL(xio_setoption(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
 
         //act
         dps_io_info = g_transport_io(TEST_URI_VALUE, NULL, NULL);
@@ -296,22 +294,14 @@ BEGIN_TEST_SUITE(prov_transport_amqp_client_ut)
         STRICT_EXPECTED_CALL(platform_get_default_tlsio());
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
-        STRICT_EXPECTED_CALL(xio_setoption(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
         STRICT_EXPECTED_CALL(saslclientio_get_interface_description());
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
-
-        size_t calls_cannot_fail[] = { 3 };
 
         umock_c_negative_tests_snapshot();
 
         size_t count = umock_c_negative_tests_call_count();
         for (size_t index = 0; index < count; index++)
         {
-            if (should_skip_index(index, calls_cannot_fail, sizeof(calls_cannot_fail) / sizeof(calls_cannot_fail[0])) != 0)
-            {
-                continue;
-            }
-
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
 
@@ -343,7 +333,6 @@ BEGIN_TEST_SUITE(prov_transport_amqp_client_ut)
         STRICT_EXPECTED_CALL(platform_get_default_tlsio());
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
-        STRICT_EXPECTED_CALL(xio_setoption(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
         STRICT_EXPECTED_CALL(saslclientio_get_interface_description());
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
         proxy_info.host_address = TEST_HOST_ADDRESS_VALUE;

--- a/provisioning_client/tests/prov_transport_amqp_ws_client_ut/prov_transport_amqp_ws_client_ut.c
+++ b/provisioning_client/tests/prov_transport_amqp_ws_client_ut/prov_transport_amqp_ws_client_ut.c
@@ -246,9 +246,6 @@ BEGIN_TEST_SUITE(prov_transport_amqp_ws_client_ut)
         STRICT_EXPECTED_CALL(platform_get_default_tlsio());
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
-#ifdef USE_OPENSSL
-        STRICT_EXPECTED_CALL(xio_setoption(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
-#endif
         STRICT_EXPECTED_CALL(saslclientio_get_interface_description());
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
 
@@ -275,9 +272,6 @@ BEGIN_TEST_SUITE(prov_transport_amqp_ws_client_ut)
         STRICT_EXPECTED_CALL(platform_get_default_tlsio());
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
-#ifdef USE_OPENSSL
-        STRICT_EXPECTED_CALL(xio_setoption(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
-#endif
 
         //act
         dps_io_info = g_transport_io(TEST_URI_VALUE, NULL, NULL);
@@ -306,9 +300,6 @@ BEGIN_TEST_SUITE(prov_transport_amqp_ws_client_ut)
         STRICT_EXPECTED_CALL(platform_get_default_tlsio());
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
-#ifdef USE_OPENSSL
-        STRICT_EXPECTED_CALL(xio_setoption(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
-#endif
         STRICT_EXPECTED_CALL(saslclientio_get_interface_description());
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
 
@@ -356,9 +347,6 @@ BEGIN_TEST_SUITE(prov_transport_amqp_ws_client_ut)
         STRICT_EXPECTED_CALL(http_proxy_io_get_interface_description());
         STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
-#ifdef USE_OPENSSL
-        STRICT_EXPECTED_CALL(xio_setoption(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
-#endif
         STRICT_EXPECTED_CALL(saslclientio_get_interface_description());
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
         proxy_info.host_address = TEST_HOST_ADDRESS_VALUE;

--- a/provisioning_client/tests/prov_transport_mqtt_client_ut/prov_transport_mqtt_client_ut.c
+++ b/provisioning_client/tests/prov_transport_mqtt_client_ut/prov_transport_mqtt_client_ut.c
@@ -221,9 +221,6 @@ BEGIN_TEST_SUITE(prov_transport_mqtt_client_ut)
         //arrange
         STRICT_EXPECTED_CALL(platform_get_default_tlsio());
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
-#ifdef USE_OPENSSL
-        STRICT_EXPECTED_CALL(xio_setoption(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
-#endif
         //act
         dps_io_info = g_transport_io(TEST_URI_VALUE, NULL);
 
@@ -244,9 +241,6 @@ BEGIN_TEST_SUITE(prov_transport_mqtt_client_ut)
         //arrange
         STRICT_EXPECTED_CALL(platform_get_default_tlsio());
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
-#ifdef USE_OPENSSL
-        STRICT_EXPECTED_CALL(xio_setoption(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
-#endif
 
         //act
         dps_io_info = g_transport_io(TEST_URI_VALUE, NULL);
@@ -308,9 +302,6 @@ BEGIN_TEST_SUITE(prov_transport_mqtt_client_ut)
         STRICT_EXPECTED_CALL(http_proxy_io_get_interface_description());
         STRICT_EXPECTED_CALL(platform_get_default_tlsio());
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
-#ifdef USE_OPENSSL
-        STRICT_EXPECTED_CALL(xio_setoption(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
-#endif
         proxy_info.host_address = TEST_HOST_ADDRESS_VALUE;
         proxy_info.username = TEST_PRIVATE_KEY_VALUE;
         proxy_info.password = TEST_HOST_ADDRESS_VALUE;

--- a/provisioning_client/tests/prov_transport_mqtt_ws_client_ut/prov_transport_mqtt_ws_client_ut.c
+++ b/provisioning_client/tests/prov_transport_mqtt_ws_client_ut/prov_transport_mqtt_ws_client_ut.c
@@ -226,9 +226,6 @@ BEGIN_TEST_SUITE(prov_transport_mqtt_ws_client_ut)
         STRICT_EXPECTED_CALL(wsio_get_interface_description());
         STRICT_EXPECTED_CALL(platform_get_default_tlsio());
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
-#ifdef USE_OPENSSL
-        STRICT_EXPECTED_CALL(xio_setoption(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
-#endif
 
         //act
         dps_io_info = g_transport_io(TEST_URI_VALUE, NULL);
@@ -251,9 +248,6 @@ BEGIN_TEST_SUITE(prov_transport_mqtt_ws_client_ut)
         STRICT_EXPECTED_CALL(wsio_get_interface_description());
         STRICT_EXPECTED_CALL(platform_get_default_tlsio());
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
-#ifdef USE_OPENSSL
-        STRICT_EXPECTED_CALL(xio_setoption(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
-#endif
 
         //act
         dps_io_info = g_transport_io(TEST_URI_VALUE, NULL);
@@ -317,9 +311,7 @@ BEGIN_TEST_SUITE(prov_transport_mqtt_ws_client_ut)
         STRICT_EXPECTED_CALL(platform_get_default_tlsio());
         STRICT_EXPECTED_CALL(http_proxy_io_get_interface_description());
         STRICT_EXPECTED_CALL(xio_create(TEST_INTERFACE_DESC, IGNORED_PTR_ARG));
-#ifdef USE_OPENSSL
-        STRICT_EXPECTED_CALL(xio_setoption(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
-#endif
+
         proxy_info.host_address = TEST_HOST_ADDRESS_VALUE;
         proxy_info.username = TEST_PRIVATE_KEY_VALUE;
         proxy_info.password = TEST_HOST_ADDRESS_VALUE;


### PR DESCRIPTION
* Remove the instances of provisioning client explicitly setting version=tls1.2.  Underlying PAL's should be on most secure version anyway, without us needing an explicit set.

Also, not directly related to this change but found when running UT on clang
* Change `HMACSHA256_ComputeHash(BUFFER_u_char(decoded_key), BUFFER_length(decoded_key),` so that the `BUFFER_u_char` and `BUFFER_length` are executed outside the function param list.  
MS Visual Studio and gcc executed the functions from right to left, but clang it turns out goes left to right.