### PR TITLE
Horton patch

### DIFF
--- a/build/.horton-e2e.yml
+++ b/build/.horton-e2e.yml
@@ -11,7 +11,7 @@ resources:
   - repository: e2e_fx
     type: github
     name: Azure/iot-sdks-e2e-fx
-    ref: e284f306b7b57f600107fde6dac21e11500acbc3
+    ref: refs/heads/master
     endpoint: 'GitHub OAuth - az-iot-builder-01'
 
 jobs:

--- a/build/.horton-e2e.yml
+++ b/build/.horton-e2e.yml
@@ -1,6 +1,6 @@
 variables:
   Horton.FrameworkRoot: $(Agent.BuildDirectory)/e2e-fx
-  Horton.FrameworkRef: master
+  Horton.FrameworkRef: git-patch
   Horton.Language: c
   Horton.Repo: $(Build.Repository.Uri)
   Horton.Commit: $(Build.SourceBranch)
@@ -11,7 +11,7 @@ resources:
   - repository: e2e_fx
     type: github
     name: Azure/iot-sdks-e2e-fx
-    ref: refs/heads/master
+    ref: refs/heads/git-patch
     endpoint: 'GitHub OAuth - az-iot-builder-01'
 
 jobs:

--- a/build/.horton-e2e.yml
+++ b/build/.horton-e2e.yml
@@ -1,6 +1,6 @@
 variables:
   Horton.FrameworkRoot: $(Agent.BuildDirectory)/e2e-fx
-  Horton.FrameworkRef: e284f306b7b57f600107fde6dac21e11500acbc3
+  Horton.FrameworkRef: snapshot
   Horton.Language: c
   Horton.Repo: $(Build.Repository.Uri)
   Horton.Commit: $(Build.SourceBranch)

--- a/build/.horton-e2e.yml
+++ b/build/.horton-e2e.yml
@@ -1,6 +1,6 @@
 variables:
   Horton.FrameworkRoot: $(Agent.BuildDirectory)/e2e-fx
-  Horton.FrameworkRef: git-patch
+  Horton.FrameworkRef: e284f306b7b57f600107fde6dac21e11500acbc3
   Horton.Language: c
   Horton.Repo: $(Build.Repository.Uri)
   Horton.Commit: $(Build.SourceBranch)
@@ -11,7 +11,7 @@ resources:
   - repository: e2e_fx
     type: github
     name: Azure/iot-sdks-e2e-fx
-    ref: refs/heads/git-patch
+    ref: e284f306b7b57f600107fde6dac21e11500acbc3
     endpoint: 'GitHub OAuth - az-iot-builder-01'
 
 jobs:

--- a/build/.horton-e2e.yml
+++ b/build/.horton-e2e.yml
@@ -1,6 +1,6 @@
 variables:
   Horton.FrameworkRoot: $(Agent.BuildDirectory)/e2e-fx
-  Horton.FrameworkRef: snapshot
+  Horton.FrameworkRef: snap
   Horton.Language: c
   Horton.Repo: $(Build.Repository.Uri)
   Horton.Commit: $(Build.SourceBranch)
@@ -11,7 +11,7 @@ resources:
   - repository: e2e_fx
     type: github
     name: Azure/iot-sdks-e2e-fx
-    ref: refs/heads/snapshot
+    ref: refs/heads/snap
     endpoint: 'GitHub OAuth - az-iot-builder-01'
 
 jobs:

--- a/build/.horton-e2e.yml
+++ b/build/.horton-e2e.yml
@@ -11,7 +11,7 @@ resources:
   - repository: e2e_fx
     type: github
     name: Azure/iot-sdks-e2e-fx
-    ref: refs/heads/master
+    ref: refs/heads/snapshot
     endpoint: 'GitHub OAuth - az-iot-builder-01'
 
 jobs:


### PR DESCRIPTION
We need to point to a single version of Horton so that the build does not break in the event of a Horton change.