### PR TITLE
Amqp refactor

### DIFF
--- a/iothub_client/devdoc/requirement_docs/iothubtransport_amqp_common_requirements.md
+++ b/iothub_client/devdoc/requirement_docs/iothubtransport_amqp_common_requirements.md
@@ -133,7 +133,7 @@ Note: see section "Per-Device DoWork Requirements" below.
 
 #### Connection-Retry Logic
 
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_031: [**device_stop() shall be invoked on all `instance->registered_devices` that are not already stopped**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_031: [**amqp_device_stop() shall be invoked on all `instance->registered_devices` that are not already stopped**]**
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_032: [** Each `instance->registered_devices` shall unsubscribe from receiving C2D method requests by calling `iothubtransportamqp_methods_unsubscribe`**]**
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_033: [**`instance->connection` shall be destroyed using amqp_connection_destroy()**]**
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_034: [**`instance->tls_io` options shall be saved on `instance->saved_tls_options` using xio_retrieveoptions()**]**
@@ -151,15 +151,15 @@ Note: all the components above will be re-created and re-started on the next cal
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_038: [**If amqp_connection_get_cbs_handle() fails, IoTHubTransport_AMQP_Common_DoWork shall fail and return**]**
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_039: [**amqp_connection_get_session_handle() shall be invoked on `instance->connection`**]**
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_040: [**If amqp_connection_get_session_handle() fails, IoTHubTransport_AMQP_Common_DoWork shall fail and return**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_041: [**The device handle shall be started using device_start_async()**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_042: [**If device_start_async() fails, IoTHubTransport_AMQP_Common_DoWork shall fail and skip to the next registered device**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_041: [**The device handle shall be started using amqp_device_start_async()**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_042: [**If amqp_device_start_async() fails, IoTHubTransport_AMQP_Common_DoWork shall fail and skip to the next registered device**]**
 
 
 ##### DEVICE_HANDLE Error Control
 
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_043: [**If the device handle is in state DEVICE_STATE_STARTING or DEVICE_STATE_STOPPING, it shall be checked for state change timeout**]**
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_044: [**If the device times out in state DEVICE_STATE_STARTING or DEVICE_STATE_STOPPING, the registered device shall be marked with failure**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_045: [**If the registered device has a failure, it shall be stopped using device_stop()**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_045: [**If the registered device has a failure, it shall be stopped using amqp_device_stop()**]**
 Note: this will cause the device to be restarted on the next call to DoWork.
 
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_046: [**If the device has failed for MAX_NUMBER_OF_DEVICE_FAILURES in a row, it shall trigger a connection retry on the transport**]**
@@ -171,9 +171,9 @@ Note: this will cause the device to be restarted on the next call to DoWork.
 
 ##### Send pending events
 
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_047: [**If the registered device is started, each event on `registered_device->wait_to_send_list` shall be removed from the list and sent using device_send_event_async()**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_048: [**device_send_event_async() shall be invoked passing `on_event_send_complete`**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_049: [**If device_send_event_async() fails, `on_event_send_complete` shall be invoked passing EVENT_SEND_COMPLETE_RESULT_ERROR_FAIL_SENDING and return**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_047: [**If the registered device is started, each event on `registered_device->wait_to_send_list` shall be removed from the list and sent using amqp_device_send_event_async()**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_048: [**amqp_device_send_event_async() shall be invoked passing `on_event_send_complete`**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_049: [**If amqp_device_send_event_async() fails, `on_event_send_complete` shall be invoked passing EVENT_SEND_COMPLETE_RESULT_ERROR_FAIL_SENDING and return**]**
 
 
 ###### on_event_send_complete
@@ -245,9 +245,9 @@ Note: the instance of AMQP_TRANSPORT_DEVICE_STATE will be referred below as `amq
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_068: [**IoTHubTransport_AMQP_Common_Register shall save the handle references to the IoTHubClient, transport, waitingToSend list on `amqp_device_instance`.**]**
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_069: [**A copy of `config->deviceId` shall be saved into `device_state->device_id`**]**
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_070: [**If STRING_construct() fails, IoTHubTransport_AMQP_Common_Register shall fail and return NULL**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_071: [**`amqp_device_instance->device_handle` shall be set using device_create()**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_072: [**The configuration for device_create shall be set according to the authentication preferred by IOTHUB_DEVICE_CONFIG**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_073: [**If device_create() fails, IoTHubTransport_AMQP_Common_Register shall fail and return NULL**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_071: [**`amqp_device_instance->device_handle` shall be set using amqp_device_create()**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_072: [**The configuration for amqp_device_create shall be set according to the authentication preferred by IOTHUB_DEVICE_CONFIG**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_073: [**If amqp_device_create() fails, IoTHubTransport_AMQP_Common_Register shall fail and return NULL**]**
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_01_010: [** `IoTHubTransport_AMQP_Common_Register` shall create a new iothubtransportamqp_methods instance by calling `iothubtransportamqp_methods_create` while passing to it the the fully qualified domain name, the device Id, and optional module Id.**]**
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_01_011: [** If `iothubtransportamqp_methods_create` fails, `IoTHubTransport_AMQP_Common_Register` shall fail and return NULL**]**
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_074: [**IoTHubTransport_AMQP_Common_Register shall add the `amqp_device_instance` to `instance->registered_devices`**]**
@@ -283,8 +283,8 @@ This function enables the transport to notify the upper client layer of new mess
 
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_084: [**If `handle` is NULL, IoTHubTransport_AMQP_Common_Subscribe shall return a non-zero result**]**
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_085: [**If `amqp_device_instance` is not registered, IoTHubTransport_AMQP_Common_Subscribe shall return a non-zero result**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_086: [**device_subscribe_message() shall be invoked passing `on_message_received_callback`**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_087: [**If device_subscribe_message() fails, IoTHubTransport_AMQP_Common_Subscribe shall return a non-zero result**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_086: [**amqp_device_subscribe_message() shall be invoked passing `on_message_received_callback`**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_087: [**If amqp_device_subscribe_message() fails, IoTHubTransport_AMQP_Common_Subscribe shall return a non-zero result**]**
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_088: [**If no failures occur, IoTHubTransport_AMQP_Common_Subscribe shall return 0**]**
 
 
@@ -309,7 +309,7 @@ This function disables the notifications to the upper client layer of new messag
 
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_093: [**If `handle` is NULL, IoTHubTransport_AMQP_Common_Subscribe shall return**]**
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_094: [**If `amqp_device_instance` is not registered, IoTHubTransport_AMQP_Common_Subscribe shall return**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_095: [**device_unsubscribe_message() shall be invoked passing `amqp_device_instance->device_handle`**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_095: [**amqp_device_unsubscribe_message() shall be invoked passing `amqp_device_instance->device_handle`**]**
 
 
 ### IoTHubTransport_AMQP_Common_SendMessageDisposition
@@ -339,10 +339,10 @@ IOTHUB_CLIENT_RESULT IoTHubTransport_AMQP_Common_GetSendStatus(IOTHUB_DEVICE_HAN
 ```
 
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_096: [**If `handle` or `iotHubClientStatus` are NULL, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_INVALID_ARG**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_097: [**IoTHubTransport_AMQP_Common_GetSendStatus shall invoke device_get_send_status()**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_098: [**If device_get_send_status() fails, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_ERROR**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_099: [**If device_get_send_status() returns DEVICE_SEND_STATUS_BUSY, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_OK and status IOTHUB_CLIENT_SEND_STATUS_BUSY**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_100: [**If device_get_send_status() returns DEVICE_SEND_STATUS_IDLE, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_OK and status IOTHUB_CLIENT_SEND_STATUS_IDLE**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_097: [**IoTHubTransport_AMQP_Common_GetSendStatus shall invoke amqp_device_get_send_status()**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_098: [**If amqp_device_get_send_status() fails, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_ERROR**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_099: [**If amqp_device_get_send_status() returns DEVICE_SEND_STATUS_BUSY, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_OK and status IOTHUB_CLIENT_SEND_STATUS_BUSY**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_100: [**If amqp_device_get_send_status() returns DEVICE_SEND_STATUS_IDLE, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_OK and status IOTHUB_CLIENT_SEND_STATUS_IDLE**]**
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_109: [**If no failures occur, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_OK**]**
 
   
@@ -370,8 +370,8 @@ Summary of options:
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_101: [**If `handle`, `option` or `value` are NULL then IoTHubTransport_AMQP_Common_SetOption shall return IOTHUB_CLIENT_INVALID_ARG.**]**
 
 
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_102: [**If `option` is a device-specific option, it shall be saved and applied to each registered device using device_set_option()**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_103: [**If device_set_option() fails, IoTHubTransport_AMQP_Common_SetOption shall return IOTHUB_CLIENT_ERROR**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_102: [**If `option` is a device-specific option, it shall be saved and applied to each registered device using amqp_device_set_option()**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_103: [**If amqp_device_set_option() fails, IoTHubTransport_AMQP_Common_SetOption shall return IOTHUB_CLIENT_ERROR**]**
 
 Note: device-specific options: sas_token_lifetime, sas_token_refresh_time, cbs_request_timeout, event_send_timeout_in_secs
 
@@ -420,8 +420,8 @@ int IoTHubTransport_AMQP_Common_Subscribe_DeviceTwin(IOTHUB_DEVICE_HANDLE handle
 ```
 
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_131: [**If `handle` is NULL, `IoTHubTransport_AMQP_Common_Subscribe_DeviceTwin` shall fail and return non-zero.**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_134: [**device_subscribe_for_twin_updates() shall be invoked for the registered device, passing `on_device_twin_update_received_callback`**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_135: [**If device_subscribe_for_twin_updates() fails, `IoTHubTransport_AMQP_Common_Subscribe_DeviceTwin` shall fail and return non-zero.**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_134: [**amqp_device_subscribe_for_twin_updates() shall be invoked for the registered device, passing `on_device_twin_update_received_callback`**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_135: [**If amqp_device_subscribe_for_twin_updates() fails, `IoTHubTransport_AMQP_Common_Subscribe_DeviceTwin` shall fail and return non-zero.**]**
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_136: [**If no errors occur, `IoTHubTransport_AMQP_Common_Subscribe_DeviceTwin` shall return zero.**]**
 
 #### on_device_twin_update_received_callback
@@ -440,8 +440,8 @@ void IoTHubTransport_AMQP_Common_Unsubscribe_DeviceTwin(IOTHUB_DEVICE_HANDLE han
 ```
 
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_140: [**If `handle` is NULL, `IoTHubTransport_AMQP_Common_Unsubscribe_DeviceTwin` shall return.**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_142: [**device_unsubscribe_for_twin_updates() shall be invoked for the registered device**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_143: [**If `device_unsubscribe_for_twin_updates` fails, the error shall be ignored**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_142: [**amqp_device_unsubscribe_for_twin_updates() shall be invoked for the registered device**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_143: [**If `amqp_device_unsubscribe_for_twin_updates` fails, the error shall be ignored**]**
 
 
 ### IoTHubTransport_AMQP_Common_GetDeviceTwinAsync
@@ -451,9 +451,9 @@ IOTHUB_CLIENT_RESULT IoTHubTransport_AMQP_Common_GetDeviceTwinAsync(IOTHUB_DEVIC
 
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_154: [** If `handle` or `completionCallback` are NULL, `IoTHubTransport_AMQP_Common_GetDeviceTwinAsync` shall fail and return IOTHUB_CLIENT_INVALID_ARG **]**
 
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_155: [** device_get_twin_async() shall be invoked for the registered device, passing `on_device_get_twin_completed_callback`**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_155: [** amqp_device_get_twin_async() shall be invoked for the registered device, passing `on_device_get_twin_completed_callback`**]**
 
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_156: [** If device_get_twin_async() fails, `IoTHubTransport_AMQP_Common_GetDeviceTwinAsync` shall fail and return IOTHUB_CLIENT_ERROR **]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_156: [** If amqp_device_get_twin_async() fails, `IoTHubTransport_AMQP_Common_GetDeviceTwinAsync` shall fail and return IOTHUB_CLIENT_ERROR **]**
 
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_157: [** If no errors occur, `IoTHubTransport_AMQP_Common_GetDeviceTwinAsync` shall return IOTHUB_CLIENT_OK **]**
 
@@ -477,8 +477,8 @@ This function was introduced to be generic point for processing user requests, h
 
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_144: [**If `handle` or `iothub_item` are NULL, `IoTHubTransport_AMQP_Common_ProcessItem` shall fail and return IOTHUB_PROCESS_ERROR.**]**
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_145: [**If `item_type` is not IOTHUB_TYPE_DEVICE_TWIN, `IoTHubTransport_AMQP_Common_ProcessItem` shall fail and return IOTHUB_PROCESS_ERROR.**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_146: [**device_send_twin_update_async() shall be invoked passing `iothub_item->device_twin->report_data_handle` and `on_device_send_twin_update_complete_callback`**]**
-**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_147: [**If device_send_twin_update_async() fails, `IoTHubTransport_AMQP_Common_ProcessItem` shall fail and return IOTHUB_PROCESS_ERROR.**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_146: [**amqp_device_send_twin_update_async() shall be invoked passing `iothub_item->device_twin->report_data_handle` and `on_device_send_twin_update_complete_callback`**]**
+**SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_147: [**If amqp_device_send_twin_update_async() fails, `IoTHubTransport_AMQP_Common_ProcessItem` shall fail and return IOTHUB_PROCESS_ERROR.**]**
 **SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_150: [**If no errors occur, `IoTHubTransport_AMQP_Common_ProcessItem` shall return IOTHUB_PROCESS_OK.**]**
 
 

--- a/iothub_client/devdoc/requirement_docs/iothubtransport_amqp_device_requirements.md
+++ b/iothub_client/devdoc/requirement_docs/iothubtransport_amqp_device_requirements.md
@@ -93,27 +93,27 @@ typedef struct DEVICE_CONFIG_TAG
     ON_DEVICE_STATE_CHANGED on_state_changed_callback;
     void* on_state_changed_context;
     IOTHUB_AUTHORIZATION_HANDLE authorization_module;
-} DEVICE_CONFIG;
+} AMQP_DEVICE_CONFIG;
 
 typedef struct DEVICE_INSTANCE* DEVICE_HANDLE;
 
-extern DEVICE_HANDLE device_create(DEVICE_CONFIG* config);
-extern void device_destroy(DEVICE_HANDLE handle);
-extern int device_start_async(DEVICE_HANDLE handle, SESSION_HANDLE session_handle, CBS_HANDLE cbs_handle);
-extern int device_stop(DEVICE_HANDLE handle);
-extern void device_do_work(DEVICE_HANDLE handle);
-extern int device_send_event_async(DEVICE_HANDLE handle, IOTHUB_MESSAGE_LIST* message, ON_DEVICE_D2C_EVENT_SEND_COMPLETE on_device_d2c_event_send_complete_callback, void* context);
-extern int device_send_twin_update_async(DEVICE_HANDLE handle, CONSTBUFFER_HANDLE data, DEVICE_SEND_TWIN_UPDATE_COMPLETE_CALLBACK on_send_twin_update_complete_callback, void* context);
-extern int device_subscribe_for_twin_updates(DEVICE_HANDLE handle, DEVICE_TWIN_UPDATE_RECEIVED_CALLBACK on_device_twin_update_received_callback, void* context);
-extern int device_unsubscribe_for_twin_updates(DEVICE_HANDLE handle);
-extern int device_get_twin_async(AMQP_DEVICE_HANDLE handle, DEVICE_TWIN_UPDATE_RECEIVED_CALLBACK on_device_get_twin_completed_callback, void* context);
-extern int device_get_send_status(DEVICE_HANDLE handle, DEVICE_SEND_STATUS *send_status);
-extern int device_subscribe_message(DEVICE_HANDLE handle, ON_DEVICE_C2D_MESSAGE_RECEIVED on_message_received_callback, void* context);
-extern int device_unsubscribe_message(DEVICE_HANDLE handle);
-extern int device_send_message_disposition(DEVICE_HANDLE device_handle, DEVICE_MESSAGE_DISPOSITION_INFO* disposition_info, DEVICE_MESSAGE_DISPOSITION_RESULT disposition_result);
-extern int device_set_retry_policy(DEVICE_HANDLE handle, IOTHUB_CLIENT_RETRY_POLICY policy, size_t retry_timeout_limit_in_seconds);
-extern int device_set_option(DEVICE_HANDLE handle, const char* name, void* value);
-extern OPTIONHANDLER_HANDLE device_retrieve_options(DEVICE_HANDLE handle);
+extern DEVICE_HANDLE amqp_device_create(AMQP_DEVICE_CONFIG* config);
+extern void amqp_device_destroy(DEVICE_HANDLE handle);
+extern int amqp_device_start_async(DEVICE_HANDLE handle, SESSION_HANDLE session_handle, CBS_HANDLE cbs_handle);
+extern int amqp_device_stop(DEVICE_HANDLE handle);
+extern void amqp_device_do_work(DEVICE_HANDLE handle);
+extern int amqp_device_send_event_async(DEVICE_HANDLE handle, IOTHUB_MESSAGE_LIST* message, ON_DEVICE_D2C_EVENT_SEND_COMPLETE on_device_d2c_event_send_complete_callback, void* context);
+extern int amqp_device_send_twin_update_async(DEVICE_HANDLE handle, CONSTBUFFER_HANDLE data, DEVICE_SEND_TWIN_UPDATE_COMPLETE_CALLBACK on_send_twin_update_complete_callback, void* context);
+extern int amqp_device_subscribe_for_twin_updates(DEVICE_HANDLE handle, DEVICE_TWIN_UPDATE_RECEIVED_CALLBACK on_device_twin_update_received_callback, void* context);
+extern int amqp_device_unsubscribe_for_twin_updates(DEVICE_HANDLE handle);
+extern int amqp_device_get_twin_async(AMQP_DEVICE_HANDLE handle, DEVICE_TWIN_UPDATE_RECEIVED_CALLBACK on_device_get_twin_completed_callback, void* context);
+extern int amqp_device_get_send_status(DEVICE_HANDLE handle, DEVICE_SEND_STATUS *send_status);
+extern int amqp_device_subscribe_message(DEVICE_HANDLE handle, ON_DEVICE_C2D_MESSAGE_RECEIVED on_message_received_callback, void* context);
+extern int amqp_device_unsubscribe_message(DEVICE_HANDLE handle);
+extern int amqp_device_send_message_disposition(DEVICE_HANDLE device_handle, DEVICE_MESSAGE_DISPOSITION_INFO* disposition_info, DEVICE_MESSAGE_DISPOSITION_RESULT disposition_result);
+extern int amqp_device_set_retry_policy(DEVICE_HANDLE handle, IOTHUB_CLIENT_RETRY_POLICY policy, size_t retry_timeout_limit_in_seconds);
+extern int amqp_device_set_option(DEVICE_HANDLE handle, const char* name, void* value);
+extern OPTIONHANDLER_HANDLE amqp_device_retrieve_options(DEVICE_HANDLE handle);
 
 ```
 
@@ -121,65 +121,65 @@ Note: `instance` refers to the structure that holds the current state and contro
 In each function (other than amqp_device_create) it shall derive from the AMQP_DEVICE_HANDLE handle passed as argument.
 
 
-### device_create
+### amqp_device_create
 
 ```c
-extern DEVICE_HANDLE device_create(DEVICE_CONFIG config);
+extern DEVICE_HANDLE amqp_device_create(AMQP_DEVICE_CONFIG config);
 ```
 
-**SRS_DEVICE_09_001: [**If `config`, `authorization_module` or `iothub_host_fqdn` or on_state_changed_callback are NULL then device_create shall fail and return NULL**]**
-**SRS_DEVICE_09_002: [**device_create shall allocate memory for the device instance structure**]**
-**SRS_DEVICE_09_003: [**If malloc fails, device_create shall fail and return NULL**]**
+**SRS_DEVICE_09_001: [**If `config`, `authorization_module` or `iothub_host_fqdn` or on_state_changed_callback are NULL then amqp_device_create shall fail and return NULL**]**
+**SRS_DEVICE_09_002: [**amqp_device_create shall allocate memory for the device instance structure**]**
+**SRS_DEVICE_09_003: [**If malloc fails, amqp_device_create shall fail and return NULL**]**
 **SRS_DEVICE_09_004: [**All `config` parameters shall be saved into `instance`**]**
-**SRS_DEVICE_09_005: [**If any `config` parameters fail to be saved into `instance`, device_create shall fail and return NULL**]**
+**SRS_DEVICE_09_005: [**If any `config` parameters fail to be saved into `instance`, amqp_device_create shall fail and return NULL**]**
 **SRS_DEVICE_09_006: [**If `instance->authentication_mode` is DEVICE_AUTH_MODE_CBS, `instance->authentication_handle` shall be set using authentication_create()**]**
-**SRS_DEVICE_09_007: [**If the AUTHENTICATION_HANDLE fails to be created, device_create shall fail and return NULL**]**
+**SRS_DEVICE_09_007: [**If the AUTHENTICATION_HANDLE fails to be created, amqp_device_create shall fail and return NULL**]**
 **SRS_DEVICE_09_008: [**`instance->messenger_handle` shall be set using telemetry_messenger_create()**]**
-**SRS_DEVICE_09_009: [**If the MESSENGER_HANDLE fails to be created, device_create shall fail and return NULL**]**
+**SRS_DEVICE_09_009: [**If the MESSENGER_HANDLE fails to be created, amqp_device_create shall fail and return NULL**]**
 
 **SRS_DEVICE_09_122: [**`instance->twin_messenger_handle` shall be set using twin_messenger_create()**]**
-**SRS_DEVICE_09_123: [**If the TWIN_MESSENGER_HANDLE fails to be created, device_create shall fail and return NULL**]**
+**SRS_DEVICE_09_123: [**If the TWIN_MESSENGER_HANDLE fails to be created, amqp_device_create shall fail and return NULL**]**
 
-**SRS_DEVICE_09_010: [**If device_create fails it shall release all memory it has allocated**]**
-**SRS_DEVICE_09_011: [**If device_create succeeds it shall return a handle to its `instance` structure**]**
+**SRS_DEVICE_09_010: [**If amqp_device_create fails it shall release all memory it has allocated**]**
+**SRS_DEVICE_09_011: [**If amqp_device_create succeeds it shall return a handle to its `instance` structure**]**
 
 
-### device_destroy
+### amqp_device_destroy
 
 ```c
-extern void device_destroy(DEVICE_HANDLE handle);
+extern void amqp_device_destroy(DEVICE_HANDLE handle);
 ```
 
-**SRS_DEVICE_09_012: [**If `handle` is NULL, device_destroy shall return**]**
-**SRS_DEVICE_09_013: [**If the device is in state DEVICE_STATE_STARTED or DEVICE_STATE_STARTING, device_stop() shall be invoked**]**
+**SRS_DEVICE_09_012: [**If `handle` is NULL, amqp_device_destroy shall return**]**
+**SRS_DEVICE_09_013: [**If the device is in state DEVICE_STATE_STARTED or DEVICE_STATE_STARTING, amqp_device_stop() shall be invoked**]**
 **SRS_DEVICE_09_014: [**`instance->messenger_handle shall be destroyed using telemetry_messenger_destroy()`**]**
 **SRS_DEVICE_09_015: [**If created, `instance->authentication_handle` shall be destroyed using authentication_destroy()`**]**
 **SRS_DEVICE_09_016: [**The contents of `instance->config` shall be detroyed and then it shall be freed**]**
 
 
-### device_start_async
+### amqp_device_start_async
 
 ```c
-extern int device_start_async(DEVICE_HANDLE handle, SESSION_HANDLE session_handle, CBS_HANDLE cbs_handle);
+extern int amqp_device_start_async(DEVICE_HANDLE handle, SESSION_HANDLE session_handle, CBS_HANDLE cbs_handle);
 ```
 
-**SRS_DEVICE_09_017: [**If `handle` is NULL, device_start_async shall return a non-zero result**]**
-**SRS_DEVICE_09_018: [**If the device state is not DEVICE_STATE_STOPPED, device_start_async shall return a non-zero result**]**
-**SRS_DEVICE_09_019: [**If `session_handle` is NULL, device_start_async shall return a non-zero result**]**
-**SRS_DEVICE_09_020: [**If using CBS authentication and `cbs_handle` is NULL, device_start_async shall return a non-zero result**]**
+**SRS_DEVICE_09_017: [**If `handle` is NULL, amqp_device_start_async shall return a non-zero result**]**
+**SRS_DEVICE_09_018: [**If the device state is not DEVICE_STATE_STOPPED, amqp_device_start_async shall return a non-zero result**]**
+**SRS_DEVICE_09_019: [**If `session_handle` is NULL, amqp_device_start_async shall return a non-zero result**]**
+**SRS_DEVICE_09_020: [**If using CBS authentication and `cbs_handle` is NULL, amqp_device_start_async shall return a non-zero result**]**
 **SRS_DEVICE_09_021: [**`session_handle` and `cbs_handle` shall be saved into the `instance`**]**
 **SRS_DEVICE_09_022: [**The device state shall be updated to DEVICE_STATE_STARTING, and state changed callback invoked**]**
-**SRS_DEVICE_09_023: [**If no failures occur, device_start_async shall return 0**]**
+**SRS_DEVICE_09_023: [**If no failures occur, amqp_device_start_async shall return 0**]**
 
 
-### device_stop
+### amqp_device_stop
 
 ```c
-extern int device_stop(DEVICE_HANDLE handle);
+extern int amqp_device_stop(DEVICE_HANDLE handle);
 ```
 
-**SRS_DEVICE_09_024: [**If `handle` is NULL, device_stop shall return a non-zero result**]**
-**SRS_DEVICE_09_025: [**If the device state is already DEVICE_STATE_STOPPED or DEVICE_STATE_STOPPING, device_stop shall return a non-zero result**]**
+**SRS_DEVICE_09_024: [**If `handle` is NULL, amqp_device_stop shall return a non-zero result**]**
+**SRS_DEVICE_09_025: [**If the device state is already DEVICE_STATE_STOPPED or DEVICE_STATE_STOPPING, amqp_device_stop shall return a non-zero result**]**
 **SRS_DEVICE_09_026: [**The device state shall be updated to DEVICE_STATE_STOPPING, and state changed callback invoked**]**
 **SRS_DEVICE_09_027: [**If `instance->messenger_handle` state is not TELEMETRY_MESSENGER_STATE_STOPPED, telemetry_messenger_stop shall be invoked**]**
 **SRS_DEVICE_09_028: [**If telemetry_messenger_stop fails, the `instance` state shall be updated to DEVICE_STATE_ERROR_MSG and the function shall return non-zero result**]**
@@ -188,16 +188,16 @@ extern int device_stop(DEVICE_HANDLE handle);
 **SRS_DEVICE_09_029: [**If CBS authentication is used, if `instance->authentication_handle` state is not AUTHENTICATION_STATE_STOPPED, authentication_stop shall be invoked**]**
 **SRS_DEVICE_09_030: [**If authentication_stop fails, the `instance` state shall be updated to DEVICE_STATE_ERROR_AUTH and the function shall return non-zero result**]**
 **SRS_DEVICE_09_031: [**The device state shall be updated to DEVICE_STATE_STOPPED, and state changed callback invoked**]**
-**SRS_DEVICE_09_032: [**If no failures occur, device_stop shall return 0**]**
+**SRS_DEVICE_09_032: [**If no failures occur, amqp_device_stop shall return 0**]**
 
 
-### device_do_work
+### amqp_device_do_work
 
 ```c
-extern void device_do_work(DEVICE_HANDLE handle);
+extern void amqp_device_do_work(DEVICE_HANDLE handle);
 ```
 
-**SRS_DEVICE_09_033: [**If `handle` is NULL, device_do_work shall return**]**
+**SRS_DEVICE_09_033: [**If `handle` is NULL, amqp_device_do_work shall return**]**
 
 #### device state DEVICE_STATE_STARTING
 
@@ -244,20 +244,20 @@ extern void device_do_work(DEVICE_HANDLE handle);
 **SRS_DEVICE_09_134: [**If `instance->twin_messenger_handle` state is not STOPPED or ERROR, twin_messenger_do_work shall be invoked**]**
 
 
-### device_send_event_async
+### amqp_device_send_event_async
 
 ```c
-extern int device_send_event_async(DEVICE_HANDLE handle, IOTHUB_MESSAGE_LIST* message, ON_DEVICE_D2C_EVENT_SEND_COMPLETE on_device_d2c_event_send_complete_callback, void* context);
+extern int amqp_device_send_event_async(DEVICE_HANDLE handle, IOTHUB_MESSAGE_LIST* message, ON_DEVICE_D2C_EVENT_SEND_COMPLETE on_device_d2c_event_send_complete_callback, void* context);
 ```
 
-**SRS_DEVICE_09_051: [**If `handle` are `message` are NULL, device_send_event_async shall return a non-zero result**]**
+**SRS_DEVICE_09_051: [**If `handle` are `message` are NULL, amqp_device_send_event_async shall return a non-zero result**]**
 **SRS_DEVICE_09_052: [**A structure (`send_task`) shall be created to track the send state of the message**]**
-**SRS_DEVICE_09_053: [**If `send_task` fails to be created, device_send_event_async shall return a non-zero value**]**
+**SRS_DEVICE_09_053: [**If `send_task` fails to be created, amqp_device_send_event_async shall return a non-zero value**]**
 **SRS_DEVICE_09_054: [**`send_task` shall contain the user callback and the context provided**]**
 **SRS_DEVICE_09_055: [**The message shall be sent using telemetry_messenger_send_async, passing `on_event_send_complete_messenger_callback` and `send_task`**]**
-**SRS_DEVICE_09_056: [**If telemetry_messenger_send_async fails, device_send_event_async shall return a non-zero value**]**
-**SRS_DEVICE_09_057: [**If any failures occur, device_send_event_async shall release all memory it has allocated**]**
-**SRS_DEVICE_09_058: [**If no failures occur, device_send_event_async shall return 0**]**
+**SRS_DEVICE_09_056: [**If telemetry_messenger_send_async fails, amqp_device_send_event_async shall return a non-zero value**]**
+**SRS_DEVICE_09_057: [**If any failures occur, amqp_device_send_event_async shall release all memory it has allocated**]**
+**SRS_DEVICE_09_058: [**If no failures occur, amqp_device_send_event_async shall return 0**]**
 
 
 #### on_event_send_complete_messenger_callback
@@ -275,22 +275,22 @@ static void on_event_send_complete_messenger_callback(IOTHUB_MESSAGE_LIST* iothu
 **SRS_DEVICE_09_065: [**The memory allocated for `send_task` shall be released**]**
 
 
-### device_send_twin_update_async
+### amqp_device_send_twin_update_async
 ```c
-extern int device_send_twin_update_async(DEVICE_HANDLE handle, CONSTBUFFER_HANDLE data, DEVICE_SEND_TWIN_UPDATE_COMPLETE_CALLBACK on_send_twin_update_complete_callback, void* context);
+extern int amqp_device_send_twin_update_async(DEVICE_HANDLE handle, CONSTBUFFER_HANDLE data, DEVICE_SEND_TWIN_UPDATE_COMPLETE_CALLBACK on_send_twin_update_complete_callback, void* context);
 ```
 
-**SRS_DEVICE_09_135: [**If `handle` or `data` are NULL, device_send_twin_update_async shall return a non-zero result**]**
+**SRS_DEVICE_09_135: [**If `handle` or `data` are NULL, amqp_device_send_twin_update_async shall return a non-zero result**]**
 
 **SRS_DEVICE_09_136: [**A structure (`twin_ctx`) shall be created to track the send state of the twin report**]**
 
-**SRS_DEVICE_09_137: [**If `twin_ctx` fails to be created, device_send_twin_update_async shall return a non-zero value**]**
+**SRS_DEVICE_09_137: [**If `twin_ctx` fails to be created, amqp_device_send_twin_update_async shall return a non-zero value**]**
 
 **SRS_DEVICE_09_138: [**The twin report shall be sent using twin_messenger_report_state_async, passing `on_report_state_complete_callback` and `twin_ctx`**]**
 
-**SRS_DEVICE_09_139: [**If twin_messenger_report_state_async fails, device_send_twin_update_async shall return a non-zero value**]**
+**SRS_DEVICE_09_139: [**If twin_messenger_report_state_async fails, amqp_device_send_twin_update_async shall return a non-zero value**]**
 
-**SRS_DEVICE_09_140: [**If no failures occur, device_send_twin_update_async shall return 0**]**
+**SRS_DEVICE_09_140: [**If no failures occur, amqp_device_send_twin_update_async shall return 0**]**
 
 
 #### on_report_state_complete_callback
@@ -304,18 +304,18 @@ static void on_report_state_complete_callback(TWIN_REPORT_STATE_RESULT result, T
 
 
 
-### device_subscribe_for_twin_updates
+### amqp_device_subscribe_for_twin_updates
 ```c
-extern int device_subscribe_for_twin_updates(DEVICE_HANDLE handle, DEVICE_TWIN_UPDATE_RECEIVED_CALLBACK on_device_twin_update_received_callback, void* context);
+extern int amqp_device_subscribe_for_twin_updates(DEVICE_HANDLE handle, DEVICE_TWIN_UPDATE_RECEIVED_CALLBACK on_device_twin_update_received_callback, void* context);
 ```
 
-**SRS_DEVICE_09_143: [**If `handle` or `on_device_twin_update_received_callback` are NULL, device_subscribe_for_twin_updates shall return a non-zero result**]**
+**SRS_DEVICE_09_143: [**If `handle` or `on_device_twin_update_received_callback` are NULL, amqp_device_subscribe_for_twin_updates shall return a non-zero result**]**
 
 **SRS_DEVICE_09_144: [**twin_messenger_subscribe shall be invoked passing `on_twin_state_update_callback`**]**
 
-**SRS_DEVICE_09_145: [**If twin_messenger_subscribe fails, device_subscribe_for_twin_updates shall return a non-zero value**]**
+**SRS_DEVICE_09_145: [**If twin_messenger_subscribe fails, amqp_device_subscribe_for_twin_updates shall return a non-zero value**]**
 
-**SRS_DEVICE_09_146: [**If no failures occur, device_subscribe_for_twin_updates shall return 0**]**
+**SRS_DEVICE_09_146: [**If no failures occur, amqp_device_subscribe_for_twin_updates shall return 0**]**
 
 
 #### on_twin_state_update_callback
@@ -326,44 +326,44 @@ static void on_twin_state_update_callback(TWIN_UPDATE_TYPE update_type, const ch
 **SRS_DEVICE_09_151: [**on_device_twin_update_received_callback (provided by user) shall be invoked passing the corresponding update type, `payload` and `size`**]**
 
 
-### device_unsubscribe_for_twin_updates
+### amqp_device_unsubscribe_for_twin_updates
 ```c
-extern int device_unsubscribe_for_twin_updates(DEVICE_HANDLE handle);
+extern int amqp_device_unsubscribe_for_twin_updates(DEVICE_HANDLE handle);
 ```
 
-**SRS_DEVICE_09_147: [**If `handle` is NULL, device_unsubscribe_for_twin_updates shall return a non-zero result**]**
+**SRS_DEVICE_09_147: [**If `handle` is NULL, amqp_device_unsubscribe_for_twin_updates shall return a non-zero result**]**
 
 **SRS_DEVICE_09_148: [**twin_messenger_unsubscribe shall be invoked passing `on_twin_state_update_callback`**]**
 
-**SRS_DEVICE_09_149: [**If twin_messenger_unsubscribe fails, device_unsubscribe_for_twin_updates shall return a non-zero value**]**
+**SRS_DEVICE_09_149: [**If twin_messenger_unsubscribe fails, amqp_device_unsubscribe_for_twin_updates shall return a non-zero value**]**
 
-**SRS_DEVICE_09_150: [**If no failures occur, device_unsubscribe_for_twin_updates shall return 0**]**
+**SRS_DEVICE_09_150: [**If no failures occur, amqp_device_unsubscribe_for_twin_updates shall return 0**]**
 
 
-### device_get_twin_async
+### amqp_device_get_twin_async
 ```c
-extern int device_get_twin_async(AMQP_DEVICE_HANDLE handle, DEVICE_TWIN_UPDATE_RECEIVED_CALLBACK on_device_get_twin_completed_callback, void* context);
+extern int amqp_device_get_twin_async(AMQP_DEVICE_HANDLE handle, DEVICE_TWIN_UPDATE_RECEIVED_CALLBACK on_device_get_twin_completed_callback, void* context);
 ```
 
-**SRS_DEVICE_09_152: [**If `handle` or `on_device_get_twin_completed_callback` are NULL, device_get_twin_async shall return a non-zero result**]**
+**SRS_DEVICE_09_152: [**If `handle` or `on_device_get_twin_completed_callback` are NULL, amqp_device_get_twin_async shall return a non-zero result**]**
 
 **SRS_DEVICE_09_153: [**twin_messenger_get_twin_async shall be invoked **]**
 
-**SRS_DEVICE_09_154: [**If twin_messenger_get_twin_async fails, device_get_twin_async shall return a non-zero value**]**
+**SRS_DEVICE_09_154: [**If twin_messenger_get_twin_async fails, amqp_device_get_twin_async shall return a non-zero value**]**
 
-**SRS_DEVICE_09_155: [**If no failures occur, device_get_twin_async shall return 0**]**
+**SRS_DEVICE_09_155: [**If no failures occur, amqp_device_get_twin_async shall return 0**]**
 
 
-### device_subscribe_message
+### amqp_device_subscribe_message
 
 ```c
-extern int device_subscribe_message(DEVICE_HANDLE handle, ON_DEVICE_C2D_MESSAGE_RECEIVED on_message_received_callback, void* context);
+extern int amqp_device_subscribe_message(DEVICE_HANDLE handle, ON_DEVICE_C2D_MESSAGE_RECEIVED on_message_received_callback, void* context);
 ```
 
-**SRS_DEVICE_09_066: [**If `handle` or `on_message_received_callback` or `context` is NULL, device_subscribe_message shall return a non-zero result**]**
+**SRS_DEVICE_09_066: [**If `handle` or `on_message_received_callback` or `context` is NULL, amqp_device_subscribe_message shall return a non-zero result**]**
 **SRS_DEVICE_09_067: [**telemetry_messenger_subscribe_for_messages shall be invoked passing `on_messenger_message_received_callback` and the user callback and context**]**
-**SRS_DEVICE_09_068: [**If telemetry_messenger_subscribe_for_messages fails, device_subscribe_message shall return a non-zero result**]**
-**SRS_DEVICE_09_069: [**If no failures occur, device_subscribe_message shall return 0**]**
+**SRS_DEVICE_09_068: [**If telemetry_messenger_subscribe_for_messages fails, amqp_device_subscribe_message shall return a non-zero result**]**
+**SRS_DEVICE_09_069: [**If no failures occur, amqp_device_subscribe_message shall return 0**]**
 
 
 #### on_messenger_message_received_callback
@@ -387,105 +387,105 @@ static TELEMETRY_MESSENGER_DISPOSITION_RESULT on_messenger_message_received_call
 
 
 
-### device_unsubscribe_message
+### amqp_device_unsubscribe_message
 
 ```c
-extern int device_unsubscribe_message(DEVICE_HANDLE handle);
+extern int amqp_device_unsubscribe_message(DEVICE_HANDLE handle);
 ```
 
-**SRS_DEVICE_09_076: [**If `handle` is NULL, device_unsubscribe_message shall return a non-zero result**]**
+**SRS_DEVICE_09_076: [**If `handle` is NULL, amqp_device_unsubscribe_message shall return a non-zero result**]**
 **SRS_DEVICE_09_077: [**telemetry_messenger_unsubscribe_for_messages shall be invoked passing `instance->messenger_handle`**]**
-**SRS_DEVICE_09_078: [**If telemetry_messenger_unsubscribe_for_messages fails, device_unsubscribe_message shall return a non-zero result**]**
-**SRS_DEVICE_09_079: [**If no failures occur, device_unsubscribe_message shall return 0**]**
+**SRS_DEVICE_09_078: [**If telemetry_messenger_unsubscribe_for_messages fails, amqp_device_unsubscribe_message shall return a non-zero result**]**
+**SRS_DEVICE_09_079: [**If no failures occur, amqp_device_unsubscribe_message shall return 0**]**
 
 
-## device_send_message_disposition
+## amqp_device_send_message_disposition
 ```c
-extern int device_send_message_disposition(DEVICE_HANDLE device_handle, DEVICE_MESSAGE_DISPOSITION_INFO* disposition_info, DEVICE_MESSAGE_DISPOSITION_RESULT disposition_result);
+extern int amqp_device_send_message_disposition(DEVICE_HANDLE device_handle, DEVICE_MESSAGE_DISPOSITION_INFO* disposition_info, DEVICE_MESSAGE_DISPOSITION_RESULT disposition_result);
 ```
 
-**SRS_DEVICE_09_111: [**If `device_handle` or `disposition_info` are NULL, device_send_message_disposition() shall fail and return MU_FAILURE**]**
+**SRS_DEVICE_09_111: [**If `device_handle` or `disposition_info` are NULL, amqp_device_send_message_disposition() shall fail and return MU_FAILURE**]**
 
-**SRS_DEVICE_09_112: [**If `disposition_info->source` is NULL, device_send_message_disposition() shall fail and return MU_FAILURE**]**
+**SRS_DEVICE_09_112: [**If `disposition_info->source` is NULL, amqp_device_send_message_disposition() shall fail and return MU_FAILURE**]**
 
 **SRS_DEVICE_09_113: [**A TELEMETRY_MESSENGER_MESSAGE_DISPOSITION_INFO instance shall be created with a copy of the `source` and `message_id` contained in `disposition_info`**]**
 
-**SRS_DEVICE_09_114: [**If the TELEMETRY_MESSENGER_MESSAGE_DISPOSITION_INFO fails to be created, device_send_message_disposition() shall fail and return MU_FAILURE**]**
+**SRS_DEVICE_09_114: [**If the TELEMETRY_MESSENGER_MESSAGE_DISPOSITION_INFO fails to be created, amqp_device_send_message_disposition() shall fail and return MU_FAILURE**]**
 
 **SRS_DEVICE_09_115: [**`telemetry_messenger_send_message_disposition()` shall be invoked passing the TELEMETRY_MESSENGER_MESSAGE_DISPOSITION_INFO instance and the corresponding TELEMETRY_MESSENGER_DISPOSITION_RESULT**]**
 
-**SRS_DEVICE_09_116: [**If `telemetry_messenger_send_message_disposition()` fails, device_send_message_disposition() shall fail and return MU_FAILURE**]**
+**SRS_DEVICE_09_116: [**If `telemetry_messenger_send_message_disposition()` fails, amqp_device_send_message_disposition() shall fail and return MU_FAILURE**]**
 
-**SRS_DEVICE_09_117: [**device_send_message_disposition() shall destroy the TELEMETRY_MESSENGER_MESSAGE_DISPOSITION_INFO instance**]**
+**SRS_DEVICE_09_117: [**amqp_device_send_message_disposition() shall destroy the TELEMETRY_MESSENGER_MESSAGE_DISPOSITION_INFO instance**]**
 
-**SRS_DEVICE_09_118: [**If no failures occurr, device_send_message_disposition() shall return 0**]**
+**SRS_DEVICE_09_118: [**If no failures occurr, amqp_device_send_message_disposition() shall return 0**]**
 
 
-### device_set_retry_policy
+### amqp_device_set_retry_policy
 
 ```c
-extern int device_set_retry_policy(DEVICE_HANDLE handle, IOTHUB_CLIENT_RETRY_POLICY policy, size_t retry_timeout_limit_in_seconds);
+extern int amqp_device_set_retry_policy(DEVICE_HANDLE handle, IOTHUB_CLIENT_RETRY_POLICY policy, size_t retry_timeout_limit_in_seconds);
 ```
 
 Note: this API is not currently implemented or supported.
 
-**SRS_DEVICE_09_080: [**If `handle` is NULL, device_set_retry_policy shall return a non-zero result**]**
-**SRS_DEVICE_09_081: [**device_set_retry_policy shall return a non-zero result**]**
+**SRS_DEVICE_09_080: [**If `handle` is NULL, amqp_device_set_retry_policy shall return a non-zero result**]**
+**SRS_DEVICE_09_081: [**amqp_device_set_retry_policy shall return a non-zero result**]**
 
 
-### device_set_option
+### amqp_device_set_option
 
 ```c
-extern int device_set_option(DEVICE_HANDLE handle, const char* name, void* value);
+extern int amqp_device_set_option(DEVICE_HANDLE handle, const char* name, void* value);
 ```
 
-**SRS_DEVICE_09_082: [**If `handle` or `name` or `value` are NULL, device_set_option shall return a non-zero result**]**
-**SRS_DEVICE_09_083: [**If `name` refers to authentication but CBS authentication is not used, device_set_option shall return a non-zero result**]**
+**SRS_DEVICE_09_082: [**If `handle` or `name` or `value` are NULL, amqp_device_set_option shall return a non-zero result**]**
+**SRS_DEVICE_09_083: [**If `name` refers to authentication but CBS authentication is not used, amqp_device_set_option shall return a non-zero result**]**
 **SRS_DEVICE_09_084: [**If `name` refers to authentication, it shall be passed along with `value` to authentication_set_option**]**
-**SRS_DEVICE_09_085: [**If authentication_set_option fails, device_set_option shall return a non-zero result**]**
+**SRS_DEVICE_09_085: [**If authentication_set_option fails, amqp_device_set_option shall return a non-zero result**]**
 **SRS_DEVICE_09_086: [**If `name` refers to messenger module, it shall be passed along with `value` to telemetry_messenger_set_option**]**
-**SRS_DEVICE_09_087: [**If telemetry_messenger_set_option fails, device_set_option shall return a non-zero result**]**
-**SRS_DEVICE_09_088: [**If `name` is DEVICE_OPTION_SAVED_AUTH_OPTIONS but CBS authentication is not being used, device_set_option shall return a non-zero result**]**
+**SRS_DEVICE_09_087: [**If telemetry_messenger_set_option fails, amqp_device_set_option shall return a non-zero result**]**
+**SRS_DEVICE_09_088: [**If `name` is DEVICE_OPTION_SAVED_AUTH_OPTIONS but CBS authentication is not being used, amqp_device_set_option shall return a non-zero result**]**
 **SRS_DEVICE_09_089: [**If `name` is DEVICE_OPTION_SAVED_MESSENGER_OPTIONS, `value` shall be fed to `instance->messenger_handle` using OptionHandler_FeedOptions**]**
 **SRS_DEVICE_09_090: [**If `name` is DEVICE_OPTION_SAVED_OPTIONS, `value` shall be fed to `instance` using OptionHandler_FeedOptions**]**
-**SRS_DEVICE_09_091: [**If any call to OptionHandler_FeedOptions fails, device_set_option shall return a non-zero result**]**
-**SRS_DEVICE_09_092: [**If no failures occur, device_set_option shall return 0**]**
+**SRS_DEVICE_09_091: [**If any call to OptionHandler_FeedOptions fails, amqp_device_set_option shall return a non-zero result**]**
+**SRS_DEVICE_09_092: [**If no failures occur, amqp_device_set_option shall return 0**]**
 
 Note:
 - Authentication-related options: DEVICE_OPTION_CBS_REQUEST_TIMEOUT_SECS, DEVICE_OPTION_SAS_TOKEN_REFRESH_TIME_SECS, DEVICE_OPTION_SAS_TOKEN_LIFETIME_SECS
 - Messenger-related options: DEVICE_OPTION_EVENT_SEND_TIMEOUT_SECS
 
 
-### device_retrieve_options
+### amqp_device_retrieve_options
 
 ```c
-extern OPTIONHANDLER_HANDLE device_retrieve_options(DEVICE_HANDLE handle);
+extern OPTIONHANDLER_HANDLE amqp_device_retrieve_options(DEVICE_HANDLE handle);
 ```
 
-**SRS_DEVICE_09_093: [**If `handle` is NULL, device_retrieve_options shall return NULL**]**
+**SRS_DEVICE_09_093: [**If `handle` is NULL, amqp_device_retrieve_options shall return NULL**]**
 
 **SRS_DEVICE_09_094: [**A OPTIONHANDLER_HANDLE instance, aka `options` shall be created using OptionHandler_Create**]**
-**SRS_DEVICE_09_095: [**If OptionHandler_Create fails, device_retrieve_options shall return NULL**]**
+**SRS_DEVICE_09_095: [**If OptionHandler_Create fails, amqp_device_retrieve_options shall return NULL**]**
 **SRS_DEVICE_09_096: [**If CBS authentication is used, `instance->authentication_handle` options shall be retrieved using authentication_retrieve_options**]**
-**SRS_DEVICE_09_097: [**If authentication_retrieve_options fails, device_retrieve_options shall return NULL**]**
+**SRS_DEVICE_09_097: [**If authentication_retrieve_options fails, amqp_device_retrieve_options shall return NULL**]**
 **SRS_DEVICE_09_098: [**The authentication options shall be added to `options` using OptionHandler_AddOption as DEVICE_OPTION_SAVED_AUTH_OPTIONS**]**
 **SRS_DEVICE_09_099: [**`instance->messenger_handle` options shall be retrieved using telemetry_messenger_retrieve_options**]**
-**SRS_DEVICE_09_100: [**If telemetry_messenger_retrieve_options fails, device_retrieve_options shall return NULL**]**
+**SRS_DEVICE_09_100: [**If telemetry_messenger_retrieve_options fails, amqp_device_retrieve_options shall return NULL**]**
 **SRS_DEVICE_09_101: [**The messenger options shall be added to `options` using OptionHandler_AddOption as DEVICE_OPTION_SAVED_MESSENGER_OPTIONS**]**
-**SRS_DEVICE_09_102: [**If any call to OptionHandler_AddOption fails, device_retrieve_options shall return NULL**]**
-**SRS_DEVICE_09_103: [**If any failure occurs, any memory allocated by device_retrieve_options shall be destroyed**]**
+**SRS_DEVICE_09_102: [**If any call to OptionHandler_AddOption fails, amqp_device_retrieve_options shall return NULL**]**
+**SRS_DEVICE_09_103: [**If any failure occurs, any memory allocated by amqp_device_retrieve_options shall be destroyed**]**
 **SRS_DEVICE_09_104: [**If no failures occur, a handle to `options` shall be return**]**
 
 
-### device_get_send_status
+### amqp_device_get_send_status
 
 ```c
-extern int device_get_send_status(DEVICE_HANDLE handle, DEVICE_SEND_STATUS *send_status);
+extern int amqp_device_get_send_status(DEVICE_HANDLE handle, DEVICE_SEND_STATUS *send_status);
 ```
 
-**SRS_DEVICE_09_105: [**If `handle` or `send_status` is NULL, device_get_send_status shall return a non-zero result**]**
+**SRS_DEVICE_09_105: [**If `handle` or `send_status` is NULL, amqp_device_get_send_status shall return a non-zero result**]**
 **SRS_DEVICE_09_106: [**The status of `instance->messenger_handle` shall be obtained using telemetry_messenger_get_send_status**]**
-**SRS_DEVICE_09_107: [**If telemetry_messenger_get_send_status fails, device_get_send_status shall return a non-zero result**]**
-**SRS_DEVICE_09_108: [**If telemetry_messenger_get_send_status returns TELEMETRY_MESSENGER_SEND_STATUS_IDLE, device_get_send_status return status DEVICE_SEND_STATUS_IDLE**]**
-**SRS_DEVICE_09_109: [**If telemetry_messenger_get_send_status returns TELEMETRY_MESSENGER_SEND_STATUS_BUSY, device_get_send_status return status DEVICE_SEND_STATUS_BUSY**]**
-**SRS_DEVICE_09_110: [**If device_get_send_status succeeds, it shall return zero as result**]**
+**SRS_DEVICE_09_107: [**If telemetry_messenger_get_send_status fails, amqp_device_get_send_status shall return a non-zero result**]**
+**SRS_DEVICE_09_108: [**If telemetry_messenger_get_send_status returns TELEMETRY_MESSENGER_SEND_STATUS_IDLE, amqp_device_get_send_status return status DEVICE_SEND_STATUS_IDLE**]**
+**SRS_DEVICE_09_109: [**If telemetry_messenger_get_send_status returns TELEMETRY_MESSENGER_SEND_STATUS_BUSY, amqp_device_get_send_status return status DEVICE_SEND_STATUS_BUSY**]**
+**SRS_DEVICE_09_110: [**If amqp_device_get_send_status succeeds, it shall return zero as result**]**

--- a/iothub_client/inc/internal/iothubtransport_amqp_device.h
+++ b/iothub_client/inc/internal/iothubtransport_amqp_device.h
@@ -17,7 +17,7 @@ extern "C"
 {
 #endif
 
-// @brief    name of option to apply the instance obtained using device_retrieve_options
+// @brief    name of option to apply the instance obtained using amqp_device_retrieve_options
 static const char* DEVICE_OPTION_SAVED_OPTIONS = "saved_device_options";
 static const char* DEVICE_OPTION_EVENT_SEND_TIMEOUT_SECS = "event_send_timeout_secs";
 static const char* DEVICE_OPTION_CBS_REQUEST_TIMEOUT_SECS = "cbs_request_timeout_secs";
@@ -102,27 +102,27 @@ typedef struct DEVICE_CONFIG_TAG
     // Auth module used to generating handle authorization
     // with either SAS Token, x509 Certs, and Device SAS Token
     IOTHUB_AUTHORIZATION_HANDLE authorization_module;
-} DEVICE_CONFIG;
+} AMQP_DEVICE_CONFIG;
 
 typedef struct AMQP_DEVICE_INSTANCE* AMQP_DEVICE_HANDLE;
 
-MOCKABLE_FUNCTION(, AMQP_DEVICE_HANDLE, device_create, DEVICE_CONFIG*, config);
-MOCKABLE_FUNCTION(, void, device_destroy, AMQP_DEVICE_HANDLE, handle);
-MOCKABLE_FUNCTION(, int, device_start_async, AMQP_DEVICE_HANDLE, handle, SESSION_HANDLE, session_handle, CBS_HANDLE, cbs_handle);
-MOCKABLE_FUNCTION(, int, device_stop, AMQP_DEVICE_HANDLE, handle);
-MOCKABLE_FUNCTION(, void, device_do_work, AMQP_DEVICE_HANDLE, handle);
-MOCKABLE_FUNCTION(, int, device_send_event_async, AMQP_DEVICE_HANDLE, handle, IOTHUB_MESSAGE_LIST*, message, ON_DEVICE_D2C_EVENT_SEND_COMPLETE, on_device_d2c_event_send_complete_callback, void*, context);
-MOCKABLE_FUNCTION(, int, device_send_twin_update_async, AMQP_DEVICE_HANDLE, handle, CONSTBUFFER_HANDLE, data, DEVICE_SEND_TWIN_UPDATE_COMPLETE_CALLBACK, on_send_twin_update_complete_callback, void*, context);
-MOCKABLE_FUNCTION(, int, device_subscribe_for_twin_updates, AMQP_DEVICE_HANDLE, handle, DEVICE_TWIN_UPDATE_RECEIVED_CALLBACK, on_device_twin_update_received_callback, void*, context);
-MOCKABLE_FUNCTION(, int, device_unsubscribe_for_twin_updates, AMQP_DEVICE_HANDLE, handle);
-MOCKABLE_FUNCTION(, int, device_get_twin_async, AMQP_DEVICE_HANDLE, handle, DEVICE_TWIN_UPDATE_RECEIVED_CALLBACK, on_device_get_twin_completed_callback, void*, context);
-MOCKABLE_FUNCTION(, int, device_get_send_status, AMQP_DEVICE_HANDLE, handle, DEVICE_SEND_STATUS*, send_status);
-MOCKABLE_FUNCTION(, int, device_subscribe_message, AMQP_DEVICE_HANDLE, handle, ON_DEVICE_C2D_MESSAGE_RECEIVED, on_message_received_callback, void*, context);
-MOCKABLE_FUNCTION(, int, device_unsubscribe_message, AMQP_DEVICE_HANDLE, handle);
-MOCKABLE_FUNCTION(, int, device_send_message_disposition, AMQP_DEVICE_HANDLE, AMQP_DEVICE_HANDLE, DEVICE_MESSAGE_DISPOSITION_INFO*, disposition_info, DEVICE_MESSAGE_DISPOSITION_RESULT, disposition_result);
-MOCKABLE_FUNCTION(, int, device_set_retry_policy, AMQP_DEVICE_HANDLE, handle, IOTHUB_CLIENT_RETRY_POLICY, policy, size_t, retry_timeout_limit_in_seconds);
-MOCKABLE_FUNCTION(, int, device_set_option, AMQP_DEVICE_HANDLE, handle, const char*, name, void*, value);
-MOCKABLE_FUNCTION(, OPTIONHANDLER_HANDLE, device_retrieve_options, AMQP_DEVICE_HANDLE, handle);
+MOCKABLE_FUNCTION(, AMQP_DEVICE_HANDLE, amqp_device_create, AMQP_DEVICE_CONFIG*, config);
+MOCKABLE_FUNCTION(, void, amqp_device_destroy, AMQP_DEVICE_HANDLE, handle);
+MOCKABLE_FUNCTION(, int, amqp_device_start_async, AMQP_DEVICE_HANDLE, handle, SESSION_HANDLE, session_handle, CBS_HANDLE, cbs_handle);
+MOCKABLE_FUNCTION(, int, amqp_device_stop, AMQP_DEVICE_HANDLE, handle);
+MOCKABLE_FUNCTION(, void, amqp_device_do_work, AMQP_DEVICE_HANDLE, handle);
+MOCKABLE_FUNCTION(, int, amqp_device_send_event_async, AMQP_DEVICE_HANDLE, handle, IOTHUB_MESSAGE_LIST*, message, ON_DEVICE_D2C_EVENT_SEND_COMPLETE, on_device_d2c_event_send_complete_callback, void*, context);
+MOCKABLE_FUNCTION(, int, amqp_device_send_twin_update_async, AMQP_DEVICE_HANDLE, handle, CONSTBUFFER_HANDLE, data, DEVICE_SEND_TWIN_UPDATE_COMPLETE_CALLBACK, on_send_twin_update_complete_callback, void*, context);
+MOCKABLE_FUNCTION(, int, amqp_device_subscribe_for_twin_updates, AMQP_DEVICE_HANDLE, handle, DEVICE_TWIN_UPDATE_RECEIVED_CALLBACK, on_device_twin_update_received_callback, void*, context);
+MOCKABLE_FUNCTION(, int, amqp_device_unsubscribe_for_twin_updates, AMQP_DEVICE_HANDLE, handle);
+MOCKABLE_FUNCTION(, int, amqp_device_get_twin_async, AMQP_DEVICE_HANDLE, handle, DEVICE_TWIN_UPDATE_RECEIVED_CALLBACK, on_device_get_twin_completed_callback, void*, context);
+MOCKABLE_FUNCTION(, int, amqp_device_get_send_status, AMQP_DEVICE_HANDLE, handle, DEVICE_SEND_STATUS*, send_status);
+MOCKABLE_FUNCTION(, int, amqp_device_subscribe_message, AMQP_DEVICE_HANDLE, handle, ON_DEVICE_C2D_MESSAGE_RECEIVED, on_message_received_callback, void*, context);
+MOCKABLE_FUNCTION(, int, amqp_device_unsubscribe_message, AMQP_DEVICE_HANDLE, handle);
+MOCKABLE_FUNCTION(, int, amqp_device_send_message_disposition, AMQP_DEVICE_HANDLE, AMQP_DEVICE_HANDLE, DEVICE_MESSAGE_DISPOSITION_INFO*, disposition_info, DEVICE_MESSAGE_DISPOSITION_RESULT, disposition_result);
+MOCKABLE_FUNCTION(, int, amqp_device_set_retry_policy, AMQP_DEVICE_HANDLE, handle, IOTHUB_CLIENT_RETRY_POLICY, policy, size_t, retry_timeout_limit_in_seconds);
+MOCKABLE_FUNCTION(, int, amqp_device_set_option, AMQP_DEVICE_HANDLE, handle, const char*, name, void*, value);
+MOCKABLE_FUNCTION(, OPTIONHANDLER_HANDLE, amqp_device_retrieve_options, AMQP_DEVICE_HANDLE, handle);
 
 
 #ifdef __cplusplus

--- a/iothub_client/tests/iothubtransport_amqp_common_ut/iothubtransport_amqp_common_ut.c
+++ b/iothub_client/tests/iothubtransport_amqp_common_ut/iothubtransport_amqp_common_ut.c
@@ -464,7 +464,7 @@ static void set_expected_calls_for_Create(IOTHUBTRANSPORT_CONFIG* transport_conf
 
 static void set_expected_calls_for_GetSendStatus(DEVICE_SEND_STATUS send_status)
 {
-    STRICT_EXPECTED_CALL(device_get_send_status(TEST_DEVICE_HANDLE, IGNORED_PTR_ARG))
+    STRICT_EXPECTED_CALL(amqp_device_get_send_status(TEST_DEVICE_HANDLE, IGNORED_PTR_ARG))
         .IgnoreArgument(2)
         .CopyOutArgumentBuffer(2, &send_status, sizeof(DEVICE_SEND_STATUS))
         .SetReturn(0);
@@ -532,7 +532,7 @@ static void set_expected_calls_for_SendMessageDisposition(IOTHUBMESSAGE_DISPOSIT
     }
 
     set_expected_calls_for_create_device_message_disposition_info();
-    STRICT_EXPECTED_CALL(device_send_message_disposition(TEST_DEVICE_HANDLE, IGNORED_PTR_ARG, device_disposition_result))
+    STRICT_EXPECTED_CALL(amqp_device_send_message_disposition(TEST_DEVICE_HANDLE, IGNORED_PTR_ARG, device_disposition_result))
         .IgnoreArgument(2);
 
     STRICT_EXPECTED_CALL(IoTHubMessage_Destroy(IGNORED_PTR_ARG)).IgnoreArgument_iotHubMessageHandle();
@@ -569,7 +569,7 @@ static void set_expected_calls_for_Register(IOTHUB_DEVICE_CONFIG* device_config,
         .SetReturn(TEST_DEVICE_ID_STRING_HANDLE);
     STRICT_EXPECTED_CALL(STRING_c_str(TEST_IOTHUB_HOST_FQDN_STRING_HANDLE))
         .SetReturn(TEST_IOTHUB_HOST_FQDN_CHAR_PTR);
-    EXPECTED_CALL(device_create(IGNORED_PTR_ARG));
+    EXPECTED_CALL(amqp_device_create(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(singlylinkedlist_get_head_item(TEST_REGISTERED_DEVICES_LIST))
         .SetReturn(NULL);
 
@@ -577,12 +577,12 @@ static void set_expected_calls_for_Register(IOTHUB_DEVICE_CONFIG* device_config,
     EXPECTED_CALL(iothubtransportamqp_methods_create(TEST_IOTHUB_HOST_FQDN_CHAR_PTR, device_config->deviceId, NULL));
 
     // replicate_device_options_to
-    STRICT_EXPECTED_CALL(device_set_option(TEST_DEVICE_HANDLE, DEVICE_OPTION_EVENT_SEND_TIMEOUT_SECS, IGNORED_PTR_ARG))
+    STRICT_EXPECTED_CALL(amqp_device_set_option(TEST_DEVICE_HANDLE, DEVICE_OPTION_EVENT_SEND_TIMEOUT_SECS, IGNORED_PTR_ARG))
         .IgnoreArgument(3);
 
     if (is_using_cbs)
     {
-        STRICT_EXPECTED_CALL(device_set_option(TEST_DEVICE_HANDLE, DEVICE_OPTION_CBS_REQUEST_TIMEOUT_SECS, IGNORED_PTR_ARG))
+        STRICT_EXPECTED_CALL(amqp_device_set_option(TEST_DEVICE_HANDLE, DEVICE_OPTION_CBS_REQUEST_TIMEOUT_SECS, IGNORED_PTR_ARG))
             .IgnoreArgument(3);
     }
 
@@ -606,7 +606,7 @@ static void set_expected_calls_for_Unregister(IOTHUB_DEVICE_HANDLE iothub_device
 
     STRICT_EXPECTED_CALL(iothubtransportamqp_methods_destroy(TEST_IOTHUBTRANSPORTAMQP_METHODS));
 
-    STRICT_EXPECTED_CALL(device_destroy(TEST_DEVICE_HANDLE));
+    STRICT_EXPECTED_CALL(amqp_device_destroy(TEST_DEVICE_HANDLE));
     STRICT_EXPECTED_CALL(STRING_delete(TEST_DEVICE_ID_STRING_HANDLE));
     EXPECTED_CALL(free(IGNORED_PTR_ARG));
 }
@@ -645,7 +645,7 @@ static void set_expected_calls_for_send_pending_events(PDLIST_ENTRY wts, int exp
         STRICT_EXPECTED_CALL(DList_IsListEmpty(wts));
         EXPECTED_CALL(DList_RemoveEntryList(IGNORED_PTR_ARG));
 
-        STRICT_EXPECTED_CALL(device_send_event_async(TEST_DEVICE_HANDLE, TEST_IOTHUB_MESSAGE_LIST_HANDLE, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        STRICT_EXPECTED_CALL(amqp_device_send_event_async(TEST_DEVICE_HANDLE, TEST_IOTHUB_MESSAGE_LIST_HANDLE, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
             .IgnoreArgument(3)
             .IgnoreArgument(4);
     }
@@ -666,11 +666,11 @@ static void set_expected_calls_for_Device_DoWork(PDLIST_ENTRY wts, int wts_lengt
             STRICT_EXPECTED_CALL(amqp_connection_get_cbs_handle(TEST_AMQP_CONNECTION_HANDLE, IGNORED_PTR_ARG))
                 .IgnoreArgument_cbs_handle();
 
-            STRICT_EXPECTED_CALL(device_start_async(TEST_DEVICE_HANDLE, TEST_SESSION_HANDLE, TEST_CBS_HANDLE));
+            STRICT_EXPECTED_CALL(amqp_device_start_async(TEST_DEVICE_HANDLE, TEST_SESSION_HANDLE, TEST_CBS_HANDLE));
         }
         else
         {
-            STRICT_EXPECTED_CALL(device_start_async(TEST_DEVICE_HANDLE, TEST_SESSION_HANDLE, IGNORED_PTR_ARG));
+            STRICT_EXPECTED_CALL(amqp_device_start_async(TEST_DEVICE_HANDLE, TEST_SESSION_HANDLE, IGNORED_PTR_ARG));
         }
     }
     else if (current_device_state == DEVICE_STATE_STARTING ||
@@ -685,7 +685,7 @@ static void set_expected_calls_for_Device_DoWork(PDLIST_ENTRY wts, int wts_lengt
         STRICT_EXPECTED_CALL(STRING_c_str(TEST_DEVICE_ID_STRING_HANDLE))
             .SetReturn(TEST_DEVICE_ID_CHAR_PTR);
 
-        STRICT_EXPECTED_CALL(device_stop(TEST_DEVICE_HANDLE));
+        STRICT_EXPECTED_CALL(amqp_device_stop(TEST_DEVICE_HANDLE));
     }
     else if (current_device_state == DEVICE_STATE_STARTED)
     {
@@ -697,7 +697,7 @@ static void set_expected_calls_for_Device_DoWork(PDLIST_ENTRY wts, int wts_lengt
         set_expected_calls_for_send_pending_events(wts, wts_length);
     }
 
-    STRICT_EXPECTED_CALL(device_do_work(TEST_DEVICE_HANDLE));
+    STRICT_EXPECTED_CALL(amqp_device_do_work(TEST_DEVICE_HANDLE));
 }
 
 static void set_expected_calls_for_get_new_underlying_io_transport(bool feed_options)
@@ -775,7 +775,7 @@ static void set_expected_calls_for_Subscribe(IOTHUB_DEVICE_CONFIG* device_config
 {
     set_expected_calls_for_is_device_registered(device_config, registered_device);
 
-    STRICT_EXPECTED_CALL(device_subscribe_message(TEST_DEVICE_HANDLE, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+    STRICT_EXPECTED_CALL(amqp_device_subscribe_message(TEST_DEVICE_HANDLE, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .IgnoreArgument(2)
         .IgnoreArgument(3);
 }
@@ -784,7 +784,7 @@ static void set_expected_calls_for_Unsubscribe(IOTHUB_DEVICE_CONFIG* device_conf
 {
     set_expected_calls_for_is_device_registered(device_config, registered_device);
 
-    STRICT_EXPECTED_CALL(device_unsubscribe_message(TEST_DEVICE_HANDLE));
+    STRICT_EXPECTED_CALL(amqp_device_unsubscribe_message(TEST_DEVICE_HANDLE));
 }
 
 static void set_expected_calls_for_prepare_device_for_connection_retry(DEVICE_STATE current_device_state)
@@ -793,7 +793,7 @@ static void set_expected_calls_for_prepare_device_for_connection_retry(DEVICE_ST
 
     if (current_device_state != DEVICE_STATE_STOPPED)
     {
-        STRICT_EXPECTED_CALL(device_stop(TEST_DEVICE_HANDLE));
+        STRICT_EXPECTED_CALL(amqp_device_stop(TEST_DEVICE_HANDLE));
     }
 }
 
@@ -896,7 +896,7 @@ static double TEST_get_difftime(time_t t1, time_t t0)
 static ON_DEVICE_STATE_CHANGED TEST_device_create_saved_on_state_changed_callback;
 static void* TEST_device_create_saved_on_state_changed_context;
 static AMQP_DEVICE_HANDLE TEST_device_create_return;
-static AMQP_DEVICE_HANDLE TEST_device_create(DEVICE_CONFIG* config)
+static AMQP_DEVICE_HANDLE TEST_device_create(AMQP_DEVICE_CONFIG* config)
 {
     TEST_device_create_saved_on_state_changed_callback = config->on_state_changed_callback;
     TEST_device_create_saved_on_state_changed_context = config->on_state_changed_context;
@@ -1084,7 +1084,7 @@ static void register_umock_alias_types()
     REGISTER_UMOCK_ALIAS_TYPE(CBS_HANDLE, void*);
     REGISTER_UMOCK_ALIAS_TYPE(CONNECTION_HANDLE, void*);
     REGISTER_UMOCK_ALIAS_TYPE(AMQP_DEVICE_HANDLE, void*);
-    REGISTER_UMOCK_ALIAS_TYPE(DEVICE_CONFIG, void*);
+    REGISTER_UMOCK_ALIAS_TYPE(AMQP_DEVICE_CONFIG, void*);
     REGISTER_UMOCK_ALIAS_TYPE(DEVICE_MESSAGE_DISPOSITION_RESULT, int);
     REGISTER_UMOCK_ALIAS_TYPE(DEVICE_SEND_STATUS, int);
     REGISTER_UMOCK_ALIAS_TYPE(IOTHUB_CLIENT_RESULT, int);
@@ -1164,8 +1164,8 @@ static void register_global_mock_hooks()
 
     REGISTER_GLOBAL_MOCK_HOOK(get_difftime, TEST_get_difftime);
 
-    REGISTER_GLOBAL_MOCK_HOOK(device_create, TEST_device_create);
-    REGISTER_GLOBAL_MOCK_HOOK(device_subscribe_message, TEST_device_subscribe_message);
+    REGISTER_GLOBAL_MOCK_HOOK(amqp_device_create, TEST_device_create);
+    REGISTER_GLOBAL_MOCK_HOOK(amqp_device_subscribe_message, TEST_device_subscribe_message);
 
     REGISTER_GLOBAL_MOCK_HOOK(Transport_MessageCallback, TEST_Transport_MessageCallback);
     REGISTER_GLOBAL_MOCK_RETURN(Transport_GetOption_Product_Info_Callback, TEST_PRODUCT_INFO_CHAR_PTR);
@@ -1189,32 +1189,32 @@ static void register_global_mock_returns()
 
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(singlylinkedlist_create, NULL);
 
-    REGISTER_GLOBAL_MOCK_RETURN(device_start_async, 0);
-    REGISTER_GLOBAL_MOCK_FAIL_RETURN(device_start_async, 1);
+    REGISTER_GLOBAL_MOCK_RETURN(amqp_device_start_async, 0);
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(amqp_device_start_async, 1);
 
-    REGISTER_GLOBAL_MOCK_RETURN(device_stop, 0);
-    REGISTER_GLOBAL_MOCK_FAIL_RETURN(device_stop, 1);
+    REGISTER_GLOBAL_MOCK_RETURN(amqp_device_stop, 0);
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(amqp_device_stop, 1);
 
     REGISTER_GLOBAL_MOCK_RETURN(IoTHub_Transport_ValidateCallbacks, 0);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(IoTHub_Transport_ValidateCallbacks, __LINE__);
 
-    REGISTER_GLOBAL_MOCK_RETURN(device_set_option, 0);
-    REGISTER_GLOBAL_MOCK_FAIL_RETURN(device_set_option, 1);
+    REGISTER_GLOBAL_MOCK_RETURN(amqp_device_set_option, 0);
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(amqp_device_set_option, 1);
 
-    REGISTER_GLOBAL_MOCK_RETURN(device_subscribe_message, 0);
-    REGISTER_GLOBAL_MOCK_FAIL_RETURN(device_subscribe_message, 1);
+    REGISTER_GLOBAL_MOCK_RETURN(amqp_device_subscribe_message, 0);
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(amqp_device_subscribe_message, 1);
 
-    REGISTER_GLOBAL_MOCK_RETURN(device_unsubscribe_message, 0);
-    REGISTER_GLOBAL_MOCK_FAIL_RETURN(device_unsubscribe_message, 1);
+    REGISTER_GLOBAL_MOCK_RETURN(amqp_device_unsubscribe_message, 0);
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(amqp_device_unsubscribe_message, 1);
 
-    REGISTER_GLOBAL_MOCK_RETURN(device_get_send_status, 0);
-    REGISTER_GLOBAL_MOCK_FAIL_RETURN(device_get_send_status, 1);
+    REGISTER_GLOBAL_MOCK_RETURN(amqp_device_get_send_status, 0);
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(amqp_device_get_send_status, 1);
 
-    REGISTER_GLOBAL_MOCK_RETURN(device_send_message_disposition, 0);
-    REGISTER_GLOBAL_MOCK_FAIL_RETURN(device_send_message_disposition, 1);
+    REGISTER_GLOBAL_MOCK_RETURN(amqp_device_send_message_disposition, 0);
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(amqp_device_send_message_disposition, 1);
 
-    REGISTER_GLOBAL_MOCK_RETURN(device_get_twin_async, 0);
-    REGISTER_GLOBAL_MOCK_FAIL_RETURN(device_get_twin_async, 1);
+    REGISTER_GLOBAL_MOCK_RETURN(amqp_device_get_twin_async, 0);
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(amqp_device_get_twin_async, 1);
 
     REGISTER_GLOBAL_MOCK_RETURN(OptionHandler_FeedOptions, OPTIONHANDLER_OK);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(OptionHandler_FeedOptions, OPTIONHANDLER_ERROR);
@@ -2307,7 +2307,7 @@ TEST_FUNCTION(Register_X509_transport_CBS_credentials)
 
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_067: [If malloc fails, IoTHubTransport_AMQP_Common_Register shall fail and return NULL.]
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_070: [If STRING_construct() fails, IoTHubTransport_AMQP_Common_Register shall fail and return NULL]
-// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_073: [If device_create() fails, IoTHubTransport_AMQP_Common_Register shall fail and return NULL]
+// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_073: [If amqp_device_create() fails, IoTHubTransport_AMQP_Common_Register shall fail and return NULL]
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_01_011: [ If `iothubtransportamqp_methods_create` fails, `IoTHubTransport_AMQP_Common_Register` shall fail and return NULL]
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_075: [If it fails to add `amqp_device_instance`, IoTHubTransport_AMQP_Common_Register shall fail and return NULL]
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_077: [If IoTHubTransport_AMQP_Common_Register fails, it shall free all memory it allocated]
@@ -2357,8 +2357,8 @@ TEST_FUNCTION(Register_failure_checks)
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_066: [IoTHubTransport_AMQP_Common_Register shall allocate an instance of AMQP_TRANSPORT_DEVICE_STATE to store the state of the new registered device.]
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_068: [IoTHubTransport_AMQP_Common_Register shall save the handle references to the IoTHubClient, transport, waitingToSend list on `amqp_device_instance`.]
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_069: [A copy of `config->deviceId` shall be saved into `device_state->device_id`]
-// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_071: [`amqp_device_instance->device_handle` shall be set using device_create()]
-// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_072: [The configuration for device_create shall be set according to the authentication preferred by IOTHUB_DEVICE_CONFIG]
+// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_071: [`amqp_device_instance->device_handle` shall be set using amqp_device_create()]
+// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_072: [The configuration for amqp_device_create shall be set according to the authentication preferred by IOTHUB_DEVICE_CONFIG]
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_01_010: [ `IoTHubTransport_AMQP_Common_Register` shall create a new iothubtransportamqp_methods instance by calling `iothubtransportamqp_methods_create` while passing to it the the fully qualified domain name, the device Id, and optional module Id.]
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_074: [IoTHubTransport_AMQP_Common_Register shall add the `amqp_device_instance` to `instance->registered_devices`]
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_076: [If the device is the first being registered on the transport, IoTHubTransport_AMQP_Common_Register shall save its authentication mode as the transport preferred authentication mode]
@@ -2428,7 +2428,7 @@ TEST_FUNCTION(Subscribe_device_not_registered)
     destroy_transport(handle, device_handle, NULL);
 }
 
-// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_086: [device_subscribe_message() shall be invoked passing `on_message_received_callback`]
+// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_086: [amqp_device_subscribe_message() shall be invoked passing `on_message_received_callback`]
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_088: [If no failures occur, IoTHubTransport_AMQP_Common_Subscribe shall return 0]
 TEST_FUNCTION(Subscribe_messages_succeeds)
 {
@@ -2455,7 +2455,7 @@ TEST_FUNCTION(Subscribe_messages_succeeds)
     destroy_transport(handle, device_handle, NULL);
 }
 
-// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_087: [If device_subscribe_message() fails, IoTHubTransport_AMQP_Common_Subscribe shall return a non-zero result]
+// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_087: [If amqp_device_subscribe_message() fails, IoTHubTransport_AMQP_Common_Subscribe shall return a non-zero result]
 TEST_FUNCTION(Subscribe_messages_failure_checks)
 {
     // arrange
@@ -2541,7 +2541,7 @@ TEST_FUNCTION(Unsubscribe_messages_device_not_registered)
     destroy_transport(handle, device_handle, NULL);
 }
 
-// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_095: [device_unsubscribe_message() shall be invoked passing `amqp_device_instance->device_handle`]
+// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_095: [amqp_device_unsubscribe_message() shall be invoked passing `amqp_device_instance->device_handle`]
 TEST_FUNCTION(Unsubscribe_messages_succeeds)
 {
     // arrange
@@ -2612,7 +2612,7 @@ TEST_FUNCTION(GetSendStatus_NULL_iotHubClientStatus)
     destroy_transport(handle, device_handle, NULL);
 }
 
-// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_098: [If device_get_send_status() fails, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_ERROR]
+// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_098: [If amqp_device_get_send_status() fails, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_ERROR]
 TEST_FUNCTION(GetSendStatus_failure_checks)
 {
     // arrange
@@ -2652,8 +2652,8 @@ TEST_FUNCTION(GetSendStatus_failure_checks)
     destroy_transport(handle, device_handle, NULL);
 }
 
-// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_097: [IoTHubTransport_AMQP_Common_GetSendStatus shall invoke device_get_send_status()]
-// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_100: [If device_get_send_status() returns DEVICE_SEND_STATUS_IDLE, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_OK and status IOTHUB_CLIENT_STATUS_IDLE]
+// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_097: [IoTHubTransport_AMQP_Common_GetSendStatus shall invoke amqp_device_get_send_status()]
+// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_100: [If amqp_device_get_send_status() returns DEVICE_SEND_STATUS_IDLE, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_OK and status IOTHUB_CLIENT_STATUS_IDLE]
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_109: [If no failures occur, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_OK]
 TEST_FUNCTION(GetSendStatus_IDLE_succeeds)
 {
@@ -2682,7 +2682,7 @@ TEST_FUNCTION(GetSendStatus_IDLE_succeeds)
     destroy_transport(handle, device_handle, NULL);
 }
 
-// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_099: [If device_get_send_status() returns DEVICE_SEND_STATUS_BUSY, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_OK and status IOTHUB_CLIENT_STATUS_BUSY]
+// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_099: [If amqp_device_get_send_status() returns DEVICE_SEND_STATUS_BUSY, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_OK and status IOTHUB_CLIENT_STATUS_BUSY]
 TEST_FUNCTION(GetSendStatus_BUSY_succeeds)
 {
     // arrange
@@ -2777,8 +2777,8 @@ TEST_FUNCTION(SetOption_NULL_value)
     destroy_transport(handle, device_handle, NULL);
 }
 
-// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_102: [If `option` is a device-specific option, it shall be saved and applied to each registered device using device_set_option()]
-// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_103: [If device_set_option() fails, IoTHubTransport_AMQP_Common_SetOption shall return IOTHUB_CLIENT_ERROR]
+// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_102: [If `option` is a device-specific option, it shall be saved and applied to each registered device using amqp_device_set_option()]
+// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_103: [If amqp_device_set_option() fails, IoTHubTransport_AMQP_Common_SetOption shall return IOTHUB_CLIENT_ERROR]
 TEST_FUNCTION(SetOption_device_specific_failure_check)
 {
     // arrange
@@ -2794,7 +2794,7 @@ TEST_FUNCTION(SetOption_device_specific_failure_check)
     umock_c_reset_all_calls();
     STRICT_EXPECTED_CALL(singlylinkedlist_get_head_item(TEST_REGISTERED_DEVICES_LIST));
     EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_PTR_ARG)).SetReturn(device_handle);
-    STRICT_EXPECTED_CALL(device_set_option(TEST_DEVICE_HANDLE, DEVICE_OPTION_EVENT_SEND_TIMEOUT_SECS, &value))
+    STRICT_EXPECTED_CALL(amqp_device_set_option(TEST_DEVICE_HANDLE, DEVICE_OPTION_EVENT_SEND_TIMEOUT_SECS, &value))
         .SetReturn(1);
     STRICT_EXPECTED_CALL(STRING_c_str(TEST_DEVICE_ID_STRING_HANDLE))
         .SetReturn(TEST_DEVICE_ID_CHAR_PTR);
@@ -4010,7 +4010,7 @@ TEST_FUNCTION(on_message_received_fails)
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_037: [If transport is using CBS authentication, amqp_connection_get_cbs_handle() shall be invoked on `instance->connection`]
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_039: [amqp_connection_get_session_handle() shall be invoked on `instance->connection`]
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_040: [If amqp_connection_get_session_handle() fails, IoTHubTransport_AMQP_Common_DoWork shall fail and return]
-// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_041: [The device handle shall be started using device_start_async()]
+// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_041: [The device handle shall be started using amqp_device_start_async()]
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_059: [`new_state` shall be saved in to the transport instance]
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_061: [If `new_state` is the same as `previous_state`, on_device_state_changed_callback shall return]
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_062: [If `new_state` shall be saved into the `registered_device` instance]
@@ -4544,7 +4544,7 @@ TEST_FUNCTION(IoTHubTransport_AMQP_Common_SendMessageDisposition_NULL_CONTEXT_fa
     destroy_transport(handle, device_handle, NULL);
 }
 
-// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_10_004: [IoTHubTransport_AMQP_Common_SendMessageDisposition shall convert the given IOTHUBMESSAGE_DISPOSITION_RESULT to the equivalent DEVICE_MESSAGE_DISPOSITION_RESULT and send it via device_send_message_disposition.]
+// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_10_004: [IoTHubTransport_AMQP_Common_SendMessageDisposition shall convert the given IOTHUBMESSAGE_DISPOSITION_RESULT to the equivalent DEVICE_MESSAGE_DISPOSITION_RESULT and send it via amqp_device_send_message_disposition.]
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_112: [A DEVICE_MESSAGE_DISPOSITION_INFO instance shall be created with a copy of the `link_name` and `message_id` contained in `message_data`]
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_114: [`IoTHubTransport_AMQP_Common_SendMessageDisposition()` shall destroy the DEVICE_MESSAGE_DISPOSITION_INFO instance]
 TEST_FUNCTION(IoTHubTransport_AMQP_Common_SendMessageDisposition_ACCEPTED_succeeds)
@@ -4594,7 +4594,7 @@ TEST_FUNCTION(IoTHubTransport_AMQP_Common_SendMessageDisposition_ACCEPTED_fails)
 
     umock_c_reset_all_calls();
     set_expected_calls_for_create_device_message_disposition_info();
-    STRICT_EXPECTED_CALL(device_send_message_disposition(TEST_DEVICE_HANDLE, IGNORED_PTR_ARG, DEVICE_MESSAGE_DISPOSITION_RESULT_ACCEPTED))
+    STRICT_EXPECTED_CALL(amqp_device_send_message_disposition(TEST_DEVICE_HANDLE, IGNORED_PTR_ARG, DEVICE_MESSAGE_DISPOSITION_RESULT_ACCEPTED))
         .IgnoreArgument(2)
         .SetReturn(1);
     EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG))
@@ -4699,7 +4699,7 @@ TEST_FUNCTION(IoTHubTransport_AMQP_Common_SendMessageDisposition_ABANDONED_fails
 
     umock_c_reset_all_calls();
     set_expected_calls_for_create_device_message_disposition_info();
-    STRICT_EXPECTED_CALL(device_send_message_disposition(TEST_DEVICE_HANDLE, IGNORED_PTR_ARG, DEVICE_MESSAGE_DISPOSITION_RESULT_RELEASED))
+    STRICT_EXPECTED_CALL(amqp_device_send_message_disposition(TEST_DEVICE_HANDLE, IGNORED_PTR_ARG, DEVICE_MESSAGE_DISPOSITION_RESULT_RELEASED))
         .IgnoreArgument(2)
         .SetReturn(1);
     EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG))
@@ -4768,7 +4768,7 @@ TEST_FUNCTION(IoTHubTransport_AMQP_Common_SendMessageDisposition_REJECTED_fails)
 
     umock_c_reset_all_calls();
     set_expected_calls_for_create_device_message_disposition_info();
-    STRICT_EXPECTED_CALL(device_send_message_disposition(TEST_DEVICE_HANDLE, IGNORED_PTR_ARG, DEVICE_MESSAGE_DISPOSITION_RESULT_REJECTED))
+    STRICT_EXPECTED_CALL(amqp_device_send_message_disposition(TEST_DEVICE_HANDLE, IGNORED_PTR_ARG, DEVICE_MESSAGE_DISPOSITION_RESULT_REJECTED))
         .IgnoreArgument(2)
         .SetReturn(1);
     EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG))
@@ -4896,7 +4896,7 @@ TEST_FUNCTION(IoTHubTransport_AMQP_SetCallbackContext_fail)
     // cleanup
 }
 
-// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_155: [ device_get_twin_async() shall be invoked for the registered device, passing `on_device_get_twin_completed_callback`]
+// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_155: [ amqp_device_get_twin_async() shall be invoked for the registered device, passing `on_device_get_twin_completed_callback`]
 // Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_157: [ If no errors occur, `IoTHubTransport_AMQP_Common_GetTwinAsync` shall return IOTHUB_CLIENT_OK ]
 TEST_FUNCTION(IoTHubTransport_AMQP_Common_GetTwinAsync_success)
 {
@@ -4914,7 +4914,7 @@ TEST_FUNCTION(IoTHubTransport_AMQP_Common_GetTwinAsync_success)
     STRICT_EXPECTED_CALL(singlylinkedlist_get_head_item(IGNORED_NUM_ARG));
     STRICT_EXPECTED_CALL(singlylinkedlist_get_next_item(IGNORED_NUM_ARG));
     STRICT_EXPECTED_CALL(malloc(IGNORED_NUM_ARG));
-    STRICT_EXPECTED_CALL(device_get_twin_async(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(amqp_device_get_twin_async(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
 
     // act
     IOTHUB_CLIENT_RESULT result = IoTHubTransport_AMQP_Common_GetTwinAsync(handle, on_device_get_twin_completed_callback, (void*)0x5566);
@@ -4969,7 +4969,7 @@ TEST_FUNCTION(IoTHubTransport_AMQP_Common_GetTwinAsync_NULL_callback)
     destroy_transport(handle, NULL, NULL);
 }
 
-// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_156: [ If device_get_twin_async() fails, `IoTHubTransport_AMQP_Common_GetTwinAsync` shall fail and return IOTHUB_CLIENT_ERROR ]
+// Tests_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_156: [ If amqp_device_get_twin_async() fails, `IoTHubTransport_AMQP_Common_GetTwinAsync` shall fail and return IOTHUB_CLIENT_ERROR ]
 TEST_FUNCTION(IoTHubTransport_AMQP_Common_GetTwinAsync_failure_checks)
 {
     // arrange
@@ -4989,7 +4989,7 @@ TEST_FUNCTION(IoTHubTransport_AMQP_Common_GetTwinAsync_failure_checks)
     STRICT_EXPECTED_CALL(singlylinkedlist_get_next_item(IGNORED_NUM_ARG))
         .CallCannotFail();
     STRICT_EXPECTED_CALL(malloc(IGNORED_NUM_ARG));
-    STRICT_EXPECTED_CALL(device_get_twin_async(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(amqp_device_get_twin_async(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
     umock_c_negative_tests_snapshot();
 
     size_t count = umock_c_negative_tests_call_count();

--- a/iothub_client/tests/iothubtransport_amqp_device_ut/iothubtransport_amqp_device_ut.c
+++ b/iothub_client/tests/iothubtransport_amqp_device_ut/iothubtransport_amqp_device_ut.c
@@ -290,10 +290,10 @@ static void on_device_get_twin_completed_callback(DEVICE_TWIN_UPDATE_TYPE update
 }
 
 // ---------- Test Helpers ---------- //
-static DEVICE_CONFIG TEST_device_config;
-static DEVICE_CONFIG* get_device_config(DEVICE_AUTH_MODE auth_mode)
+static AMQP_DEVICE_CONFIG TEST_device_config;
+static AMQP_DEVICE_CONFIG* get_device_config(DEVICE_AUTH_MODE auth_mode)
 {
-    memset(&TEST_device_config, 0, sizeof(DEVICE_CONFIG));
+    memset(&TEST_device_config, 0, sizeof(AMQP_DEVICE_CONFIG));
     TEST_device_config.device_id = TEST_DEVICE_ID_CHAR_PTR;
     TEST_device_config.product_info = TEST_PRODUCT_INFO_CHAR_PTR;
     TEST_device_config.iothub_host_fqdn = TEST_IOTHUB_HOST_FQDN_CHAR_PTR;
@@ -305,9 +305,9 @@ static DEVICE_CONFIG* get_device_config(DEVICE_AUTH_MODE auth_mode)
     return &TEST_device_config;
 }
 
-static DEVICE_CONFIG* get_device_config_with_module_id(DEVICE_AUTH_MODE auth_mode)
+static AMQP_DEVICE_CONFIG* get_device_config_with_module_id(DEVICE_AUTH_MODE auth_mode)
 {
-    DEVICE_CONFIG* config = get_device_config(auth_mode);
+    AMQP_DEVICE_CONFIG* config = get_device_config(auth_mode);
     config->module_id = TEST_MODULE_ID_CHAR_PTR;
     return config;
 }
@@ -499,7 +499,7 @@ static void set_expected_calls_for_is_timeout_reached(time_t current_time)
     }
 }
 
-static void set_expected_calls_for_clone_device_config(DEVICE_CONFIG *config)
+static void set_expected_calls_for_clone_device_config(AMQP_DEVICE_CONFIG *config)
 {
     STRICT_EXPECTED_CALL(malloc(IGNORED_NUM_ARG));
     STRICT_EXPECTED_CALL(mallocAndStrcpy_s(IGNORED_PTR_ARG, config->product_info));
@@ -509,25 +509,25 @@ static void set_expected_calls_for_clone_device_config(DEVICE_CONFIG *config)
     STRICT_EXPECTED_CALL(IoTHubClient_Auth_Get_ModuleId(TEST_AUTHORIZATION_HANDLE)).SetReturn(config->module_id);
 }
 
-static void set_expected_calls_for_create_authentication_instance(DEVICE_CONFIG *config)
+static void set_expected_calls_for_create_authentication_instance(AMQP_DEVICE_CONFIG *config)
 {
     (void)config;
     EXPECTED_CALL(authentication_create(IGNORED_PTR_ARG));
 }
 
-static void set_expected_calls_for_create_messenger_instance(DEVICE_CONFIG *config)
+static void set_expected_calls_for_create_messenger_instance(AMQP_DEVICE_CONFIG *config)
 {
     (void)config;
     EXPECTED_CALL(telemetry_messenger_create(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
 }
 
-static void set_expected_calls_for_create_twin_messenger(DEVICE_CONFIG *config)
+static void set_expected_calls_for_create_twin_messenger(AMQP_DEVICE_CONFIG *config)
 {
     (void)config;
     EXPECTED_CALL(twin_messenger_create(IGNORED_PTR_ARG));
 }
 
-static void set_expected_calls_for_device_create(DEVICE_CONFIG *config, time_t current_time)
+static void set_expected_calls_for_device_create(AMQP_DEVICE_CONFIG *config, time_t current_time)
 {
     (void)current_time;
 
@@ -545,14 +545,14 @@ static void set_expected_calls_for_device_create(DEVICE_CONFIG *config, time_t c
     set_expected_calls_for_create_twin_messenger(config);
 }
 
-static void set_expected_calls_for_device_start_async(DEVICE_CONFIG* config, time_t current_time)
+static void set_expected_calls_for_device_start_async(AMQP_DEVICE_CONFIG* config, time_t current_time)
 {
     (void)config;
     (void)current_time;
     // Nothing to expect from this function.
 }
 
-static void set_expected_calls_for_device_stop(DEVICE_CONFIG* config, time_t current_time, AUTHENTICATION_STATE auth_state, TELEMETRY_MESSENGER_STATE messenger_state, TWIN_MESSENGER_STATE twin_msgr_state)
+static void set_expected_calls_for_device_stop(AMQP_DEVICE_CONFIG* config, time_t current_time, AUTHENTICATION_STATE auth_state, TELEMETRY_MESSENGER_STATE messenger_state, TWIN_MESSENGER_STATE twin_msgr_state)
 {
     (void)current_time;
 
@@ -572,7 +572,7 @@ static void set_expected_calls_for_device_stop(DEVICE_CONFIG* config, time_t cur
     }
 }
 
-static void set_expected_calls_for_device_do_work(DEVICE_CONFIG* config, time_t current_time, DEVICE_STATE device_state, AUTHENTICATION_STATE auth_state, TELEMETRY_MESSENGER_STATE msgr_state, TWIN_MESSENGER_STATE twin_msgr_state)
+static void set_expected_calls_for_device_do_work(AMQP_DEVICE_CONFIG* config, time_t current_time, DEVICE_STATE device_state, AUTHENTICATION_STATE auth_state, TELEMETRY_MESSENGER_STATE msgr_state, TWIN_MESSENGER_STATE twin_msgr_state)
 {
     if (device_state == DEVICE_STATE_STARTING)
     {
@@ -629,7 +629,7 @@ static void set_expected_calls_for_device_do_work(DEVICE_CONFIG* config, time_t 
     }
 }
 
-static void set_expected_calls_for_device_destroy(AMQP_DEVICE_HANDLE handle, DEVICE_CONFIG *config, time_t current_time, DEVICE_STATE device_state, AUTHENTICATION_STATE auth_state, TELEMETRY_MESSENGER_STATE msgr_state, TWIN_MESSENGER_STATE twin_msgr_state)
+static void set_expected_calls_for_device_destroy(AMQP_DEVICE_HANDLE handle, AMQP_DEVICE_CONFIG *config, time_t current_time, DEVICE_STATE device_state, AUTHENTICATION_STATE auth_state, TELEMETRY_MESSENGER_STATE msgr_state, TWIN_MESSENGER_STATE twin_msgr_state)
 {
     if (device_state == DEVICE_STATE_STARTED || device_state == DEVICE_STATE_STARTING)
     {
@@ -652,7 +652,7 @@ static void set_expected_calls_for_device_destroy(AMQP_DEVICE_HANDLE handle, DEV
     STRICT_EXPECTED_CALL(free(handle));
 }
 
-static void set_expected_calls_for_device_retrieve_options(DEVICE_CONFIG *config)
+static void set_expected_calls_for_device_retrieve_options(AMQP_DEVICE_CONFIG *config)
 {
     EXPECTED_CALL(OptionHandler_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .SetReturn(TEST_OPTIONHANDLER_HANDLE);
@@ -671,7 +671,7 @@ static void set_expected_calls_for_device_retrieve_options(DEVICE_CONFIG *config
         .SetReturn(OPTIONHANDLER_OK);
 }
 
-static void set_expected_calls_for_device_set_option(AMQP_DEVICE_HANDLE handle, DEVICE_CONFIG *config, const char* option_name, void* option_value)
+static void set_expected_calls_for_device_set_option(AMQP_DEVICE_HANDLE handle, AMQP_DEVICE_CONFIG *config, const char* option_name, void* option_value)
 {
     if (config->authentication_mode == DEVICE_AUTH_MODE_CBS)
     {
@@ -701,7 +701,7 @@ static void set_expected_calls_for_device_set_option(AMQP_DEVICE_HANDLE handle, 
     }
 }
 
-static void set_expected_calls_for_device_send_async(DEVICE_CONFIG *config)
+static void set_expected_calls_for_device_send_async(AMQP_DEVICE_CONFIG *config)
 {
     (void)config;
     EXPECTED_CALL(malloc(IGNORED_NUM_ARG));
@@ -713,14 +713,14 @@ static void set_expected_calls_for_device_send_async(DEVICE_CONFIG *config)
 
 // ---------- set_expected*-dependent Test Helpers ---------- //
 
-static AMQP_DEVICE_HANDLE create_device(DEVICE_CONFIG* config, time_t current_time)
+static AMQP_DEVICE_HANDLE create_device(AMQP_DEVICE_CONFIG* config, time_t current_time)
 {
     umock_c_reset_all_calls();
     set_expected_calls_for_device_create(config, current_time);
-    return device_create(config);
+    return amqp_device_create(config);
 }
 
-static AMQP_DEVICE_HANDLE create_and_start_device(DEVICE_CONFIG* config, time_t current_time)
+static AMQP_DEVICE_HANDLE create_and_start_device(AMQP_DEVICE_CONFIG* config, time_t current_time)
 {
     AMQP_DEVICE_HANDLE handle = create_device(config, current_time);
 
@@ -728,21 +728,21 @@ static AMQP_DEVICE_HANDLE create_and_start_device(DEVICE_CONFIG* config, time_t 
 
     if (config->authentication_mode == DEVICE_AUTH_MODE_CBS)
     {
-        (void)device_start_async(handle, TEST_SESSION_HANDLE, TEST_CBS_HANDLE);
+        (void)amqp_device_start_async(handle, TEST_SESSION_HANDLE, TEST_CBS_HANDLE);
     }
     else
     {
-        (void)device_start_async(handle, TEST_SESSION_HANDLE, NULL);
+        (void)amqp_device_start_async(handle, TEST_SESSION_HANDLE, NULL);
     }
 
     return handle;
 }
 
-static void crank_device_do_work(AMQP_DEVICE_HANDLE handle, DEVICE_CONFIG* config, time_t current_time, DEVICE_STATE device_state, AUTHENTICATION_STATE auth_state, TELEMETRY_MESSENGER_STATE msgr_state, TWIN_MESSENGER_STATE twin_msgr_state)
+static void crank_device_do_work(AMQP_DEVICE_HANDLE handle, AMQP_DEVICE_CONFIG* config, time_t current_time, DEVICE_STATE device_state, AUTHENTICATION_STATE auth_state, TELEMETRY_MESSENGER_STATE msgr_state, TWIN_MESSENGER_STATE twin_msgr_state)
 {
     umock_c_reset_all_calls();
     set_expected_calls_for_device_do_work(config, current_time, device_state, auth_state, msgr_state, twin_msgr_state);
-    device_do_work(handle);
+    amqp_device_do_work(handle);
 }
 
 static void set_authentication_state(AUTHENTICATION_STATE previous_state, AUTHENTICATION_STATE new_state, time_t current_time)
@@ -775,7 +775,7 @@ static void set_twin_messenger_state(TWIN_MESSENGER_STATE previous_state, TWIN_M
         new_state);
 }
 
-static AMQP_DEVICE_HANDLE create_and_start_and_crank_device(DEVICE_CONFIG* config, time_t current_time)
+static AMQP_DEVICE_HANDLE create_and_start_and_crank_device(AMQP_DEVICE_CONFIG* config, time_t current_time)
 {
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, current_time);
 
@@ -845,13 +845,13 @@ TEST_FUNCTION_CLEANUP(TestMethodCleanup)
 }
 
 
-// Tests_SRS_DEVICE_09_001: [If `config` or device_id or iothub_host_fqdn or on_state_changed_callback are NULL then device_create shall fail and return NULL]
+// Tests_SRS_DEVICE_09_001: [If `config` or device_id or iothub_host_fqdn or on_state_changed_callback are NULL then amqp_device_create shall fail and return NULL]
 TEST_FUNCTION(device_create_NULL_config)
 {
     // arrange
 
     // act
-    AMQP_DEVICE_HANDLE handle = device_create(NULL);
+    AMQP_DEVICE_HANDLE handle = amqp_device_create(NULL);
 
     // assert
     ASSERT_IS_NULL(handle);
@@ -859,15 +859,15 @@ TEST_FUNCTION(device_create_NULL_config)
     // cleanup
 }
 
-// Tests_SRS_DEVICE_09_001: [If `config` or iothub_host_fqdn or on_state_changed_callback are NULL then device_create shall fail and return NULL]
+// Tests_SRS_DEVICE_09_001: [If `config` or iothub_host_fqdn or on_state_changed_callback are NULL then amqp_device_create shall fail and return NULL]
 TEST_FUNCTION(device_create_NULL_config_iothub_host_fqdn)
 {
     // arrange
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     config->iothub_host_fqdn = NULL;
 
     // act
-    AMQP_DEVICE_HANDLE handle = device_create(config);
+    AMQP_DEVICE_HANDLE handle = amqp_device_create(config);
 
     // assert
     ASSERT_IS_NULL(handle);
@@ -875,15 +875,15 @@ TEST_FUNCTION(device_create_NULL_config_iothub_host_fqdn)
     // cleanup
 }
 
-// Tests_SRS_DEVICE_09_001: [If `config` or iothub_host_fqdn or on_state_changed_callback are NULL then device_create shall fail and return NULL]
+// Tests_SRS_DEVICE_09_001: [If `config` or iothub_host_fqdn or on_state_changed_callback are NULL then amqp_device_create shall fail and return NULL]
 TEST_FUNCTION(device_create_NULL_config_on_state_changed_callback)
 {
     // arrange
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     config->on_state_changed_callback = NULL;
 
     // act
-    AMQP_DEVICE_HANDLE handle = device_create(config);
+    AMQP_DEVICE_HANDLE handle = amqp_device_create(config);
 
     // assert
     ASSERT_IS_NULL(handle);
@@ -891,67 +891,67 @@ TEST_FUNCTION(device_create_NULL_config_on_state_changed_callback)
     // cleanup
 }
 
-// Tests_SRS_DEVICE_09_002: [device_create shall allocate memory for the device instance structure]
+// Tests_SRS_DEVICE_09_002: [amqp_device_create shall allocate memory for the device instance structure]
 // Tests_SRS_DEVICE_09_004: [All `config` parameters shall be saved into `instance`]
 // Tests_SRS_DEVICE_09_006: [If `instance->authentication_mode` is DEVICE_AUTH_MODE_CBS, `instance->authentication_handle` shall be set using authentication_create()]
 // Tests_SRS_DEVICE_09_008: [`instance->messenger_handle` shall be set using telemetry_messenger_create()]
 // Tests_SRS_DEVICE_09_122: [`instance->twin_messenger_handle` shall be set using twin_messenger_create()]
-// Tests_SRS_DEVICE_09_011: [If device_create succeeds it shall return a handle to its `instance` structure]
+// Tests_SRS_DEVICE_09_011: [If amqp_device_create succeeds it shall return a handle to its `instance` structure]
 TEST_FUNCTION(device_create_succeeds)
 {
     // arrange
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
 
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
     set_expected_calls_for_device_create(config, TEST_current_time);
 
     // act
-    AMQP_DEVICE_HANDLE handle = device_create(config);
+    AMQP_DEVICE_HANDLE handle = amqp_device_create(config);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_002: [device_create shall allocate memory for the device instance structure]
+// Tests_SRS_DEVICE_09_002: [amqp_device_create shall allocate memory for the device instance structure]
 // Tests_SRS_DEVICE_09_004: [All `config` parameters shall be saved into `instance`]
 // Tests_SRS_DEVICE_09_006: [If `instance->authentication_mode` is DEVICE_AUTH_MODE_CBS, `instance->authentication_handle` shall be set using authentication_create()]
 // Tests_SRS_DEVICE_09_008: [`instance->messenger_handle` shall be set using telemetry_messenger_create()]
 // Tests_SRS_DEVICE_09_122: [`instance->twin_messenger_handle` shall be set using twin_messenger_create()]
-// Tests_SRS_DEVICE_09_011: [If device_create succeeds it shall return a handle to its `instance` structure]
+// Tests_SRS_DEVICE_09_011: [If amqp_device_create succeeds it shall return a handle to its `instance` structure]
 TEST_FUNCTION(device_create_with_module_succeeds)
 {
     // arrange
-    DEVICE_CONFIG* config = get_device_config_with_module_id(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config_with_module_id(DEVICE_AUTH_MODE_CBS);
 
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
     set_expected_calls_for_device_create(config, TEST_current_time);
 
     // act
-    AMQP_DEVICE_HANDLE handle = device_create(config);
+    AMQP_DEVICE_HANDLE handle = amqp_device_create(config);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_003: [If malloc fails, device_create shall fail and return NULL]
-// Tests_SRS_DEVICE_09_005: [If any `config` parameters fail to be saved into `instance`, device_create shall fail and return NULL]
-// Tests_SRS_DEVICE_09_007: [If the AUTHENTICATION_HANDLE fails to be created, device_create shall fail and return NULL]
-// Tests_SRS_DEVICE_09_009: [If the TELEMETRY_MESSENGER_HANDLE fails to be created, device_create shall fail and return NULL]
-// Tests_SRS_DEVICE_09_123: [If the TWIN_MESSENGER_HANDLE fails to be created, device_create shall fail and return NULL]
-// Tests_SRS_DEVICE_09_010: [If device_create fails it shall release all memory it has allocated]
+// Tests_SRS_DEVICE_09_003: [If malloc fails, amqp_device_create shall fail and return NULL]
+// Tests_SRS_DEVICE_09_005: [If any `config` parameters fail to be saved into `instance`, amqp_device_create shall fail and return NULL]
+// Tests_SRS_DEVICE_09_007: [If the AUTHENTICATION_HANDLE fails to be created, amqp_device_create shall fail and return NULL]
+// Tests_SRS_DEVICE_09_009: [If the TELEMETRY_MESSENGER_HANDLE fails to be created, amqp_device_create shall fail and return NULL]
+// Tests_SRS_DEVICE_09_123: [If the TWIN_MESSENGER_HANDLE fails to be created, amqp_device_create shall fail and return NULL]
+// Tests_SRS_DEVICE_09_010: [If amqp_device_create fails it shall release all memory it has allocated]
 TEST_FUNCTION(device_create_failure_checks)
 {
     // arrange
     ASSERT_ARE_EQUAL(int, 0, umock_c_negative_tests_init());
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
     umock_c_reset_all_calls();
@@ -974,7 +974,7 @@ TEST_FUNCTION(device_create_failure_checks)
         umock_c_negative_tests_reset();
         umock_c_negative_tests_fail_call(i);
 
-        AMQP_DEVICE_HANDLE handle = device_create(config);
+        AMQP_DEVICE_HANDLE handle = amqp_device_create(config);
 
         // assert
         sprintf(error_msg, "On failed call %lu", (unsigned long)i);
@@ -986,32 +986,32 @@ TEST_FUNCTION(device_create_failure_checks)
     umock_c_reset_all_calls();
 }
 
-// Tests_SRS_DEVICE_09_017: [If `handle` is NULL, device_start_async shall return a non-zero result]
+// Tests_SRS_DEVICE_09_017: [If `handle` is NULL, amqp_device_start_async shall return a non-zero result]
 TEST_FUNCTION(device_start_async_NULL_handle)
 {
     // arrange
 
     // act
-    int result = device_start_async(NULL, TEST_SESSION_HANDLE, TEST_CBS_HANDLE);
+    int result = amqp_device_start_async(NULL, TEST_SESSION_HANDLE, TEST_CBS_HANDLE);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
 }
 
-// Tests_SRS_DEVICE_09_018: [If the device state is not DEVICE_STATE_STOPPED, device_start_async shall return a non-zero result]
+// Tests_SRS_DEVICE_09_018: [If the device state is not DEVICE_STATE_STOPPED, amqp_device_start_async shall return a non-zero result]
 TEST_FUNCTION(device_start_async_device_not_stopped)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     ASSERT_ARE_EQUAL(int, DEVICE_STATE_STOPPED, TEST_on_state_changed_callback_saved_previous_state);
     ASSERT_ARE_EQUAL(int, DEVICE_STATE_STARTING, TEST_on_state_changed_callback_saved_new_state);
 
     // act
-    int result = device_start_async(handle, TEST_SESSION_HANDLE, TEST_CBS_HANDLE);
+    int result = amqp_device_start_async(handle, TEST_SESSION_HANDLE, TEST_CBS_HANDLE);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1021,23 +1021,23 @@ TEST_FUNCTION(device_start_async_device_not_stopped)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_019: [If `session_handle` is NULL, device_start_async shall return a non-zero result]
+// Tests_SRS_DEVICE_09_019: [If `session_handle` is NULL, amqp_device_start_async shall return a non-zero result]
 TEST_FUNCTION(device_start_async_NULL_session_handle)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
     set_expected_calls_for_device_start_async(config, TEST_current_time);
 
     // act
-    int result = device_start_async(handle, NULL, TEST_CBS_HANDLE);
+    int result = amqp_device_start_async(handle, NULL, TEST_CBS_HANDLE);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1045,23 +1045,23 @@ TEST_FUNCTION(device_start_async_NULL_session_handle)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_020: [If using CBS authentication and `cbs_handle` is NULL, device_start_async shall return a non-zero result]
+// Tests_SRS_DEVICE_09_020: [If using CBS authentication and `cbs_handle` is NULL, amqp_device_start_async shall return a non-zero result]
 TEST_FUNCTION(device_start_async_CBS_NULL_cbs_handle)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
     set_expected_calls_for_device_start_async(config, TEST_current_time);
 
     // act
-    int result = device_start_async(handle, TEST_SESSION_HANDLE, NULL);
+    int result = amqp_device_start_async(handle, TEST_SESSION_HANDLE, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1069,24 +1069,24 @@ TEST_FUNCTION(device_start_async_CBS_NULL_cbs_handle)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_022: [The device state shall be updated to DEVICE_STATE_STARTING, and state changed callback invoked]
-// Tests_SRS_DEVICE_09_023: [If no failures occur, device_start_async shall return 0]
+// Tests_SRS_DEVICE_09_023: [If no failures occur, amqp_device_start_async shall return 0]
 TEST_FUNCTION(device_start_async_X509_succeeds)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_X509);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_X509);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
     set_expected_calls_for_device_start_async(config, TEST_current_time);
 
     // act
-    int result = device_start_async(handle, TEST_SESSION_HANDLE, NULL);
+    int result = amqp_device_start_async(handle, TEST_SESSION_HANDLE, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1096,24 +1096,24 @@ TEST_FUNCTION(device_start_async_X509_succeeds)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_022: [The device state shall be updated to DEVICE_STATE_STARTING, and state changed callback invoked]
-// Tests_SRS_DEVICE_09_023: [If no failures occur, device_start_async shall return 0]
+// Tests_SRS_DEVICE_09_023: [If no failures occur, amqp_device_start_async shall return 0]
 TEST_FUNCTION(device_start_async_X509_with_module_succeeds)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config_with_module_id(DEVICE_AUTH_MODE_X509);
+    AMQP_DEVICE_CONFIG* config = get_device_config_with_module_id(DEVICE_AUTH_MODE_X509);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
     set_expected_calls_for_device_start_async(config, TEST_current_time);
 
     // act
-    int result = device_start_async(handle, TEST_SESSION_HANDLE, NULL);
+    int result = amqp_device_start_async(handle, TEST_SESSION_HANDLE, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1123,25 +1123,25 @@ TEST_FUNCTION(device_start_async_X509_with_module_succeeds)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 
 // Tests_SRS_DEVICE_09_022: [The device state shall be updated to DEVICE_STATE_STARTING, and state changed callback invoked]
-// Tests_SRS_DEVICE_09_023: [If no failures occur, device_start_async shall return 0]
+// Tests_SRS_DEVICE_09_023: [If no failures occur, amqp_device_start_async shall return 0]
 TEST_FUNCTION(device_start_async_CBS_succeeds)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
     set_expected_calls_for_device_start_async(config, TEST_current_time);
 
     // act
-    int result = device_start_async(handle, TEST_SESSION_HANDLE, TEST_CBS_HANDLE);
+    int result = amqp_device_start_async(handle, TEST_SESSION_HANDLE, TEST_CBS_HANDLE);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1151,36 +1151,36 @@ TEST_FUNCTION(device_start_async_CBS_succeeds)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 
-// Tests_SRS_DEVICE_09_024: [If `handle` is NULL, device_stop shall return a non-zero result]
+// Tests_SRS_DEVICE_09_024: [If `handle` is NULL, amqp_device_stop shall return a non-zero result]
 TEST_FUNCTION(device_stop_NULL_handle)
 {
     // arrange
 
     // act
-    int result = device_stop(NULL);
+    int result = amqp_device_stop(NULL);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
 }
 
-// Tests_SRS_DEVICE_09_025: [If the device state is already DEVICE_STATE_STOPPED or DEVICE_STATE_STOPPING, device_stop shall return a non-zero result]
+// Tests_SRS_DEVICE_09_025: [If the device state is already DEVICE_STATE_STOPPED or DEVICE_STATE_STOPPING, amqp_device_stop shall return a non-zero result]
 TEST_FUNCTION(device_stop_device_already_stopped)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
     set_expected_calls_for_device_stop(config, TEST_current_time, AUTHENTICATION_STATE_STOPPED, TELEMETRY_MESSENGER_STATE_STOPPED, TWIN_MESSENGER_STATE_STOPPED);
 
     // act
-    int result = device_stop(handle);
+    int result = amqp_device_stop(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1190,7 +1190,7 @@ TEST_FUNCTION(device_stop_device_already_stopped)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_028: [If telemetry_messenger_stop fails, the `instance` state shall be updated to DEVICE_STATE_ERROR_MSG and the function shall return non-zero result]
@@ -1202,7 +1202,7 @@ TEST_FUNCTION(device_stop_DEVICE_STATE_STARTED_failure_checks)
     ASSERT_ARE_EQUAL(int, 0, umock_c_negative_tests_init());
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
 
     size_t i, n;
     for (i = 0, n = 1; i < n; i++)
@@ -1220,7 +1220,7 @@ TEST_FUNCTION(device_stop_DEVICE_STATE_STARTED_failure_checks)
         umock_c_negative_tests_reset();
         umock_c_negative_tests_fail_call(i);
 
-        int result = device_stop(handle);
+        int result = amqp_device_stop(handle);
 
         // assert
         sprintf(error_msg, "On failed call %lu", (unsigned long)i);
@@ -1231,7 +1231,7 @@ TEST_FUNCTION(device_stop_DEVICE_STATE_STARTED_failure_checks)
         ASSERT_IS_NOT_NULL(handle, error_msg);
 
         // cleanup
-        device_destroy(handle);
+        amqp_device_destroy(handle);
     }
 
     // cleanup
@@ -1242,20 +1242,20 @@ TEST_FUNCTION(device_stop_DEVICE_STATE_STARTED_failure_checks)
 
 // Tests_SRS_DEVICE_09_026: [The device state shall be updated to DEVICE_STATE_STOPPING, and state changed callback invoked]
 // Tests_SRS_DEVICE_09_031: [The device state shall be updated to DEVICE_STATE_STOPPED, and state changed callback invoked]
-// Tests_SRS_DEVICE_09_032: [If no failures occur, device_stop shall return 0]
+// Tests_SRS_DEVICE_09_032: [If no failures occur, amqp_device_stop shall return 0]
 TEST_FUNCTION(device_stop_DEVICE_STATE_STARTING_succeeds)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
     set_expected_calls_for_device_stop(config, TEST_current_time, AUTHENTICATION_STATE_STOPPED, TELEMETRY_MESSENGER_STATE_STOPPED, TWIN_MESSENGER_STATE_STOPPED);
 
     // act
-    int result = device_stop(handle);
+    int result = amqp_device_stop(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1265,7 +1265,7 @@ TEST_FUNCTION(device_stop_DEVICE_STATE_STARTING_succeeds)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_027: [If `instance->messenger_handle` state is not TELEMETRY_MESSENGER_STATE_STOPPED, telemetry_messenger_stop shall be invoked]
@@ -1276,14 +1276,14 @@ TEST_FUNCTION(device_stop_DEVICE_STATE_STARTED_succeeds)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_and_crank_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
     set_expected_calls_for_device_stop(config, TEST_current_time, AUTHENTICATION_STATE_STARTED, TELEMETRY_MESSENGER_STATE_STARTED, TWIN_MESSENGER_STATE_STARTED);
 
     // act
-    int result = device_stop(handle);
+    int result = amqp_device_stop(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1293,7 +1293,7 @@ TEST_FUNCTION(device_stop_DEVICE_STATE_STARTED_succeeds)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_027: [If `instance->messenger_handle` state is not TELEMETRY_MESSENGER_STATE_STOPPED, telemetry_messenger_stop shall be invoked]
@@ -1304,14 +1304,14 @@ TEST_FUNCTION(device_stop_DEVICE_STATE_STARTED_with_module_succeeds)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config_with_module_id(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config_with_module_id(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_and_crank_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
     set_expected_calls_for_device_stop(config, TEST_current_time, AUTHENTICATION_STATE_STARTED, TELEMETRY_MESSENGER_STATE_STARTED, TWIN_MESSENGER_STATE_STARTED);
 
     // act
-    int result = device_stop(handle);
+    int result = amqp_device_stop(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1321,18 +1321,18 @@ TEST_FUNCTION(device_stop_DEVICE_STATE_STARTED_with_module_succeeds)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 
-// Tests_SRS_DEVICE_09_012: [If `handle` is NULL, device_destroy shall return]
+// Tests_SRS_DEVICE_09_012: [If `handle` is NULL, amqp_device_destroy shall return]
 TEST_FUNCTION(device_destroy_NULL_handle)
 {
     // arrange
     umock_c_reset_all_calls();
 
     // act
-    device_destroy(NULL);
+    amqp_device_destroy(NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1340,7 +1340,7 @@ TEST_FUNCTION(device_destroy_NULL_handle)
     // cleanup
 }
 
-// Tests_SRS_DEVICE_09_013: [If the device is in state DEVICE_STATE_STARTED or DEVICE_STATE_STARTING, device_stop() shall be invoked]
+// Tests_SRS_DEVICE_09_013: [If the device is in state DEVICE_STATE_STARTED or DEVICE_STATE_STARTING, amqp_device_stop() shall be invoked]
 // Tests_SRS_DEVICE_09_014: [`instance->messenger_handle shall be destroyed using telemetry_messenger_destroy()`]
 // Tests_SRS_DEVICE_09_015: [If created, `instance->authentication_handle` shall be destroyed using authentication_destroy()`]
 // Tests_SRS_DEVICE_09_016: [The contents of `instance->config` shall be detroyed and then it shall be freed]
@@ -1349,14 +1349,14 @@ TEST_FUNCTION(device_destroy_DEVICE_STATE_STARTED_succeeds)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_and_crank_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
     set_expected_calls_for_device_destroy(handle, config, TEST_current_time, DEVICE_STATE_STARTED, AUTHENTICATION_STATE_STARTED, TELEMETRY_MESSENGER_STATE_STARTED, TWIN_MESSENGER_STATE_STARTED);
 
     // act
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1366,7 +1366,7 @@ TEST_FUNCTION(device_destroy_DEVICE_STATE_STARTED_succeeds)
 }
 
 
-// Tests_SRS_DEVICE_09_105: [If `handle` or `send_status` is NULL, device_get_send_status shall return a non-zero result]
+// Tests_SRS_DEVICE_09_105: [If `handle` or `send_status` is NULL, amqp_device_get_send_status shall return a non-zero result]
 TEST_FUNCTION(device_get_send_status_NULL_handle)
 {
     // arrange
@@ -1375,7 +1375,7 @@ TEST_FUNCTION(device_get_send_status_NULL_handle)
     DEVICE_SEND_STATUS send_status;
 
     // act
-    int result = device_get_send_status(NULL, &send_status);
+    int result = amqp_device_get_send_status(NULL, &send_status);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1384,19 +1384,19 @@ TEST_FUNCTION(device_get_send_status_NULL_handle)
     // cleanup
 }
 
-// Tests_SRS_DEVICE_09_105: [If `handle` or `send_status` is NULL, device_get_send_status shall return a non-zero result]
+// Tests_SRS_DEVICE_09_105: [If `handle` or `send_status` is NULL, amqp_device_get_send_status shall return a non-zero result]
 TEST_FUNCTION(device_get_send_status_NULL_send_status)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
 
     // act
-    int result = device_get_send_status(handle, NULL);
+    int result = amqp_device_get_send_status(handle, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1404,18 +1404,18 @@ TEST_FUNCTION(device_get_send_status_NULL_send_status)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_106: [The status of `instance->messenger_handle` shall be obtained using telemetry_messenger_get_send_status]
-// Tests_SRS_DEVICE_09_108: [If telemetry_messenger_get_send_status returns TELEMETRY_MESSENGER_SEND_STATUS_IDLE, device_get_send_status return status DEVICE_SEND_STATUS_IDLE]
-// Tests_SRS_DEVICE_09_110: [If device_get_send_status succeeds, it shall return zero as result]
+// Tests_SRS_DEVICE_09_108: [If telemetry_messenger_get_send_status returns TELEMETRY_MESSENGER_SEND_STATUS_IDLE, amqp_device_get_send_status return status DEVICE_SEND_STATUS_IDLE]
+// Tests_SRS_DEVICE_09_110: [If amqp_device_get_send_status succeeds, it shall return zero as result]
 TEST_FUNCTION(device_get_send_status_IDLE_success)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     TELEMETRY_MESSENGER_SEND_STATUS telemetry_messenger_get_send_status_result = TELEMETRY_MESSENGER_SEND_STATUS_IDLE;
@@ -1428,7 +1428,7 @@ TEST_FUNCTION(device_get_send_status_IDLE_success)
 
     // act
     DEVICE_SEND_STATUS send_status;
-    int result = device_get_send_status(handle, &send_status);
+    int result = amqp_device_get_send_status(handle, &send_status);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1437,18 +1437,18 @@ TEST_FUNCTION(device_get_send_status_IDLE_success)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_106: [The status of `instance->messenger_handle` shall be obtained using telemetry_messenger_get_send_status]
-// Tests_SRS_DEVICE_09_108: [If telemetry_messenger_get_send_status returns TELEMETRY_MESSENGER_SEND_STATUS_IDLE, device_get_send_status return status DEVICE_SEND_STATUS_IDLE]
-// Tests_SRS_DEVICE_09_110: [If device_get_send_status succeeds, it shall return zero as result]
+// Tests_SRS_DEVICE_09_108: [If telemetry_messenger_get_send_status returns TELEMETRY_MESSENGER_SEND_STATUS_IDLE, amqp_device_get_send_status return status DEVICE_SEND_STATUS_IDLE]
+// Tests_SRS_DEVICE_09_110: [If amqp_device_get_send_status succeeds, it shall return zero as result]
 TEST_FUNCTION(device_get_send_status_IDLE_with_module_success)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config_with_module_id(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config_with_module_id(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     TELEMETRY_MESSENGER_SEND_STATUS telemetry_messenger_get_send_status_result = TELEMETRY_MESSENGER_SEND_STATUS_IDLE;
@@ -1461,7 +1461,7 @@ TEST_FUNCTION(device_get_send_status_IDLE_with_module_success)
 
     // act
     DEVICE_SEND_STATUS send_status;
-    int result = device_get_send_status(handle, &send_status);
+    int result = amqp_device_get_send_status(handle, &send_status);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1470,17 +1470,17 @@ TEST_FUNCTION(device_get_send_status_IDLE_with_module_success)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 
-// Tests_SRS_DEVICE_09_109: [If telemetry_messenger_get_send_status returns TELEMETRY_MESSENGER_SEND_STATUS_BUSY, device_get_send_status return status DEVICE_SEND_STATUS_BUSY]
+// Tests_SRS_DEVICE_09_109: [If telemetry_messenger_get_send_status returns TELEMETRY_MESSENGER_SEND_STATUS_BUSY, amqp_device_get_send_status return status DEVICE_SEND_STATUS_BUSY]
 TEST_FUNCTION(device_get_send_status_BUSY_success)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     TELEMETRY_MESSENGER_SEND_STATUS telemetry_messenger_get_send_status_result = TELEMETRY_MESSENGER_SEND_STATUS_BUSY;
@@ -1493,7 +1493,7 @@ TEST_FUNCTION(device_get_send_status_BUSY_success)
 
     // act
     DEVICE_SEND_STATUS send_status;
-    int result = device_get_send_status(handle, &send_status);
+    int result = amqp_device_get_send_status(handle, &send_status);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1502,16 +1502,16 @@ TEST_FUNCTION(device_get_send_status_BUSY_success)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_107: [If telemetry_messenger_get_send_status fails, device_get_send_status shall return a non-zero result]
+// Tests_SRS_DEVICE_09_107: [If telemetry_messenger_get_send_status fails, amqp_device_get_send_status shall return a non-zero result]
 TEST_FUNCTION(device_get_send_status_failure_checks)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
@@ -1521,7 +1521,7 @@ TEST_FUNCTION(device_get_send_status_failure_checks)
 
     // act
     DEVICE_SEND_STATUS send_status;
-    int result = device_get_send_status(handle, &send_status);
+    int result = amqp_device_get_send_status(handle, &send_status);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1529,17 +1529,17 @@ TEST_FUNCTION(device_get_send_status_failure_checks)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_066: [If `handle` or `on_message_received_callback` or `context` is NULL, device_subscribe_message shall return a non-zero result]
+// Tests_SRS_DEVICE_09_066: [If `handle` or `on_message_received_callback` or `context` is NULL, amqp_device_subscribe_message shall return a non-zero result]
 TEST_FUNCTION(device_subscribe_message_NULL_handle)
 {
     // arrange
     umock_c_reset_all_calls();
 
     // act
-    int result = device_subscribe_message(NULL, TEST_on_message_received, TEST_VOID_PTR);
+    int result = amqp_device_subscribe_message(NULL, TEST_on_message_received, TEST_VOID_PTR);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1548,19 +1548,19 @@ TEST_FUNCTION(device_subscribe_message_NULL_handle)
     // cleanup
 }
 
-// Tests_SRS_DEVICE_09_066: [If `handle` or `on_message_received_callback` or `context` is NULL, device_subscribe_message shall return a non-zero result]
+// Tests_SRS_DEVICE_09_066: [If `handle` or `on_message_received_callback` or `context` is NULL, amqp_device_subscribe_message shall return a non-zero result]
 TEST_FUNCTION(device_subscribe_message_NULL_callback)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
 
     // act
-    int result = device_subscribe_message(handle, NULL, handle);
+    int result = amqp_device_subscribe_message(handle, NULL, handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1568,22 +1568,22 @@ TEST_FUNCTION(device_subscribe_message_NULL_callback)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_066: [If `handle` or `on_message_received_callback` or `context` is NULL, device_subscribe_message shall return a non-zero result]
+// Tests_SRS_DEVICE_09_066: [If `handle` or `on_message_received_callback` or `context` is NULL, amqp_device_subscribe_message shall return a non-zero result]
 TEST_FUNCTION(device_subscribe_message_NULL_context)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
 
     // act
-    int result = device_subscribe_message(handle, TEST_on_message_received, NULL);
+    int result = amqp_device_subscribe_message(handle, TEST_on_message_received, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1591,17 +1591,17 @@ TEST_FUNCTION(device_subscribe_message_NULL_context)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_067: [telemetry_messenger_subscribe_for_messages shall be invoked passing `on_messenger_message_received_callback` and the user callback and context]
-// Tests_SRS_DEVICE_09_069: [If no failures occur, device_subscribe_message shall return 0]
+// Tests_SRS_DEVICE_09_069: [If no failures occur, amqp_device_subscribe_message shall return 0]
 TEST_FUNCTION(device_subscribe_message_succeess)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
@@ -1612,7 +1612,7 @@ TEST_FUNCTION(device_subscribe_message_succeess)
         .IgnoreArgument(3);
 
     // act
-    int result = device_subscribe_message(handle, TEST_on_message_received, handle);
+    int result = amqp_device_subscribe_message(handle, TEST_on_message_received, handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1621,16 +1621,16 @@ TEST_FUNCTION(device_subscribe_message_succeess)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_068: [If telemetry_messenger_subscribe_for_messages fails, device_subscribe_message shall return a non-zero result]
+// Tests_SRS_DEVICE_09_068: [If telemetry_messenger_subscribe_for_messages fails, amqp_device_subscribe_message shall return a non-zero result]
 TEST_FUNCTION(device_subscribe_message_failure_checks)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
@@ -1641,7 +1641,7 @@ TEST_FUNCTION(device_subscribe_message_failure_checks)
         .SetReturn(1);
 
     // act
-    int result = device_subscribe_message(handle, TEST_on_message_received, handle);
+    int result = amqp_device_subscribe_message(handle, TEST_on_message_received, handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1649,17 +1649,17 @@ TEST_FUNCTION(device_subscribe_message_failure_checks)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_080: [If `handle` is NULL, device_set_retry_policy shall return a non-zero result]
+// Tests_SRS_DEVICE_09_080: [If `handle` is NULL, amqp_device_set_retry_policy shall return a non-zero result]
 TEST_FUNCTION(device_set_retry_policy_NULL_handle)
 {
     // arrange
     umock_c_reset_all_calls();
 
     // act
-    int result = device_set_retry_policy(NULL, IOTHUB_CLIENT_RETRY_EXPONENTIAL_BACKOFF_WITH_JITTER, 300);
+    int result = amqp_device_set_retry_policy(NULL, IOTHUB_CLIENT_RETRY_EXPONENTIAL_BACKOFF_WITH_JITTER, 300);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1668,19 +1668,19 @@ TEST_FUNCTION(device_set_retry_policy_NULL_handle)
     // cleanup
 }
 
-// Tests_SRS_DEVICE_09_081: [device_set_retry_policy shall return a non-zero result]
+// Tests_SRS_DEVICE_09_081: [amqp_device_set_retry_policy shall return a non-zero result]
 TEST_FUNCTION(device_set_retry_policy_succeeds)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
 
     // act
-    int result = device_set_retry_policy(handle, IOTHUB_CLIENT_RETRY_EXPONENTIAL_BACKOFF_WITH_JITTER, 300);
+    int result = amqp_device_set_retry_policy(handle, IOTHUB_CLIENT_RETRY_EXPONENTIAL_BACKOFF_WITH_JITTER, 300);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1688,17 +1688,17 @@ TEST_FUNCTION(device_set_retry_policy_succeeds)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_093: [If `handle` is NULL, device_retrieve_options shall return NULL]
+// Tests_SRS_DEVICE_09_093: [If `handle` is NULL, amqp_device_retrieve_options shall return NULL]
 TEST_FUNCTION(device_retrieve_options_NULL_handle)
 {
     // arrange
     umock_c_reset_all_calls();
 
     // act
-    OPTIONHANDLER_HANDLE options = device_retrieve_options(NULL);
+    OPTIONHANDLER_HANDLE options = amqp_device_retrieve_options(NULL);
 
     // assert
     ASSERT_IS_NULL(options);
@@ -1717,14 +1717,14 @@ TEST_FUNCTION(device_retrieve_options_CBS_succeeds)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
     set_expected_calls_for_device_retrieve_options(config);
 
     // act
-    OPTIONHANDLER_HANDLE result = device_retrieve_options(handle);
+    OPTIONHANDLER_HANDLE result = amqp_device_retrieve_options(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1732,7 +1732,7 @@ TEST_FUNCTION(device_retrieve_options_CBS_succeeds)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_096: [If CBS authentication is used, `instance->authentication_handle` options shall be retrieved using authentication_retrieve_options]
@@ -1741,14 +1741,14 @@ TEST_FUNCTION(device_retrieve_options_X509_succeeds)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_X509);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_X509);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
     set_expected_calls_for_device_retrieve_options(config);
 
     // act
-    OPTIONHANDLER_HANDLE result = device_retrieve_options(handle);
+    OPTIONHANDLER_HANDLE result = amqp_device_retrieve_options(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1756,21 +1756,21 @@ TEST_FUNCTION(device_retrieve_options_X509_succeeds)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_095: [If OptionHandler_Create fails, device_retrieve_options shall return NULL]
-// Tests_SRS_DEVICE_09_097: [If authentication_retrieve_options fails, device_retrieve_options shall return NULL]
-// Tests_SRS_DEVICE_09_100: [If telemetry_messenger_retrieve_options fails, device_retrieve_options shall return NULL]
-// Tests_SRS_DEVICE_09_102: [If any call to OptionHandler_AddOption fails, device_retrieve_options shall return NULL]
-// Tests_SRS_DEVICE_09_103: [If any failure occurs, any memory allocated by device_retrieve_options shall be destroyed]
+// Tests_SRS_DEVICE_09_095: [If OptionHandler_Create fails, amqp_device_retrieve_options shall return NULL]
+// Tests_SRS_DEVICE_09_097: [If authentication_retrieve_options fails, amqp_device_retrieve_options shall return NULL]
+// Tests_SRS_DEVICE_09_100: [If telemetry_messenger_retrieve_options fails, amqp_device_retrieve_options shall return NULL]
+// Tests_SRS_DEVICE_09_102: [If any call to OptionHandler_AddOption fails, amqp_device_retrieve_options shall return NULL]
+// Tests_SRS_DEVICE_09_103: [If any failure occurs, any memory allocated by amqp_device_retrieve_options shall be destroyed]
 TEST_FUNCTION(device_retrieve_options_CBS_failure_checks)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
     ASSERT_ARE_EQUAL(int, 0, umock_c_negative_tests_init());
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
@@ -1787,7 +1787,7 @@ TEST_FUNCTION(device_retrieve_options_CBS_failure_checks)
         umock_c_negative_tests_reset();
         umock_c_negative_tests_fail_call(i);
 
-        OPTIONHANDLER_HANDLE result = device_retrieve_options(handle);
+        OPTIONHANDLER_HANDLE result = amqp_device_retrieve_options(handle);
 
         // assert
         sprintf(error_msg, "On failed call %lu", (unsigned long)i);
@@ -1797,18 +1797,18 @@ TEST_FUNCTION(device_retrieve_options_CBS_failure_checks)
     // cleanup
     umock_c_negative_tests_deinit();
     umock_c_reset_all_calls();
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 
-// Tests_SRS_DEVICE_09_082: [If `handle` or `name` or `value` are NULL, device_set_option shall return a non-zero result]
-// Tests_SRS_DEVICE_09_083: [If `name` refers to authentication but CBS authentication is not used, device_set_option shall return a non-zero result]
+// Tests_SRS_DEVICE_09_082: [If `handle` or `name` or `value` are NULL, amqp_device_set_option shall return a non-zero result]
+// Tests_SRS_DEVICE_09_083: [If `name` refers to authentication but CBS authentication is not used, amqp_device_set_option shall return a non-zero result]
 TEST_FUNCTION(device_set_option_X509_AUTH_fails)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_X509);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_X509);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     size_t value = 400;
@@ -1817,7 +1817,7 @@ TEST_FUNCTION(device_set_option_X509_AUTH_fails)
     set_expected_calls_for_device_set_option(handle, config, DEVICE_OPTION_CBS_REQUEST_TIMEOUT_SECS, &value);
 
     // act
-    int result = device_set_option(handle, DEVICE_OPTION_CBS_REQUEST_TIMEOUT_SECS, &value);
+    int result = amqp_device_set_option(handle, DEVICE_OPTION_CBS_REQUEST_TIMEOUT_SECS, &value);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1825,10 +1825,10 @@ TEST_FUNCTION(device_set_option_X509_AUTH_fails)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_085: [If authentication_set_option fails, device_set_option shall return a non-zero result]
+// Tests_SRS_DEVICE_09_085: [If authentication_set_option fails, amqp_device_set_option shall return a non-zero result]
 TEST_FUNCTION(device_set_option_saved_auth_options_fails)
 {
     // arrange
@@ -1836,7 +1836,7 @@ TEST_FUNCTION(device_set_option_saved_auth_options_fails)
 
     ASSERT_ARE_EQUAL(int, 0, umock_c_negative_tests_init());
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     size_t value = 400;
@@ -1849,7 +1849,7 @@ TEST_FUNCTION(device_set_option_saved_auth_options_fails)
     umock_c_negative_tests_fail_call(0);
 
     // act
-    int result = device_set_option(handle, DEVICE_OPTION_CBS_REQUEST_TIMEOUT_SECS, &value);
+    int result = amqp_device_set_option(handle, DEVICE_OPTION_CBS_REQUEST_TIMEOUT_SECS, &value);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -1859,10 +1859,10 @@ TEST_FUNCTION(device_set_option_saved_auth_options_fails)
     umock_c_negative_tests_deinit();
     umock_c_reset_all_calls();
 
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_087: [If telemetry_messenger_set_option fails, device_set_option shall return a non-zero result]
+// Tests_SRS_DEVICE_09_087: [If telemetry_messenger_set_option fails, amqp_device_set_option shall return a non-zero result]
 TEST_FUNCTION(device_set_option_saved_msgr_options_fails)
 {
     // arrange
@@ -1870,7 +1870,7 @@ TEST_FUNCTION(device_set_option_saved_msgr_options_fails)
 
     ASSERT_ARE_EQUAL(int, 0, umock_c_negative_tests_init());
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     size_t value = 400;
@@ -1883,7 +1883,7 @@ TEST_FUNCTION(device_set_option_saved_msgr_options_fails)
     umock_c_negative_tests_fail_call(0);
 
     // act
-    int result = device_set_option(handle, DEVICE_OPTION_EVENT_SEND_TIMEOUT_SECS, &value);
+    int result = amqp_device_set_option(handle, DEVICE_OPTION_EVENT_SEND_TIMEOUT_SECS, &value);
 
     // assert
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
@@ -1893,17 +1893,17 @@ TEST_FUNCTION(device_set_option_saved_msgr_options_fails)
     umock_c_negative_tests_deinit();
     umock_c_reset_all_calls();
 
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_084: [If `name` refers to authentication, it shall be passed along with `value` to authentication_set_option]
-// Tests_SRS_DEVICE_09_092: [If no failures occur, device_set_option shall return 0]
+// Tests_SRS_DEVICE_09_092: [If no failures occur, amqp_device_set_option shall return 0]
 TEST_FUNCTION(device_set_option_CBS_AUTH_succeeds)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     size_t value = 400;
@@ -1912,7 +1912,7 @@ TEST_FUNCTION(device_set_option_CBS_AUTH_succeeds)
     set_expected_calls_for_device_set_option(handle, config, DEVICE_OPTION_CBS_REQUEST_TIMEOUT_SECS, &value);
 
     // act
-    int result = device_set_option(handle, DEVICE_OPTION_CBS_REQUEST_TIMEOUT_SECS, &value);
+    int result = amqp_device_set_option(handle, DEVICE_OPTION_CBS_REQUEST_TIMEOUT_SECS, &value);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1920,17 +1920,17 @@ TEST_FUNCTION(device_set_option_CBS_AUTH_succeeds)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_086: [If `name` refers to messenger module, it shall be passed along with `value` to telemetry_messenger_set_option]
-// Tests_SRS_DEVICE_09_092: [If no failures occur, device_set_option shall return 0]
+// Tests_SRS_DEVICE_09_092: [If no failures occur, amqp_device_set_option shall return 0]
 TEST_FUNCTION(device_set_option_MSGR_succeeds)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     size_t value = 400;
@@ -1939,7 +1939,7 @@ TEST_FUNCTION(device_set_option_MSGR_succeeds)
     set_expected_calls_for_device_set_option(handle, config, DEVICE_OPTION_EVENT_SEND_TIMEOUT_SECS, &value);
 
     // act
-    int result = device_set_option(handle, DEVICE_OPTION_EVENT_SEND_TIMEOUT_SECS, &value);
+    int result = amqp_device_set_option(handle, DEVICE_OPTION_EVENT_SEND_TIMEOUT_SECS, &value);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1947,16 +1947,16 @@ TEST_FUNCTION(device_set_option_MSGR_succeeds)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_088: [If `name` is DEVICE_OPTION_SAVED_AUTH_OPTIONS but CBS authentication is not being used, device_set_option shall return a non-zero result]
+// Tests_SRS_DEVICE_09_088: [If `name` is DEVICE_OPTION_SAVED_AUTH_OPTIONS but CBS authentication is not being used, amqp_device_set_option shall return a non-zero result]
 TEST_FUNCTION(device_set_option_X509_saved_auth_options)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_X509);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_X509);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     OPTIONHANDLER_HANDLE value = TEST_AUTH_OPTIONHANDLER_HANDLE;
@@ -1965,7 +1965,7 @@ TEST_FUNCTION(device_set_option_X509_saved_auth_options)
     set_expected_calls_for_device_set_option(handle, config, DEVICE_OPTION_SAVED_AUTH_OPTIONS, &value); // no-op
 
     // act
-    int result = device_set_option(handle, DEVICE_OPTION_SAVED_AUTH_OPTIONS, &value);
+    int result = amqp_device_set_option(handle, DEVICE_OPTION_SAVED_AUTH_OPTIONS, &value);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1973,7 +1973,7 @@ TEST_FUNCTION(device_set_option_X509_saved_auth_options)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 TEST_FUNCTION(device_set_option_AUTH_saved_auth_options_succeeds)
@@ -1981,7 +1981,7 @@ TEST_FUNCTION(device_set_option_AUTH_saved_auth_options_succeeds)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     OPTIONHANDLER_HANDLE value = TEST_AUTH_OPTIONHANDLER_HANDLE;
@@ -1990,7 +1990,7 @@ TEST_FUNCTION(device_set_option_AUTH_saved_auth_options_succeeds)
     set_expected_calls_for_device_set_option(handle, config, DEVICE_OPTION_SAVED_AUTH_OPTIONS, &value);
 
     // act
-    int result = device_set_option(handle, DEVICE_OPTION_SAVED_AUTH_OPTIONS, &value);
+    int result = amqp_device_set_option(handle, DEVICE_OPTION_SAVED_AUTH_OPTIONS, &value);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1998,7 +1998,7 @@ TEST_FUNCTION(device_set_option_AUTH_saved_auth_options_succeeds)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_089: [If `name` is DEVICE_OPTION_SAVED_MESSENGER_OPTIONS, `value` shall be fed to `instance->messenger_handle` using OptionHandler_FeedOptions]
@@ -2007,7 +2007,7 @@ TEST_FUNCTION(device_set_option_MSGR_saved_msgr_options_succeeds)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     OPTIONHANDLER_HANDLE value = TEST_MSGR_OPTIONHANDLER_HANDLE;
@@ -2016,7 +2016,7 @@ TEST_FUNCTION(device_set_option_MSGR_saved_msgr_options_succeeds)
     set_expected_calls_for_device_set_option(handle, config, DEVICE_OPTION_SAVED_MESSENGER_OPTIONS, &value);
 
     // act
-    int result = device_set_option(handle, DEVICE_OPTION_SAVED_MESSENGER_OPTIONS, &value);
+    int result = amqp_device_set_option(handle, DEVICE_OPTION_SAVED_MESSENGER_OPTIONS, &value);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2024,7 +2024,7 @@ TEST_FUNCTION(device_set_option_MSGR_saved_msgr_options_succeeds)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_090: [If `name` is DEVICE_OPTION_SAVED_OPTIONS, `value` shall be fed to `instance` using OptionHandler_FeedOptions]
@@ -2033,7 +2033,7 @@ TEST_FUNCTION(device_set_option_saved_device_options_succeeds)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     OPTIONHANDLER_HANDLE value = TEST_OPTIONHANDLER_HANDLE;
@@ -2042,7 +2042,7 @@ TEST_FUNCTION(device_set_option_saved_device_options_succeeds)
     set_expected_calls_for_device_set_option(handle, config, DEVICE_OPTION_SAVED_OPTIONS, &value);
 
     // act
-    int result = device_set_option(handle, DEVICE_OPTION_SAVED_OPTIONS, &value);
+    int result = amqp_device_set_option(handle, DEVICE_OPTION_SAVED_OPTIONS, &value);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2050,10 +2050,10 @@ TEST_FUNCTION(device_set_option_saved_device_options_succeeds)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_091: [If any call to OptionHandler_FeedOptions fails, device_set_option shall return a non-zero result]
+// Tests_SRS_DEVICE_09_091: [If any call to OptionHandler_FeedOptions fails, amqp_device_set_option shall return a non-zero result]
 TEST_FUNCTION(device_set_option_saved_device_options_fails)
 {
     // arrange
@@ -2061,7 +2061,7 @@ TEST_FUNCTION(device_set_option_saved_device_options_fails)
 
     ASSERT_ARE_EQUAL(int, 0, umock_c_negative_tests_init());
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     OPTIONHANDLER_HANDLE value = TEST_OPTIONHANDLER_HANDLE;
@@ -2074,7 +2074,7 @@ TEST_FUNCTION(device_set_option_saved_device_options_fails)
     umock_c_negative_tests_fail_call(0);
 
     // act
-    int result = device_set_option(handle, DEVICE_OPTION_SAVED_OPTIONS, &value);
+    int result = amqp_device_set_option(handle, DEVICE_OPTION_SAVED_OPTIONS, &value);
 
     // assert
     //ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2085,17 +2085,17 @@ TEST_FUNCTION(device_set_option_saved_device_options_fails)
     umock_c_negative_tests_deinit();
     umock_c_reset_all_calls();
 
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_076: [If `handle` is NULL, device_unsubscribe_message shall return a non-zero result]
+// Tests_SRS_DEVICE_09_076: [If `handle` is NULL, amqp_device_unsubscribe_message shall return a non-zero result]
 TEST_FUNCTION(device_unsubscribe_message_NULL_handle)
 {
     // arrange
     umock_c_reset_all_calls();
 
     // act
-    int result = device_unsubscribe_message(NULL);
+    int result = amqp_device_unsubscribe_message(NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2105,13 +2105,13 @@ TEST_FUNCTION(device_unsubscribe_message_NULL_handle)
 }
 
 // Tests_SRS_DEVICE_09_077: [telemetry_messenger_unsubscribe_for_messages shall be invoked passing `instance->messenger_handle`]
-// Tests_SRS_DEVICE_09_079: [If no failures occur, device_unsubscribe_message shall return 0]
+// Tests_SRS_DEVICE_09_079: [If no failures occur, amqp_device_unsubscribe_message shall return 0]
 TEST_FUNCTION(device_unsubscribe_message_succeess)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
@@ -2120,7 +2120,7 @@ TEST_FUNCTION(device_unsubscribe_message_succeess)
         .SetReturn(0);
 
     // act
-    int result = device_unsubscribe_message(handle);
+    int result = amqp_device_unsubscribe_message(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2128,16 +2128,16 @@ TEST_FUNCTION(device_unsubscribe_message_succeess)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_078: [If telemetry_messenger_unsubscribe_for_messages fails, device_unsubscribe_message shall return a non-zero result]
+// Tests_SRS_DEVICE_09_078: [If telemetry_messenger_unsubscribe_for_messages fails, amqp_device_unsubscribe_message shall return a non-zero result]
 TEST_FUNCTION(device_unsubscribe_message_failure_checks)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
@@ -2146,7 +2146,7 @@ TEST_FUNCTION(device_unsubscribe_message_failure_checks)
         .SetReturn(1);
 
     // act
-    int result = device_unsubscribe_message(handle);
+    int result = amqp_device_unsubscribe_message(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2154,22 +2154,22 @@ TEST_FUNCTION(device_unsubscribe_message_failure_checks)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_051: [If `handle` or `message` are NULL, device_send_event_async shall return a non-zero result]
+// Tests_SRS_DEVICE_09_051: [If `handle` or `message` are NULL, amqp_device_send_event_async shall return a non-zero result]
 TEST_FUNCTION(telemetry_messenger_send_async_NULL_handle)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
 
     // act
-    int result = device_send_event_async(NULL, TEST_IOTHUB_MESSAGE_LIST, TEST_on_device_d2c_event_send_complete_callback, TEST_ON_DEVICE_EVENT_SEND_COMPLETE_CONTEXT);
+    int result = amqp_device_send_event_async(NULL, TEST_IOTHUB_MESSAGE_LIST, TEST_on_device_d2c_event_send_complete_callback, TEST_ON_DEVICE_EVENT_SEND_COMPLETE_CONTEXT);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2177,22 +2177,22 @@ TEST_FUNCTION(telemetry_messenger_send_async_NULL_handle)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_051: [If `handle` or `message` are NULL, device_send_event_async shall return a non-zero result]
+// Tests_SRS_DEVICE_09_051: [If `handle` or `message` are NULL, amqp_device_send_event_async shall return a non-zero result]
 TEST_FUNCTION(telemetry_messenger_send_async_NULL_message)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
 
     // act
-    int result = device_send_event_async(handle, NULL, TEST_on_device_d2c_event_send_complete_callback, TEST_ON_DEVICE_EVENT_SEND_COMPLETE_CONTEXT);
+    int result = amqp_device_send_event_async(handle, NULL, TEST_on_device_d2c_event_send_complete_callback, TEST_ON_DEVICE_EVENT_SEND_COMPLETE_CONTEXT);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2200,12 +2200,12 @@ TEST_FUNCTION(telemetry_messenger_send_async_NULL_message)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_053: [If `send_task` fails to be created, device_send_event_async shall return a non-zero value]
-// Tests_SRS_DEVICE_09_056: [If telemetry_messenger_send_async fails, device_send_event_async shall return a non-zero value]
-// Tests_SRS_DEVICE_09_057: [If any failures occur, device_send_event_async shall release all memory it has allocated]
+// Tests_SRS_DEVICE_09_053: [If `send_task` fails to be created, amqp_device_send_event_async shall return a non-zero value]
+// Tests_SRS_DEVICE_09_056: [If telemetry_messenger_send_async fails, amqp_device_send_event_async shall return a non-zero value]
+// Tests_SRS_DEVICE_09_057: [If any failures occur, amqp_device_send_event_async shall release all memory it has allocated]
 TEST_FUNCTION(telemetry_messenger_send_async_failure_checks)
 {
     // arrange
@@ -2213,7 +2213,7 @@ TEST_FUNCTION(telemetry_messenger_send_async_failure_checks)
 
     ASSERT_ARE_EQUAL(int, 0, umock_c_negative_tests_init());
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
@@ -2230,7 +2230,7 @@ TEST_FUNCTION(telemetry_messenger_send_async_failure_checks)
         umock_c_negative_tests_reset();
         umock_c_negative_tests_fail_call(i);
 
-        int result = device_send_event_async(handle, TEST_IOTHUB_MESSAGE_LIST, TEST_on_device_d2c_event_send_complete_callback, TEST_ON_DEVICE_EVENT_SEND_COMPLETE_CONTEXT);
+        int result = amqp_device_send_event_async(handle, TEST_IOTHUB_MESSAGE_LIST, TEST_on_device_d2c_event_send_complete_callback, TEST_ON_DEVICE_EVENT_SEND_COMPLETE_CONTEXT);
 
         // assert
         sprintf(error_msg, "On failed call %lu", (unsigned long)i);
@@ -2241,26 +2241,26 @@ TEST_FUNCTION(telemetry_messenger_send_async_failure_checks)
     umock_c_negative_tests_deinit();
     umock_c_reset_all_calls();
 
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_052: [A structure (`send_task`) shall be created to track the send state of the message]
 // Tests_SRS_DEVICE_09_054: [`send_task` shall contain the user callback and the context provided]
 // Tests_SRS_DEVICE_09_055: [The message shall be sent using telemetry_messenger_send_async, passing `on_event_send_complete_messenger_callback` and `send_task`]
-// Tests_SRS_DEVICE_09_058: [If no failures occur, device_send_event_async shall return 0]
+// Tests_SRS_DEVICE_09_058: [If no failures occur, amqp_device_send_event_async shall return 0]
 TEST_FUNCTION(telemetry_messenger_send_async_succeeds)
 {
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
     set_expected_calls_for_device_send_async(config);
 
     // act
-    int result = device_send_event_async(handle, TEST_IOTHUB_MESSAGE_LIST, TEST_on_device_d2c_event_send_complete_callback, TEST_ON_DEVICE_EVENT_SEND_COMPLETE_CONTEXT);
+    int result = amqp_device_send_event_async(handle, TEST_IOTHUB_MESSAGE_LIST, TEST_on_device_d2c_event_send_complete_callback, TEST_ON_DEVICE_EVENT_SEND_COMPLETE_CONTEXT);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2271,18 +2271,18 @@ TEST_FUNCTION(telemetry_messenger_send_async_succeeds)
     EXPECTED_CALL(free(IGNORED_PTR_ARG));
     TEST_telemetry_messenger_send_async_saved_callback(TEST_telemetry_messenger_send_async_saved_message, TELEMETRY_MESSENGER_EVENT_SEND_COMPLETE_RESULT_OK, TEST_telemetry_messenger_send_async_saved_context);
 
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 
-// Tests_SRS_DEVICE_09_033: [If `handle` is NULL, device_do_work shall return]
+// Tests_SRS_DEVICE_09_033: [If `handle` is NULL, amqp_device_do_work shall return]
 TEST_FUNCTION(device_do_work_NULL_handle)
 {
     // arrange
     umock_c_reset_all_calls();
 
     // act
-    device_do_work(NULL);
+    amqp_device_do_work(NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2295,14 +2295,14 @@ TEST_FUNCTION(device_do_work_authentication_start_fails)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
     set_expected_calls_for_device_do_work(config, TEST_current_time, DEVICE_STATE_STARTING, AUTHENTICATION_STATE_STOPPED, TELEMETRY_MESSENGER_STATE_STOPPED, TWIN_MESSENGER_STATE_STOPPED);
 
     // act
-    device_do_work(handle);
+    amqp_device_do_work(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2310,7 +2310,7 @@ TEST_FUNCTION(device_do_work_authentication_start_fails)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_036: [If authentication state is AUTHENTICATION_STATE_STARTING, the device shall track the time since last event change and timeout if needed]
@@ -2320,7 +2320,7 @@ TEST_FUNCTION(device_do_work_authentication_start_times_out)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     time_t next_time = add_seconds(TEST_current_time, DEFAULT_AUTH_STATE_CHANGED_TIMEOUT_SECS + 1);
@@ -2328,13 +2328,13 @@ TEST_FUNCTION(device_do_work_authentication_start_times_out)
     umock_c_reset_all_calls();
     set_expected_calls_for_device_do_work(config, TEST_current_time, DEVICE_STATE_STARTING, AUTHENTICATION_STATE_STOPPED, TELEMETRY_MESSENGER_STATE_STOPPED, TWIN_MESSENGER_STATE_STOPPED);
 
-    device_do_work(handle);
+    amqp_device_do_work(handle);
     set_authentication_state(AUTHENTICATION_STATE_STOPPED, AUTHENTICATION_STATE_STARTING, TEST_current_time);
 
     set_expected_calls_for_device_do_work(config, next_time, DEVICE_STATE_STARTING, AUTHENTICATION_STATE_STARTING, TELEMETRY_MESSENGER_STATE_STOPPED, TWIN_MESSENGER_STATE_STOPPED);
 
     // act
-    device_do_work(handle);
+    amqp_device_do_work(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2343,7 +2343,7 @@ TEST_FUNCTION(device_do_work_authentication_start_times_out)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_038: [If authentication state is AUTHENTICATION_STATE_ERROR and error code is AUTH_FAILED, the device state shall be updated to DEVICE_STATE_ERROR_AUTH]
@@ -2352,12 +2352,12 @@ TEST_FUNCTION(device_do_work_authentication_start_AUTH_FAILED)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
     set_expected_calls_for_device_do_work(config, TEST_current_time, DEVICE_STATE_STARTING, AUTHENTICATION_STATE_STOPPED, TELEMETRY_MESSENGER_STATE_STOPPED, TWIN_MESSENGER_STATE_STOPPED);
-    device_do_work(handle);
+    amqp_device_do_work(handle);
 
     ASSERT_IS_NOT_NULL(TEST_authentication_create_saved_on_authentication_changed_callback);
     ASSERT_IS_NOT_NULL(TEST_authentication_create_saved_on_error_callback);
@@ -2366,7 +2366,7 @@ TEST_FUNCTION(device_do_work_authentication_start_AUTH_FAILED)
     TEST_authentication_create_saved_on_error_callback(TEST_authentication_create_saved_on_error_context, AUTHENTICATION_ERROR_AUTH_FAILED);
 
     // act
-    device_do_work(handle);
+    amqp_device_do_work(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2375,7 +2375,7 @@ TEST_FUNCTION(device_do_work_authentication_start_AUTH_FAILED)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_039: [If authentication state is AUTHENTICATION_STATE_ERROR and error code is TIMEOUT, the device state shall be updated to DEVICE_STATE_ERROR_AUTH_TIMEOUT]
@@ -2384,12 +2384,12 @@ TEST_FUNCTION(device_do_work_authentication_start_AUTH_TIMEOUT)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
     set_expected_calls_for_device_do_work(config, TEST_current_time, DEVICE_STATE_STARTING, AUTHENTICATION_STATE_STOPPED, TELEMETRY_MESSENGER_STATE_STOPPED, TWIN_MESSENGER_STATE_STOPPED);
-    device_do_work(handle);
+    amqp_device_do_work(handle);
 
     ASSERT_IS_NOT_NULL(TEST_authentication_create_saved_on_authentication_changed_callback);
     ASSERT_IS_NOT_NULL(TEST_authentication_create_saved_on_error_callback);
@@ -2398,7 +2398,7 @@ TEST_FUNCTION(device_do_work_authentication_start_AUTH_TIMEOUT)
     TEST_authentication_create_saved_on_error_callback(TEST_authentication_create_saved_on_error_context, AUTHENTICATION_ERROR_AUTH_TIMEOUT);
 
     // act
-    device_do_work(handle);
+    amqp_device_do_work(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2407,7 +2407,7 @@ TEST_FUNCTION(device_do_work_authentication_start_AUTH_TIMEOUT)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_041: [If messenger state is TELEMETRY_MESSENGER_STATE_STOPPED, telemetry_messenger_start shall be invoked]
@@ -2420,7 +2420,7 @@ TEST_FUNCTION(device_do_work_telemetry_messenger_start_FAILED)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
@@ -2439,7 +2439,7 @@ TEST_FUNCTION(device_do_work_telemetry_messenger_start_FAILED)
     set_expected_calls_for_device_do_work(config, TEST_current_time, DEVICE_STATE_STARTING, AUTHENTICATION_STATE_STARTED, TELEMETRY_MESSENGER_STATE_ERROR, TWIN_MESSENGER_STATE_STARTING);
 
     // act
-    device_do_work(handle);
+    amqp_device_do_work(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2448,7 +2448,7 @@ TEST_FUNCTION(device_do_work_telemetry_messenger_start_FAILED)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_043: [If messenger state is TELEMETRY_MESSENGER_STATE_STARTING, the device shall track the time since last event change and timeout if needed]
@@ -2459,7 +2459,7 @@ TEST_FUNCTION(device_do_work_telemetry_messenger_start_timeout)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     time_t next_time = add_seconds(TEST_current_time, DEFAULT_MSGR_STATE_CHANGED_TIMEOUT_SECS + 1);
@@ -2479,7 +2479,7 @@ TEST_FUNCTION(device_do_work_telemetry_messenger_start_timeout)
     set_expected_calls_for_device_do_work(config, next_time, DEVICE_STATE_STARTING, AUTHENTICATION_STATE_STARTED, TELEMETRY_MESSENGER_STATE_STARTING, TWIN_MESSENGER_STATE_STARTING);
 
     // act
-    device_do_work(handle);
+    amqp_device_do_work(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2488,7 +2488,7 @@ TEST_FUNCTION(device_do_work_telemetry_messenger_start_timeout)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_040: [Messenger shall not be started if using CBS authentication and authentication start has not completed yet]
@@ -2503,7 +2503,7 @@ TEST_FUNCTION(device_do_work_succeeds)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     time_t t0 = TEST_current_time;
@@ -2530,7 +2530,7 @@ TEST_FUNCTION(device_do_work_succeeds)
     set_expected_calls_for_device_do_work(config, t4, DEVICE_STATE_STARTING, AUTHENTICATION_STATE_STARTED, TELEMETRY_MESSENGER_STATE_STARTED, TWIN_MESSENGER_STATE_STARTED);
 
     // act
-    device_do_work(handle);
+    amqp_device_do_work(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2539,7 +2539,7 @@ TEST_FUNCTION(device_do_work_succeeds)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 
@@ -2549,7 +2549,7 @@ TEST_FUNCTION(device_do_work_STARTED_auth_unexpected_state)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_and_crank_device(config, TEST_current_time);
 
     TEST_authentication_create_saved_on_error_callback(TEST_authentication_create_saved_on_error_context, AUTHENTICATION_ERROR_SAS_REFRESH_TIMEOUT);
@@ -2558,7 +2558,7 @@ TEST_FUNCTION(device_do_work_STARTED_auth_unexpected_state)
     set_expected_calls_for_device_do_work(config, TEST_current_time, DEVICE_STATE_STARTED, AUTHENTICATION_STATE_ERROR, TELEMETRY_MESSENGER_STATE_STARTED, TWIN_MESSENGER_STATE_STARTED);
 
     // act
-    device_do_work(handle);
+    amqp_device_do_work(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2567,7 +2567,7 @@ TEST_FUNCTION(device_do_work_STARTED_auth_unexpected_state)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_048: [If messenger state is not TELEMETRY_MESSENGER_STATE_STARTED, the device state shall be updated to DEVICE_STATE_ERROR_MSG]
@@ -2576,7 +2576,7 @@ TEST_FUNCTION(device_do_work_STARTED_messenger_unexpected_state)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_and_crank_device(config, TEST_current_time);
 
     set_messenger_state(TELEMETRY_MESSENGER_STATE_STARTED, TELEMETRY_MESSENGER_STATE_ERROR, TEST_current_time);
@@ -2584,7 +2584,7 @@ TEST_FUNCTION(device_do_work_STARTED_messenger_unexpected_state)
     set_expected_calls_for_device_do_work(config, TEST_current_time, DEVICE_STATE_STARTED, AUTHENTICATION_STATE_STARTED, TELEMETRY_MESSENGER_STATE_ERROR, TWIN_MESSENGER_STATE_STARTED);
 
     // act
-    device_do_work(handle);
+    amqp_device_do_work(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2593,7 +2593,7 @@ TEST_FUNCTION(device_do_work_STARTED_messenger_unexpected_state)
     ASSERT_IS_NOT_NULL(handle);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 
@@ -2609,7 +2609,7 @@ TEST_FUNCTION(on_event_send_complete_messenger_callback_succeeds)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_device(config, TEST_current_time);
 
     TELEMETRY_MESSENGER_EVENT_SEND_COMPLETE_RESULT messenger_results[5];
@@ -2635,7 +2635,7 @@ TEST_FUNCTION(on_event_send_complete_messenger_callback_succeeds)
         umock_c_reset_all_calls();
         set_expected_calls_for_device_send_async(config);
 
-        int result = device_send_event_async(handle, TEST_IOTHUB_MESSAGE_LIST, TEST_on_device_d2c_event_send_complete_callback, TEST_ON_DEVICE_EVENT_SEND_COMPLETE_CONTEXT);
+        int result = amqp_device_send_event_async(handle, TEST_IOTHUB_MESSAGE_LIST, TEST_on_device_d2c_event_send_complete_callback, TEST_ON_DEVICE_EVENT_SEND_COMPLETE_CONTEXT);
         ASSERT_ARE_EQUAL(int, 0, result);
 
         ASSERT_IS_NOT_NULL(TEST_telemetry_messenger_send_async_saved_callback);
@@ -2648,7 +2648,7 @@ TEST_FUNCTION(on_event_send_complete_messenger_callback_succeeds)
     }
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_070: [If `iothub_message_handle` or `context` is NULL, on_messenger_message_received_callback shall return TELEMETRY_MESSENGER_DISPOSITION_RESULT_RELEASED]
@@ -2657,7 +2657,7 @@ TEST_FUNCTION(on_messenger_message_received_callback_NULL_handle)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_and_crank_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
@@ -2666,7 +2666,7 @@ TEST_FUNCTION(on_messenger_message_received_callback_NULL_handle)
         .IgnoreArgument(2)
         .IgnoreArgument(3);
 
-    (void)device_subscribe_message(handle, TEST_on_message_received, handle);
+    (void)amqp_device_subscribe_message(handle, TEST_on_message_received, handle);
     ASSERT_IS_NOT_NULL(TEST_telemetry_messenger_subscribe_for_messages_saved_on_message_received_callback);
 
     TELEMETRY_MESSENGER_MESSAGE_DISPOSITION_INFO disposition_info;
@@ -2686,7 +2686,7 @@ TEST_FUNCTION(on_messenger_message_received_callback_NULL_handle)
     ASSERT_ARE_EQUAL(int, TELEMETRY_MESSENGER_DISPOSITION_RESULT_RELEASED, result);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_070: [If `iothub_message_handle` or `context` is NULL, on_messenger_message_received_callback shall return TELEMETRY_MESSENGER_DISPOSITION_RESULT_RELEASED]
@@ -2695,7 +2695,7 @@ TEST_FUNCTION(on_messenger_message_received_callback_NULL_context)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_and_crank_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
@@ -2704,7 +2704,7 @@ TEST_FUNCTION(on_messenger_message_received_callback_NULL_context)
         .IgnoreArgument(2)
         .IgnoreArgument(3);
 
-    (void)device_subscribe_message(handle, TEST_on_message_received, handle);
+    (void)amqp_device_subscribe_message(handle, TEST_on_message_received, handle);
     ASSERT_IS_NOT_NULL(TEST_telemetry_messenger_subscribe_for_messages_saved_on_message_received_callback);
 
     TELEMETRY_MESSENGER_MESSAGE_DISPOSITION_INFO disposition_info;
@@ -2724,7 +2724,7 @@ TEST_FUNCTION(on_messenger_message_received_callback_NULL_context)
     ASSERT_ARE_EQUAL(int, TELEMETRY_MESSENGER_DISPOSITION_RESULT_RELEASED, result);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_071: [The user callback shall be invoked, passing the context it provided]
@@ -2738,7 +2738,7 @@ TEST_FUNCTION(on_messenger_message_received_callback_succeess)
     // arrange
     ASSERT_IS_TRUE(INDEFINITE_TIME != TEST_current_time, "Failed setting TEST_current_time");
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_and_crank_device(config, TEST_current_time);
 
     TELEMETRY_MESSENGER_DISPOSITION_RESULT messenger_results[3];
@@ -2757,7 +2757,7 @@ TEST_FUNCTION(on_messenger_message_received_callback_succeess)
         .IgnoreArgument(2)
         .IgnoreArgument(3);
 
-    (void)device_subscribe_message(handle, TEST_on_message_received, handle);
+    (void)amqp_device_subscribe_message(handle, TEST_on_message_received, handle);
     ASSERT_IS_NOT_NULL(TEST_telemetry_messenger_subscribe_for_messages_saved_on_message_received_callback);
 
     // act
@@ -2789,7 +2789,7 @@ TEST_FUNCTION(on_messenger_message_received_callback_succeess)
     }
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 // Tests_SRS_DEVICE_09_120: [If the DEVICE_MESSAGE_DISPOSITION_INFO instance fails to be created, on_messenger_message_received_callback shall return TELEMETRY_MESSENGER_DISPOSITION_RESULT_RELEASED]
@@ -2798,7 +2798,7 @@ TEST_FUNCTION(on_messenger_message_received_callback_failure_checks)
     // arrange
     ASSERT_ARE_EQUAL(int, 0, umock_c_negative_tests_init());
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_and_crank_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
@@ -2807,7 +2807,7 @@ TEST_FUNCTION(on_messenger_message_received_callback_failure_checks)
         .IgnoreArgument(2)
         .IgnoreArgument(3);
 
-    (void)device_subscribe_message(handle, TEST_on_message_received, handle);
+    (void)amqp_device_subscribe_message(handle, TEST_on_message_received, handle);
     ASSERT_IS_NOT_NULL(TEST_telemetry_messenger_subscribe_for_messages_saved_on_message_received_callback);
 
     TELEMETRY_MESSENGER_MESSAGE_DISPOSITION_INFO disposition_info;
@@ -2848,18 +2848,18 @@ TEST_FUNCTION(on_messenger_message_received_callback_failure_checks)
     }
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
     umock_c_negative_tests_deinit();
 }
 
 // Tests_SRS_DEVICE_09_113: [A TELEMETRY_MESSENGER_MESSAGE_DISPOSITION_INFO instance shall be created with a copy of the `source` and `message_id` contained in `disposition_info`]
 // Tests_SRS_DEVICE_09_115: [`telemetry_messenger_send_message_disposition()` shall be invoked passing the TELEMETRY_MESSENGER_MESSAGE_DISPOSITION_INFO instance and the corresponding TELEMETRY_MESSENGER_DISPOSITION_RESULT]
-// Tests_SRS_DEVICE_09_117: [device_send_message_disposition() shall destroy the TELEMETRY_MESSENGER_MESSAGE_DISPOSITION_INFO instance]
-// Tests_SRS_DEVICE_09_118: [If no failures occurr, device_send_message_disposition() shall return 0]
+// Tests_SRS_DEVICE_09_117: [amqp_device_send_message_disposition() shall destroy the TELEMETRY_MESSENGER_MESSAGE_DISPOSITION_INFO instance]
+// Tests_SRS_DEVICE_09_118: [If no failures occurr, amqp_device_send_message_disposition() shall return 0]
 TEST_FUNCTION(device_send_message_disposition_succeess)
 {
     // arrange
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     DEVICE_MESSAGE_DISPOSITION_INFO disposition_info;
@@ -2875,37 +2875,37 @@ TEST_FUNCTION(device_send_message_disposition_succeess)
     EXPECTED_CALL(free(IGNORED_PTR_ARG));
 
     // act
-    int result = device_send_message_disposition(handle, &disposition_info, DEVICE_MESSAGE_DISPOSITION_RESULT_ACCEPTED);
+    int result = amqp_device_send_message_disposition(handle, &disposition_info, DEVICE_MESSAGE_DISPOSITION_RESULT_ACCEPTED);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
     ASSERT_ARE_EQUAL(int, 0, result);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_111: [If `device_handle` or `disposition_info` are NULL, device_send_message_disposition() shall fail and return MU_FAILURE]
+// Tests_SRS_DEVICE_09_111: [If `device_handle` or `disposition_info` are NULL, amqp_device_send_message_disposition() shall fail and return MU_FAILURE]
 TEST_FUNCTION(device_send_message_NULL_disposition_info)
 {
     // arrange
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
 
     // act
-    int result = device_send_message_disposition(handle, NULL, DEVICE_MESSAGE_DISPOSITION_RESULT_ACCEPTED);
+    int result = amqp_device_send_message_disposition(handle, NULL, DEVICE_MESSAGE_DISPOSITION_RESULT_ACCEPTED);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_111: [If `device_handle` or `disposition_info` are NULL, device_send_message_disposition() shall fail and return MU_FAILURE]
+// Tests_SRS_DEVICE_09_111: [If `device_handle` or `disposition_info` are NULL, amqp_device_send_message_disposition() shall fail and return MU_FAILURE]
 TEST_FUNCTION(device_send_message_NULL_handle)
 {
     // arrange
@@ -2916,7 +2916,7 @@ TEST_FUNCTION(device_send_message_NULL_handle)
     umock_c_reset_all_calls();
 
     // act
-    int result = device_send_message_disposition(NULL, &disposition_info, DEVICE_MESSAGE_DISPOSITION_RESULT_ACCEPTED);
+    int result = amqp_device_send_message_disposition(NULL, &disposition_info, DEVICE_MESSAGE_DISPOSITION_RESULT_ACCEPTED);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2925,11 +2925,11 @@ TEST_FUNCTION(device_send_message_NULL_handle)
     // cleanup
 }
 
-// Tests_SRS_DEVICE_09_112: [If `disposition_info->source` is NULL, device_send_message_disposition() shall fail and return MU_FAILURE]
+// Tests_SRS_DEVICE_09_112: [If `disposition_info->source` is NULL, amqp_device_send_message_disposition() shall fail and return MU_FAILURE]
 TEST_FUNCTION(device_send_message_NULL_disposition_info_source)
 {
     // arrange
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     DEVICE_MESSAGE_DISPOSITION_INFO disposition_info;
@@ -2939,24 +2939,24 @@ TEST_FUNCTION(device_send_message_NULL_disposition_info_source)
     umock_c_reset_all_calls();
 
     // act
-    int result = device_send_message_disposition(handle, &disposition_info, DEVICE_MESSAGE_DISPOSITION_RESULT_ACCEPTED);
+    int result = amqp_device_send_message_disposition(handle, &disposition_info, DEVICE_MESSAGE_DISPOSITION_RESULT_ACCEPTED);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_114: [If the TELEMETRY_MESSENGER_MESSAGE_DISPOSITION_INFO fails to be created, device_send_message_disposition() shall fail and return MU_FAILURE]
-// Tests_SRS_DEVICE_09_116: [If `telemetry_messenger_send_message_disposition()` fails, device_send_message_disposition() shall fail and return MU_FAILURE]
+// Tests_SRS_DEVICE_09_114: [If the TELEMETRY_MESSENGER_MESSAGE_DISPOSITION_INFO fails to be created, amqp_device_send_message_disposition() shall fail and return MU_FAILURE]
+// Tests_SRS_DEVICE_09_116: [If `telemetry_messenger_send_message_disposition()` fails, amqp_device_send_message_disposition() shall fail and return MU_FAILURE]
 TEST_FUNCTION(device_send_message_disposition_failure_checks)
 {
     // arrange
     ASSERT_ARE_EQUAL(int, 0, umock_c_negative_tests_init());
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     DEVICE_MESSAGE_DISPOSITION_INFO disposition_info;
@@ -2987,7 +2987,7 @@ TEST_FUNCTION(device_send_message_disposition_failure_checks)
         umock_c_negative_tests_reset();
         umock_c_negative_tests_fail_call(i);
 
-        int result = device_send_message_disposition(handle, &disposition_info, DEVICE_MESSAGE_DISPOSITION_RESULT_ACCEPTED);
+        int result = amqp_device_send_message_disposition(handle, &disposition_info, DEVICE_MESSAGE_DISPOSITION_RESULT_ACCEPTED);
 
         // assert
         sprintf(error_msg, "On failed call %lu", (unsigned long)i);
@@ -2996,16 +2996,16 @@ TEST_FUNCTION(device_send_message_disposition_failure_checks)
 
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
     umock_c_negative_tests_deinit();
 }
 
 // Tests_SRS_DEVICE_09_153: [twin_messenger_get_twin_async shall be invoked ]
-// Tests_SRS_DEVICE_09_155: [If no failures occur, device_get_twin_async shall return 0]
+// Tests_SRS_DEVICE_09_155: [If no failures occur, amqp_device_get_twin_async shall return 0]
 TEST_FUNCTION(device_get_twin_async_succeess)
 {
     // arrange
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
@@ -3013,7 +3013,7 @@ TEST_FUNCTION(device_get_twin_async_succeess)
     EXPECTED_CALL(twin_messenger_get_twin_async(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
 
     // act
-    int result = device_get_twin_async(handle, on_device_get_twin_completed_callback, (void*)0x4567);
+    int result = amqp_device_get_twin_async(handle, on_device_get_twin_completed_callback, (void*)0x4567);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -3022,19 +3022,19 @@ TEST_FUNCTION(device_get_twin_async_succeess)
 
     // cleanup
     free(get_twin_context);
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 TEST_FUNCTION(device_get_twin_async_callback_succeess)
 {
     // arrange
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
     STRICT_EXPECTED_CALL(malloc(IGNORED_NUM_ARG));
     STRICT_EXPECTED_CALL(twin_messenger_get_twin_async(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
-    (void)device_get_twin_async(handle, on_device_get_twin_completed_callback, (void*)0x4567);
+    (void)amqp_device_get_twin_async(handle, on_device_get_twin_completed_callback, (void*)0x4567);
     STRICT_EXPECTED_CALL(free(IGNORED_PTR_ARG));
     
     ASSERT_IS_NOT_NULL(get_twin_callback);
@@ -3054,16 +3054,16 @@ TEST_FUNCTION(device_get_twin_async_callback_succeess)
     ASSERT_ARE_EQUAL(void_ptr, (void*)0x4567, dvc_get_twin_context);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
-// Tests_SRS_DEVICE_09_154: [If twin_messenger_get_twin_async fails, device_get_twin_async shall return a non-zero value]
+// Tests_SRS_DEVICE_09_154: [If twin_messenger_get_twin_async fails, amqp_device_get_twin_async shall return a non-zero value]
 TEST_FUNCTION(device_get_twin_async_failure_checks)
 {
     // arrange
     ASSERT_ARE_EQUAL(int, 0, umock_c_negative_tests_init());
 
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
@@ -3085,25 +3085,25 @@ TEST_FUNCTION(device_get_twin_async_failure_checks)
 
         char tmp_msg[64];
         sprintf(tmp_msg, "Failure in test %lu/%lu", (unsigned long)index, (unsigned long)count);
-        int result = device_get_twin_async(handle, on_device_get_twin_completed_callback, (void*)0x4567);
+        int result = amqp_device_get_twin_async(handle, on_device_get_twin_completed_callback, (void*)0x4567);
 
         // assert
         ASSERT_ARE_NOT_EQUAL(int, 0, result, tmp_msg);
     }
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
     umock_c_negative_tests_deinit();
 }
 
-// Tests_SRS_DEVICE_09_152: [If `handle` or `on_device_get_twin_completed_callback` are NULL, device_get_twin_async shall return a non-zero result]
+// Tests_SRS_DEVICE_09_152: [If `handle` or `on_device_get_twin_completed_callback` are NULL, amqp_device_get_twin_async shall return a non-zero result]
 TEST_FUNCTION(device_get_twin_async_NULL_handle)
 {
     // arrange
     umock_c_reset_all_calls();
 
     // act
-    int result = device_get_twin_async(NULL, on_device_get_twin_completed_callback, (void*)0x4567);
+    int result = amqp_device_get_twin_async(NULL, on_device_get_twin_completed_callback, (void*)0x4567);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -3112,24 +3112,24 @@ TEST_FUNCTION(device_get_twin_async_NULL_handle)
     // cleanup
 }
 
-// Tests_SRS_DEVICE_09_152: [If `handle` or `on_device_get_twin_completed_callback` are NULL, device_get_twin_async shall return a non-zero result]
+// Tests_SRS_DEVICE_09_152: [If `handle` or `on_device_get_twin_completed_callback` are NULL, amqp_device_get_twin_async shall return a non-zero result]
 TEST_FUNCTION(device_get_twin_async_NULL_callback)
 {
     // arrange
-    DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
+    AMQP_DEVICE_CONFIG* config = get_device_config(DEVICE_AUTH_MODE_CBS);
     AMQP_DEVICE_HANDLE handle = create_and_start_device(config, TEST_current_time);
 
     umock_c_reset_all_calls();
 
     // act
-    int result = device_get_twin_async(handle, NULL, (void*)0x4567);
+    int result = amqp_device_get_twin_async(handle, NULL, (void*)0x4567);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
 
     // cleanup
-    device_destroy(handle);
+    amqp_device_destroy(handle);
 }
 
 END_TEST_SUITE(iothubtransport_amqp_device_ut)


### PR DESCRIPTION
In the AMQP Transport we have some generically named public functions that can easily conflict with public functions created by a customer. To prevent any confusing behavior, I have renamed all these functions with the prefix "iothubtransport_amqp_".

In reference to https://github.com/Azure/azure-iot-sdk-c/issues/651