### PR TITLE
Additional PnP bug fixes

### DIFF
--- a/digitaltwin_client/src/dt_client_core.c
+++ b/digitaltwin_client/src/dt_client_core.c
@@ -666,6 +666,22 @@ static DT_SEND_TELEMETRY_CALLBACK_CONTEXT* CreateDTSendTelemetryCallbackContext(
     return dtSendTelemetryCallbackContext;
 }
 
+// ReportedSdkInfo_Callback is invoked when SendSdkInformation property is acknowledged. Because this is best
+// effort only, we simply log the result for diagnostics purposes but take no further action.
+static void ReportedSdkInfo_Callback(int status_code, void* userContextCallback)
+{
+    (void)userContextCallback;
+    if (status_code < 300)
+    {
+        LogInfo("Sending SDKInformation properties to server successful, status=<%d>", status_code);
+    }
+    else
+    {
+        LogError("Sending SDKInformation properties to server failed, status=<%d>", status_code);
+    }
+}
+
+
 // SendSdkInformation sends information about this SDK to the corresponding reported properties.
 // This sending of SDK info is a best effort only; if it fails, we will not otherwise block application
 // from using the rest of the SDK.
@@ -684,7 +700,7 @@ static void SendSdkInformation(DT_CLIENT_CORE* dtClientCore)
         const size_t sdkInfoLen = strlen(sdkInfoString);
 
         LogInfo("Sending reported state for sdkInfo=%s", sdkInfoString);
-        (void)InvokeBindingSendReportedStateAsync(dtClientCore, (unsigned const char*)sdkInfoString, sdkInfoLen, ReportedDTStateUpdate_Callback, NULL);
+        (void)InvokeBindingSendReportedStateAsync(dtClientCore, (unsigned const char*)sdkInfoString, sdkInfoLen, ReportedSdkInfo_Callback, NULL);
     }
 
     STRING_delete(sdkInfo);

--- a/jenkins/ubuntu1604_c.sh
+++ b/jenkins/ubuntu1604_c.sh
@@ -12,6 +12,6 @@ build_root=$(cd "$(dirname "$0")/.." && pwd)
 cd $build_root
 
 # -- C --
-./build_all/linux/build.sh --run-unittests --run_valgrind --run-e2e-tests --provisioning --use-edge-modules "$@" #-x 
+./build_all/linux/build.sh --run-unittests --run_valgrind --run-e2e-tests --run-sfc-tests --provisioning --use-edge-modules "$@" #-x 
 [ $? -eq 0 ] || exit $?
 

--- a/jenkins/ubuntu_clang.sh
+++ b/jenkins/ubuntu_clang.sh
@@ -11,6 +11,6 @@ build_root=$(cd "$(dirname "$0")/.." && pwd)
 cd $build_root
 
 # -- C --
-./build_all/linux/build.sh --run-unittests --run_valgrind --run-e2e-tests "$@" #-x 
+./build_all/linux/build.sh --run-unittests --run_valgrind --run-e2e-tests --run-sfc-tests "$@" #-x 
 [ $? -eq 0 ] || exit $?
 

--- a/jenkins/windows_c.cmd
+++ b/jenkins/windows_c.cmd
@@ -12,6 +12,6 @@ for %%i in ("%build-root%") do set build-root=%%~fi
 
 REM -- C --
 cd %build-root%\build_all\windows
-call build.cmd --run-unittests --run-e2e-tests --build-traceabilitytool --provisioning --use-edge-modules %*
+call build.cmd --run-unittests --run-e2e-tests --run-sfc-tests --build-traceabilitytool --provisioning --use-edge-modules %*
 if errorlevel 1 goto :eof
 cd %build-root%

--- a/jenkins/windows_c_vs2017.cmd
+++ b/jenkins/windows_c_vs2017.cmd
@@ -53,7 +53,7 @@ echo CMAKE Output Path: %build-root%\cmake\%CMAKE_DIR%
 mkdir %build-root%\cmake\%CMAKE_DIR%
 pushd %build-root%\cmake\%CMAKE_DIR%
 
-cmake -Drun_longhaul_tests:BOOL=OFF -Drun_e2e_tests:BOOL=ON -Drun_unittests:BOOL=ON -Duse_c2d_amqp_methods:BOOL=ON -Duse_edge_modules=ON %build-root% -G %BUILD_ARCH%
+cmake -Drun_longhaul_tests:BOOL=OFF -Drun_e2e_tests:BOOL=ON -Drun_sfc_tests:BOOL=ON -Drun_unittests:BOOL=ON -Duse_c2d_amqp_methods:BOOL=ON -Duse_edge_modules=ON %build-root% -G %BUILD_ARCH%
 
 msbuild /m azure_iot_sdks.sln
 if !ERRORLEVEL! neq 0 exit /b !ERRORLEVEL!


### PR DESCRIPTION
Fixes that had been blocked on required changes going into master first.

* Have SDKInformation upload have its own callback for SDKInfo specific log messages.
* Re-enable fault injection tests.