### PR TITLE
Remove hardcoded key name usage from iothub_messaging_ll.c

### DIFF
--- a/iothub_service_client/src/iothub_messaging_ll.c
+++ b/iothub_service_client/src/iothub_messaging_ll.c
@@ -457,15 +457,16 @@ static char* createAuthCid(IOTHUB_MESSAGING_HANDLE messagingHandle)
     }
     else
     {
-        const char* AMQP_SEND_AUTHCID_FMT = "iothubowner@sas.root.%s";
-        size_t authCidLen = strlen(AMQP_SEND_AUTHCID_FMT) + strlen(messagingHandle->iothubName);
+        const char* AMQP_SEND_AUTHCID_FMT = "%s@sas.root.%s";
+        const int AMQP_SEND_AUTHCID_FMT_LENGTH = 10;
+        size_t authCidLen = strlen(messagingHandle->keyName) + AMQP_SEND_AUTHCID_FMT_LENGTH + strlen(messagingHandle->iothubName);
 
         if ((buffer = (char*)malloc(authCidLen + 1)) == NULL)
         {
             LogError("Malloc failed for authCid.");
             result = NULL;
         }
-        else if ((snprintf(buffer, authCidLen + 1, AMQP_SEND_AUTHCID_FMT, messagingHandle->iothubName)) < 0)
+        else if ((snprintf(buffer, authCidLen + 1, AMQP_SEND_AUTHCID_FMT, messagingHandle->keyName, messagingHandle->iothubName)) < 0)
         {
             LogError("sprintf_s failed for authCid.");
             free(buffer);

--- a/iothub_service_client/src/iothub_messaging_ll.c
+++ b/iothub_service_client/src/iothub_messaging_ll.c
@@ -26,6 +26,8 @@
 #include "iothub_messaging_ll.h"
 #include "iothub_sc_version.h"
 
+#define SIZE_OF_PERCENT_S_IN_FMT_STRING 2
+
 MU_DEFINE_ENUM_STRINGS(IOTHUB_FEEDBACK_STATUS_CODE, IOTHUB_FEEDBACK_STATUS_CODE_VALUES);
 MU_DEFINE_ENUM_STRINGS(IOTHUB_MESSAGE_SEND_STATE, IOTHUB_MESSAGE_SEND_STATE_VALUES);
 MU_DEFINE_ENUM_STRINGS(IOTHUB_MESSAGING_RESULT, IOTHUB_MESSAGING_RESULT_VALUES);
@@ -457,8 +459,9 @@ static char* createAuthCid(IOTHUB_MESSAGING_HANDLE messagingHandle)
     }
     else
     {
-        const char* AMQP_SEND_AUTHCID_FMT = "%s@sas.root.%s";
-        const int AMQP_SEND_AUTHCID_FMT_LENGTH = 10;
+        const char AMQP_SEND_AUTHCID_FMT[] = "%s@sas.root.%s";
+        const int AMQP_SEND_AUTHCID_FMT_LENGTH = sizeof(AMQP_SEND_AUTHCID_FMT) - 2 * SIZE_OF_PERCENT_S_IN_FMT_STRING;
+
         size_t authCidLen = strlen(messagingHandle->keyName) + AMQP_SEND_AUTHCID_FMT_LENGTH + strlen(messagingHandle->iothubName);
 
         if ((buffer = (char*)malloc(authCidLen + 1)) == NULL)


### PR DESCRIPTION


<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

The service client for cloud-to-device messaging constructed a token authentication id using a hardcoded name of the policy owner.
Only policies with owner "iothubowner" would then work with this client.


# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 

This change removes this hard-coded name, consuming the policy owner name as provided by the user through the IoT Hub connection string.

The service client has no tests in general, so no automated tests were added. 
This fix has been tested manually though with different IoT Hub policies (different owner names).