### PR TITLE
Bugfix/location cmake config files on install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,15 +158,19 @@ endif()
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # build the parson library for json parsing
-add_library(parson
+if (NOT ${use_installed_dependencies})
+  add_library(parson
     ./deps/parson/parson.c
     ./deps/parson/parson.h
-)
-if (MSVC)
+    )
+  if (MSVC)
     set_source_files_properties(../deps/parson/parson.c PROPERTIES COMPILE_FLAGS "/wd4244 /wd4232")
+  endif()
+  set(parson_h_install_files ./deps/parson/parson.h)
+  set(parson_install_libs parson)
+else()
+  find_package(parson REQUIRED CONFIG)
 endif()
-set(parson_h_install_files ./deps/parson/parson.h)
-set(parson_install_libs parson)
 
 if (IN_OPENWRT)
     ADD_DEFINITIONS("$ENV{TARGET_LDFLAGS}" "$ENV{TARGET_CPPFLAGS}" "$ENV{TARGET_CFLAGS}")
@@ -398,16 +402,16 @@ if (${use_installed_dependencies})
         "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}Config.cmake"
         COPYONLY
     )
-
-    install(FILES ${parson_h_install_files}
+    if (NOT ${use_installed_dependencies})
+      install(FILES ${parson_h_install_files}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot
-    )
-    install(TARGETS ${parson_install_libs} EXPORT azure_iot_sdksTargets
+	)
+      install(TARGETS ${parson_install_libs} EXPORT azure_iot_sdksTargets
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot
-    )
-
+	)
+    endif()
     install(EXPORT azure_iot_sdksTargets
         FILE
             "${PROJECT_NAME}Targets.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,7 +384,7 @@ endif()
 
 if (${use_installed_dependencies})
     # Install azure_iot_sdks
-    set(package_location "cmake")
+    set(package_location "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
     include(CMakePackageConfigHelpers)
 

--- a/iothub_client/CMakeLists.txt
+++ b/iothub_client/CMakeLists.txt
@@ -247,7 +247,7 @@ endif()
 set(IOTHUB_CLIENT_INC_FOLDER ${CMAKE_CURRENT_LIST_DIR}/inc CACHE INTERNAL "this is what needs to be included if using iothub_client lib" FORCE)
 
 
-if(NOT ${dont_use_uploadtoblob} OR ${use_edge_modules})
+if((NOT ${dont_use_uploadtoblob} OR ${use_edge_modules}) AND NOT ${use_installed_dependencies})
     include_directories(../deps/parson)
 endif()
 
@@ -331,8 +331,7 @@ if(${use_amqp})
         set(iothub_transport_source ${iothub_transport_source}
             ${iothub_client_amqp_ws_transport_c_files}
             ${iothub_client_amqp_ws_transport_h_files})
-
-        set(iothub_client_libs ${iothub_client_libs} uamqp)
+	set(uamqp_libs uamqp)
     endif(build_as_dynamic)
 endif()
 
@@ -412,7 +411,7 @@ if (${build_as_dynamic})
     )
 
     setSdkTargetBuildProperties(iothub_client_dll)
-    target_link_libraries(iothub_client_dll ${iothub_client_libs})
+    target_link_libraries(iothub_client_dll ${iothub_client_libs} ${uamqp_libs})
     if(NOT WIN32)
         set_target_properties(iothub_client_dll PROPERTIES OUTPUT_NAME "iothub_client")
     endif()
@@ -431,11 +430,11 @@ if (${build_as_dynamic})
     if (${use_prov_client_core})
         target_link_libraries(iothub_client_dll hsm_security_client prov_auth_client)
     endif()
-    target_link_libraries(iothub_client_dll parson)
+    target_link_libraries(iothub_client_dll parson::parson)
 
     if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
         target_link_libraries(iothub_client_dll
-            "-Wl,--exclude-libs,libparson.a"
+	  parson::parson
         )
     endif()
 
@@ -447,8 +446,8 @@ add_library(iothub_client
     ${iothub_client_h_files}
 )
 setSdkTargetBuildProperties(iothub_client)
-target_link_libraries(iothub_client ${iothub_client_libs})
-target_link_libraries(iothub_client parson)
+target_link_libraries(iothub_client ${iothub_client_libs} ${uamqp_libs})
+target_link_libraries(iothub_client parson::parson)
 
 if (${use_prov_client_core})
     target_link_libraries(iothub_client hsm_security_client prov_auth_client)
@@ -494,7 +493,7 @@ if(${use_installed_dependencies})
     install(TARGETS ${iothub_client_libs} EXPORT azure_iot_sdksTargets
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/../bin
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot
     )
     install(FILES ${iothub_client_h_install_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot)

--- a/iothub_client/CMakeLists.txt
+++ b/iothub_client/CMakeLists.txt
@@ -405,8 +405,7 @@ if (${build_as_dynamic})
 
     add_library(iothub_client_dll SHARED
         ${iothub_client_c_files}
-        ${iothub_client_h_files}
-        ${iothub_def_file}
+        ${iothub_client_h_files}       
         ${iothub_transport_source}
     )
 

--- a/iothub_service_client/CMakeLists.txt
+++ b/iothub_service_client/CMakeLists.txt
@@ -41,7 +41,7 @@ include_directories(${UAMQP_INCLUDES})
 
 set(IOTHUB_SERVICE_CLIENT_INC_FOLDER ${CMAKE_CURRENT_LIST_DIR}/inc CACHE INTERNAL "This is the include folder for iothub_service_client" FORCE)
 
-include_directories(${CMAKE_CURRENT_LIST_DIR}/../deps/parson ${IOTHUB_SERVICE_CLIENT_INC_FOLDER} ${CMAKE_CURRENT_LIST_DIR}/../iothub_client/inc)
+include_directories(${IOTHUB_SERVICE_CLIENT_INC_FOLDER} ${CMAKE_CURRENT_LIST_DIR}/../iothub_client/inc)
 
 IF(WIN32)
     #windows needs this define
@@ -58,11 +58,11 @@ if (${build_as_dynamic})
     add_library(iothub_service_client_dll SHARED ${iothub_service_client_c_files} ${iothub_service_client_h_files} ./src/iothub_service_client.def)
     linkSharedUtil(iothub_service_client_dll)
 
-    target_link_libraries(iothub_service_client_dll uamqp parson)
+    target_link_libraries(iothub_service_client_dll uamqp parson::parson)
 
     if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
         target_link_libraries(iothub_service_client_dll
-            "-Wl,--exclude-libs,libparson.a"
+            parson::parson
         )
     endif()
 
@@ -81,9 +81,9 @@ endif()
 setSdkTargetBuildProperties(iothub_service_client)
 
 if(NOT ${nuget_e2e_tests})
-    target_link_libraries(iothub_service_client uamqp parson)
+    target_link_libraries(iothub_service_client uamqp parson::parson)
 else()
-    target_link_libraries(iothub_service_client parson)
+    target_link_libraries(iothub_service_client parson::parson)
 endif()
 
 if (NOT ${ARCHITECTURE} STREQUAL "ARM")

--- a/provisioning_client/CMakeLists.txt
+++ b/provisioning_client/CMakeLists.txt
@@ -163,7 +163,9 @@ set(DEV_AUTH_MODULES_CLIENT_INC_FOLDER "${CMAKE_CURRENT_LIST_DIR}/inc" "${CMAKE_
 
 include_directories(${DEV_AUTH_MODULES_CLIENT_INC_FOLDER})
 include_directories(${SHARED_UTIL_INC_FOLDER})
-include_directories(${CMAKE_CURRENT_LIST_DIR}/../deps/parson)
+if (NOT ${use_installed_dependencies})
+  include_directories(${CMAKE_CURRENT_LIST_DIR}/../deps/parson)
+endif()
 include_directories(${UHTTP_C_INC_FOLDER})
 include_directories(${IOTHUB_CLIENT_INC_FOLDER})
 include_directories(${CMAKE_CURRENT_LIST_DIR}/adapters)
@@ -203,14 +205,14 @@ if(${use_prov_client})
     link_security_client(prov_device_ll_client)
     set(provisioning_libs ${provisioning_libs} prov_device_ll_client)
     set(provisioning_headers ${provisioning_headers} ${PROV_DEVICE_LL_CLEINT_SOURCE_H_FILES})
-    target_link_libraries(prov_device_ll_client parson)
+    target_link_libraries(prov_device_ll_client parson::parson)
 
     add_library(prov_device_client ${PROV_DEVICE_CLIENT_SOURCE_C_FILES} ${PROV_DEVICE_CLIENT_SOURCE_H_FILES})
     setSdkTargetBuildProperties(prov_device_client)
     target_link_libraries(prov_device_client  prov_device_ll_client)
     set(provisioning_libs ${provisioning_libs} prov_device_client)
     set(provisioning_headers ${provisioning_headers} ${PROV_DEVICE_CLIENT_SOURCE_H_FILES})
-    target_link_libraries(prov_device_client parson)
+    target_link_libraries(prov_device_client parson::parson)
 
 
     if (${build_as_dynamic})
@@ -222,7 +224,7 @@ if(${use_prov_client})
             ./src/prov_device_client_dll.def
         )
         linkSharedUtil(prov_device_client_dll)
-        target_link_libraries(prov_device_client_dll prov_device_ll_client parson)
+        target_link_libraries(prov_device_client_dll prov_device_ll_client parson::parson)
 
         if(NOT WIN32)
             set_target_properties(prov_device_client_dll PROPERTIES OUTPUT_NAME "prov_device_client")
@@ -238,7 +240,7 @@ if(${use_prov_client})
         )
         if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
             target_link_libraries(prov_device_client_dll
-                "-Wl,--exclude-libs,libparson.a"
+	      parson::parson
             )
         endif()
         set(provisioning_libs ${provisioning_libs} prov_device_client_dll)

--- a/provisioning_client/CMakeLists.txt
+++ b/provisioning_client/CMakeLists.txt
@@ -66,6 +66,7 @@ elseif (${use_prov_client})
         add_subdirectory(./tests/common_prov_e2e/prov_hsm)
 
         set(HSM_CLIENT_LIBRARY ${HSM_CLIENT_LIBRARY} msr_riot utpm prov_hsm)
+	set(provisioning_libs ${provisioning_libs} msr_riot)
         if (WIN32)
             set(HSM_CLIENT_LIBRARY ${HSM_CLIENT_LIBRARY} Tbs)
         endif ()
@@ -86,6 +87,7 @@ elseif (${use_prov_client})
             include_directories(./deps/RIoT/Emulator/RIoT/RIoTCrypt/include)
 
             set(HSM_CLIENT_LIBRARY ${HSM_CLIENT_LIBRARY} msr_riot)
+	    set(provisioning_libs ${provisioning_libs} msr_riot)
         endif()
 
         if (${hsm_type_sastoken})

--- a/provisioning_client/CMakeLists.txt
+++ b/provisioning_client/CMakeLists.txt
@@ -8,6 +8,7 @@ compileAsC99()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_PROV_MODULE")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_PROV_MODULE")
 
+add_library(msr_riot "")
 add_subdirectory(./deps)
 if (${use_installed_dependencies})
   find_package(utpm REQUIRED CONFIG)

--- a/provisioning_client/CMakeLists.txt
+++ b/provisioning_client/CMakeLists.txt
@@ -357,7 +357,7 @@ endif ()
 if(${use_installed_dependencies})
 
     # Install Provisioning libs
-    set(package_location "share/cmake/${PROJECT_NAME}")
+    set(package_location "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
     if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
         set(CMAKE_INSTALL_LIBDIR "lib")
@@ -409,7 +409,7 @@ else()
     install(TARGETS ${provisioning_libs}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/../bin
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
 endif()

--- a/provisioning_client/CMakeLists.txt
+++ b/provisioning_client/CMakeLists.txt
@@ -357,7 +357,7 @@ endif ()
 if(${use_installed_dependencies})
 
     # Install Provisioning libs
-    set(package_location "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+    set(package_location "${CMAKE_INSTALL_LIBDIR}/cmake/azure_prov_sdks")
 
     if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
         set(CMAKE_INSTALL_LIBDIR "lib")
@@ -366,7 +366,7 @@ if(${use_installed_dependencies})
     install(TARGETS ${provisioning_libs} EXPORT azure_prov_sdksTargets
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/../bin
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot
     )
     install(FILES ${provisioning_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot/azure_prov_client)
@@ -374,27 +374,27 @@ if(${use_installed_dependencies})
     include(CMakePackageConfigHelpers)
 
     write_basic_package_version_file(
-        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}ConfigVersion.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/azure_prov_sdks/azure_prov_sdksConfigVersion.cmake"
         VERSION ${PROV_SDK_VERSION}
         COMPATIBILITY SameMajorVersion
     )
 
     configure_file("../configs/${PROJECT_NAME}Config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}Config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/azure_prov_sdks/azure_prov_sdksConfig.cmake"
         COPYONLY
     )
 
     install(EXPORT azure_prov_sdksTargets
         FILE
-            "${PROJECT_NAME}Targets.cmake"
+            "azure_prov_sdksTargets.cmake"
         DESTINATION
             ${package_location}
     )
 
     install(
         FILES
-            "../configs/${PROJECT_NAME}Config.cmake"
-            "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}ConfigVersion.cmake"
+            "configs/azure_prov_sdksConfig.cmake"
+            "${CMAKE_CURRENT_BINARY_DIR}/azure_prov_sdks/azure_prov_sdksConfigVersion.cmake"
         DESTINATION
             ${package_location}
     )

--- a/provisioning_client/CMakeLists.txt
+++ b/provisioning_client/CMakeLists.txt
@@ -9,6 +9,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_PROV_MODULE")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_PROV_MODULE")
 
 add_subdirectory(./deps)
+if (${use_installed_dependencies})
+  find_package(utpm REQUIRED CONFIG)
+endif()
 
 set(provisioning_libs)
 set(provisioning_headers)

--- a/provisioning_client/configs/azure_prov_sdksConfig.cmake
+++ b/provisioning_client/configs/azure_prov_sdksConfig.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/azure_prov_sdksTargets.cmake")

--- a/provisioning_client/deps/CMakeLists.txt
+++ b/provisioning_client/deps/CMakeLists.txt
@@ -12,17 +12,17 @@ else()
 
     if(${hsm_type_x509})
         set(msr_riot_c_files
-            ./RIoT/Emulator/DICE/DiceSha256.c
-            ./RIoT/Emulator/RIoT/RIoTCrypt/RiotAes128.c
-            ./RIoT/Emulator/RIoT/RIoTCrypt/RiotAesTables.c
-            ./RIoT/Emulator/RIoT/RIoTCrypt/RiotCrypt.c
-            ./RIoT/Emulator/RIoT/RIoTCrypt/RiotDerEnc.c
-            ./RIoT/Emulator/RIoT/RIoTCrypt/RiotEcc.c
-            ./RIoT/Emulator/RIoT/RIoTCrypt/RiotHmac.c
-            ./RIoT/Emulator/RIoT/RIoTCrypt/RiotKdf.c
-            ./RIoT/Emulator/RIoT/RIoTCrypt/RiotSha256.c
-            ./RIoT/Emulator/RIoT/RIoTCrypt/RiotX509Bldr.c
-            ./RIoT/Emulator/RIoT/RIoTCrypt/RiotBase64.c
+            ${CMAKE_CURRENT_LIST_DIR}/RIoT/Emulator/DICE/DiceSha256.c
+            ${CMAKE_CURRENT_LIST_DIR}/RIoT/Emulator/RIoT/RIoTCrypt/RiotAes128.c
+            ${CMAKE_CURRENT_LIST_DIR}/RIoT/Emulator/RIoT/RIoTCrypt/RiotAesTables.c
+            ${CMAKE_CURRENT_LIST_DIR}/RIoT/Emulator/RIoT/RIoTCrypt/RiotCrypt.c
+            ${CMAKE_CURRENT_LIST_DIR}/RIoT/Emulator/RIoT/RIoTCrypt/RiotDerEnc.c
+            ${CMAKE_CURRENT_LIST_DIR}/RIoT/Emulator/RIoT/RIoTCrypt/RiotEcc.c
+            ${CMAKE_CURRENT_LIST_DIR}/RIoT/Emulator/RIoT/RIoTCrypt/RiotHmac.c
+            ${CMAKE_CURRENT_LIST_DIR}/RIoT/Emulator/RIoT/RIoTCrypt/RiotKdf.c
+            ${CMAKE_CURRENT_LIST_DIR}/RIoT/Emulator/RIoT/RIoTCrypt/RiotSha256.c
+            ${CMAKE_CURRENT_LIST_DIR}/RIoT/Emulator/RIoT/RIoTCrypt/RiotX509Bldr.c
+            ${CMAKE_CURRENT_LIST_DIR}/RIoT/Emulator/RIoT/RIoTCrypt/RiotBase64.c
         )
 
         set(msr_riot_h_files
@@ -56,7 +56,7 @@ endif()
             add_definitions(-DWIN32)
         ENDIF(WIN32)
 
-        add_library(msr_riot ${msr_riot_c_files} ${msr_riot_h_files})
+        target_sources(msr_riot PRIVATE ${msr_riot_c_files})
 	set_target_properties(msr_riot PROPERTIES
             ENABLE_EXPORTS YES
             VERSION ${PROV_SDK_VERSION}

--- a/provisioning_client/deps/CMakeLists.txt
+++ b/provisioning_client/deps/CMakeLists.txt
@@ -57,14 +57,23 @@ endif()
         ENDIF(WIN32)
 
         add_library(msr_riot ${msr_riot_c_files} ${msr_riot_h_files})
+	set_target_properties(msr_riot PROPERTIES
+            ENABLE_EXPORTS YES
+            VERSION ${PROV_SDK_VERSION}
+            SOVERSION ${PROV_SDK_VERSION_MAJOR}
+            BUILD_WITH_INSTALL_RPATH TRUE
+        )
     endif()
 
     if(${hsm_type_sastoken})
-        # Default tpm implementation
+      # Default tpm implementation
+      if (${use_installed_dependencies})
+	find_package(utpm REQUIRED CONFIG)
+      else()
         if (${use_tpm_simulator})
-            set(use_emulator ON CACHE BOOL "enable use_emulator in utpm" FORCE)
+          set(use_emulator ON CACHE BOOL "enable use_emulator in utpm" FORCE)
         else()
-            set(use_emulator OFF CACHE BOOL "disable use_emulator in utpm" FORCE)
+          set(use_emulator OFF CACHE BOOL "disable use_emulator in utpm" FORCE)
         endif()
 
         set(original_run_e2e_tests ${run_e2e_tests})

--- a/provisioning_client/deps/CMakeLists.txt
+++ b/provisioning_client/deps/CMakeLists.txt
@@ -67,9 +67,7 @@ endif()
 
     if(${hsm_type_sastoken})
       # Default tpm implementation
-      if (${use_installed_dependencies})
-	find_package(utpm REQUIRED CONFIG)
-      else()
+      if (NOT ${use_installed_dependencies})
         if (${use_tpm_simulator})
           set(use_emulator ON CACHE BOOL "enable use_emulator in utpm" FORCE)
         else()
@@ -86,5 +84,6 @@ endif()
 
         set(run_e2e_tests ${original_run_e2e_tests})
         set(run_unittests ${original_run_unittests})
+      endif()
     endif()
 endif()

--- a/provisioning_service_client/CMakeLists.txt
+++ b/provisioning_service_client/CMakeLists.txt
@@ -43,7 +43,9 @@ set(provisioning_service_client_h_files
 
 include_directories(${SHARED_UTIL_INC_FOLDER})
 include_directories(${UHTTP_C_INC_FOLDER})
-include_directories(${CMAKE_CURRENT_LIST_DIR}/../deps/parson)
+if (NOT ${use_installed_dependencies})
+  include_directories(${CMAKE_CURRENT_LIST_DIR}/../deps/parson)
+endif()
 
 set(PROVISIONING_SERVICE_CLIENT_INC_FOLDER ${CMAKE_CURRENT_LIST_DIR}/inc CACHE INTERNAL "This is the include folder for provisioning_service_client" FORCE)
 
@@ -59,7 +61,7 @@ ENDIF(WIN32)
 add_library(provisioning_service_client
     ${provisioning_service_client_c_files}
     ${provisioning_service_client_h_files})
-target_link_libraries(provisioning_service_client parson uhttp)
+target_link_libraries(provisioning_service_client parson::parson uhttp)
 
 if (NOT ${ARCHITECTURE} STREQUAL "ARM")
     if (NOT ${skip_samples})

--- a/serializer/CMakeLists.txt
+++ b/serializer/CMakeLists.txt
@@ -58,7 +58,9 @@ set(serializer_h_files
 #the following "set" statement exports across the project a global variable called SHARED_UTIL_INC_FOLDER that expands to whatever needs to included when using COMMON library
 set(SERIALIZER_INC_FOLDER ${CMAKE_CURRENT_LIST_DIR}/inc CACHE INTERNAL "this is what needs to be included if using serializer lib" FORCE)
 
-include_directories(../deps/parson)
+if (NOT ${use_installed_dependencies})
+  include_directories(../deps/parson)
+endif()
 include_directories(${SERIALIZER_INC_FOLDER} ${SHARED_UTIL_INC_FOLDER})
 include_directories(${AZURE_C_SHARED_UTILITY_INCLUDES})
 
@@ -68,7 +70,7 @@ IF(WIN32)
 ENDIF(WIN32)
 
 add_library(serializer ${serializer_c_files} ${serializer_h_files})
-target_link_libraries(serializer parson)
+target_link_libraries(serializer parson::parson)
 
 set (install_libs serializer)
 
@@ -77,13 +79,13 @@ if (${build_as_dynamic})
         serializer_dll SHARED ${serializer_c_files} ${serializer_h_files} ./src/serializer.def
     )
     target_link_libraries(serializer_dll
-        aziotsharedutil_dll
-        parson
+        aziotsharedutil
+        parson::parson
     )
 
     if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
         target_link_libraries(serializer_dll
-            "-Wl,--exclude-libs,libparson.a"
+	  parson::parson
         )
     endif()
 
@@ -129,7 +131,7 @@ if(${use_installed_dependencies})
     install(TARGETS serializer EXPORT azure_iot_sdksTargets
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/../bin
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot
     )
     install(FILES ${serializer_h_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot)


### PR DESCRIPTION
# Checklist
- \[x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - \[x]  This pull-request is submitted against the `master` branch. 
  - \[x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Description of the problem
Azure-iot-sdk-c and its dependencies have deprecated and plain out wrong usage of cmake. These patches try to ease the pain to a degree that it can be used with yocto / openembedded and also recent Linux Distros. But whats really needed is a complete rewrite of all dependencies. 

# Description of the solution
All but RIoT can now be build and used from external dependencies, I also created PR there to hopefully better usage of (modern) cmake. But whats really needed is:
 * Rewrite of cmake
 * Add (public) CI Pipelines so one can check if changes break some architectures / builds I am as azure noob am not aware of. If cmake < 3.0 is still a thing for you guys, then I fear there might be other stuff that can also break easily