### PR TITLE
fixed broken link to porting guide in iothub_client readme

### DIFF
--- a/iothub_client/readme.md
+++ b/iothub_client/readme.md
@@ -118,7 +118,7 @@ In addition to the simple samples found in the current repository, you can find 
 [devbox-setup]: ../doc/devbox_setup.md
 [setup-iothub]: https://aka.ms/howtocreateazureiothub
 [c-sdk-intro]: https://azure.microsoft.com/documentation/articles/iot-hub-device-sdk-c-intro/
-[c-porting-guide]: ../doc/porting_guide.md
+[c-porting-guide]: https://github.com/Azure/azure-c-shared-utility/blob/master/devdoc/porting_guide.md
 [c-cross-compile]: ../doc/SDK_cross_compile_example.md
 [c-api-reference]: https://azure.github.io/azure-iot-sdk-c
 [apt-get-instructions]: ../doc/ubuntu_apt-get_sample_setup.md


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)
None

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
Broken link  to the porting guide in the iothub_client/readme.md file

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Modified the link to point to the correct spot. (Same as the link inside the sdk readme.md file)