### PR TITLE
Use JSON file for ll sample config

### DIFF
--- a/digitaltwin_client/samples/digitaltwin_sample_device/digitaltwin_sample_device.c
+++ b/digitaltwin_client/samples/digitaltwin_sample_device/digitaltwin_sample_device.c
@@ -24,13 +24,13 @@
 #include <digitaltwin_device_client.h>
 #include <digitaltwin_interface_client.h>
 
+// #define ENABLE_MODEL_DEFINITION_INTERFACE to enable ModelDefinition interface.  Remove it if your DTDL definitions will be 
+// available on the cloud already (e.g. a private repository) to save space on constrained devices.
 #define ENABLE_MODEL_DEFINITION_INTERFACE
 
-// #define ENABLE_MODEL_DEFINITION_INTERFACE to enable ModelDefinition interface.  It is left out of default sample because it is not required and will add resources on constrained devices.
 #ifdef ENABLE_MODEL_DEFINITION_INTERFACE
 #include <digitaltwin_model_definition.h>
 #endif 
-
 
 //
 // Headers that implement the sample interfaces that this sample device registers

--- a/digitaltwin_client/samples/digitaltwin_sample_device/digitaltwin_sample_device.c
+++ b/digitaltwin_client/samples/digitaltwin_sample_device/digitaltwin_sample_device.c
@@ -42,9 +42,9 @@
 
 // Number of DigitalTwin Interfaces that this DigitalTwin Device supports.
 #ifdef ENABLE_MODEL_DEFINITION_INTERFACE
-#define DIGITALTWIN_SAMPLE_DEVICE_MAX_INTERFACES 3
+#define DIGITALTWIN_SAMPLE_DEVICE_NUM_INTERFACES 3
 #else
-#define DIGITALTWIN_SAMPLE_DEVICE_MAX_INTERFACES 2
+#define DIGITALTWIN_SAMPLE_DEVICE_NUM_INTERFACES 2
 #endif
 #define DIGITALTWIN_SAMPLE_DEVICE_INFO_INDEX 0
 #define DIGITALTWIN_SAMPLE_ENVIRONMENTAL_SENSOR_INDEX 1
@@ -191,7 +191,7 @@ int main(int argc, char *argv[])
     DIGITALTWIN_CLIENT_RESULT result;
     IOTHUB_DEVICE_HANDLE deviceHandle = NULL; 
     DIGITALTWIN_DEVICE_CLIENT_HANDLE dtDeviceClientHandle = NULL;
-    DIGITALTWIN_INTERFACE_CLIENT_HANDLE interfaceClientHandles[DIGITALTWIN_SAMPLE_DEVICE_MAX_INTERFACES];
+    DIGITALTWIN_INTERFACE_CLIENT_HANDLE interfaceClientHandles[DIGITALTWIN_SAMPLE_DEVICE_NUM_INTERFACES];
 #ifdef ENABLE_MODEL_DEFINITION_INTERFACE
     MODEL_DEFINITION_CLIENT_HANDLE modeldefClientHandle = NULL;
 #endif
@@ -245,7 +245,7 @@ int main(int argc, char *argv[])
 #endif
     // Register the interface we've created with Azure IoT.  This call will block until interfaces
     // are successfully registered, we get a failure from server, or we timeout.
-    else if (DigitalTwinSampleDevice_RegisterDigitalTwinInterfacesAndWait(dtDeviceClientHandle, interfaceClientHandles, DIGITALTWIN_SAMPLE_DEVICE_MAX_INTERFACES) != DIGITALTWIN_CLIENT_OK)
+    else if (DigitalTwinSampleDevice_RegisterDigitalTwinInterfacesAndWait(dtDeviceClientHandle, interfaceClientHandles, DIGITALTWIN_SAMPLE_DEVICE_NUM_INTERFACES) != DIGITALTWIN_CLIENT_OK)
     {
         LogError("DigitalTwinSampleDevice_RegisterDigitalTwinInterfacesAndWait failed");
     }

--- a/digitaltwin_client/samples/digitaltwin_sample_ll_device/digitaltwin_sample_ll_device.c
+++ b/digitaltwin_client/samples/digitaltwin_sample_ll_device/digitaltwin_sample_ll_device.c
@@ -109,9 +109,9 @@ static const char* ConfigValue_DPSSX509 = "DPS_X509";
 
 // Number of DigitalTwin Interfaces that this DigitalTwin device supports.
 #ifdef ENABLE_MODEL_DEFINITION_INTERFACE
-#define DIGITALTWIN_SAMPLE_DEVICE_MAX_INTERFACES 3
+#define DIGITALTWIN_SAMPLE_DEVICE_NUM_INTERFACES 3
 #else
-#define DIGITALTWIN_SAMPLE_DEVICE_MAX_INTERFACES 2
+#define DIGITALTWIN_SAMPLE_DEVICE_NUM_INTERFACES 2
 #endif
 #define DIGITALTWIN_SAMPLE_DEVICE_INFO_INDEX 0
 #define DIGITALTWIN_SAMPLE_ENVIRONMENTAL_SENSOR_INDEX 1
@@ -489,7 +489,7 @@ int main(int argc, char *argv[])
     DIGITALTWIN_CLIENT_RESULT result;
     IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceLLHandle = NULL;
     DIGITALTWIN_DEVICE_CLIENT_LL_HANDLE digitaltwinDeviceClientLLHandle = NULL;
-    DIGITALTWIN_INTERFACE_CLIENT_HANDLE interfaceClientHandles[DIGITALTWIN_SAMPLE_DEVICE_MAX_INTERFACES];
+    DIGITALTWIN_INTERFACE_CLIENT_HANDLE interfaceClientHandles[DIGITALTWIN_SAMPLE_DEVICE_NUM_INTERFACES];
 #ifdef ENABLE_MODEL_DEFINITION_INTERFACE
     MODEL_DEFINITION_CLIENT_HANDLE modeldefClientHandle = NULL;
 #endif
@@ -552,7 +552,7 @@ int main(int argc, char *argv[])
 #endif
     // Register the interface we've created with Azure IoT.  This call will block until interfaces
     // are successfully registered, we get a failure from server, or we timeout.
-    else if (DigitalTwinSampleDevice_LL_RegisterDigitalTwinInterfacesAndWait(digitaltwinDeviceClientLLHandle, interfaceClientHandles, DIGITALTWIN_SAMPLE_DEVICE_MAX_INTERFACES) != DIGITALTWIN_CLIENT_OK)
+    else if (DigitalTwinSampleDevice_LL_RegisterDigitalTwinInterfacesAndWait(digitaltwinDeviceClientLLHandle, interfaceClientHandles, DIGITALTWIN_SAMPLE_DEVICE_NUM_INTERFACES) != DIGITALTWIN_CLIENT_OK)
     {
         LogError("DigitalTwinSampleDevice_LL_RegisterDigitalTwinInterfacesAndWait failed");
     }

--- a/digitaltwin_client/samples/digitaltwin_sample_ll_device/digitaltwin_sample_ll_device.c
+++ b/digitaltwin_client/samples/digitaltwin_sample_ll_device/digitaltwin_sample_ll_device.c
@@ -104,7 +104,7 @@ static const char* ConfigOption_DeviceId = "deviceId";
 static const char* ConfigOption_DeviceKey = "deviceKey";
 static const char* ConfigValue_ConnectionString = "ConnectionString";
 static const char* ConfigValue_DPSSymmetricKey = "DPSSymmetricKey";
-static const char* ConfigValue_DPSSX509 = "DPS X509";
+static const char* ConfigValue_DPSSX509 = "DPSX509";
 
 
 // Number of DigitalTwin Interfaces that this DigitalTwin device supports.
@@ -389,17 +389,17 @@ static IOTHUB_DEVICE_CLIENT_LL_HANDLE DigitalTwinSampleDevice_LL_InitializeIotHu
 
 
 // commandArgument is either the connection string or else it's a flag for using DPS for IoT Central
-static IOTHUB_DEVICE_CLIENT_LL_HANDLE DigitalTwinSampleDevice_LL_CreateHandle()
+static IOTHUB_DEVICE_CLIENT_LL_HANDLE DigitalTwinSampleDevice_LL_CreateHandle(bool traceOn)
 {
     IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceLLHandle = NULL;
 
     if (digitaltwinSampleConfig.securityType == DIGITALTWIN_SAMPLE_SECURITY_TYPE_CONNECTION_STRING)
     {
-        deviceLLHandle = DigitalTwinSampleDevice_LL_InitializeIotHubViaConnectionString(false);
+        deviceLLHandle = DigitalTwinSampleDevice_LL_InitializeIotHubViaConnectionString(traceOn);
     }
     else
     {
-        deviceLLHandle = DigitalTwinSampleDevice_LL_InitializeIotHubViaProvisioning(false);
+        deviceLLHandle = DigitalTwinSampleDevice_LL_InitializeIotHubViaProvisioning(traceOn);
     }
 
     return deviceLLHandle;
@@ -510,7 +510,7 @@ int main(int argc, char *argv[])
         LogError("Parsing %s failed", argv[1]);
     }
     // First, we create a standard IOTHUB_DEVICE_CLIENT_LL_HANDLE handle for DigitalTwin to consume.
-    else if ((deviceLLHandle = DigitalTwinSampleDevice_LL_CreateHandle()) == NULL)
+    else if ((deviceLLHandle = DigitalTwinSampleDevice_LL_CreateHandle(true)) == NULL)
     {
         LogError("Could not allocate IoTHub Device handle");
     }

--- a/digitaltwin_client/samples/digitaltwin_sample_ll_device/digitaltwin_sample_ll_device.c
+++ b/digitaltwin_client/samples/digitaltwin_sample_ll_device/digitaltwin_sample_ll_device.c
@@ -97,14 +97,14 @@ static const char* digitaltwinSample_CustomProvisioningData = "{"
                                                       "}";
 
 // Names of JSON fields and possible values for configuration of this sample
-static const char* ConfigOption_SecurityType = "securityType";
-static const char* ConfigOption_ConnectionString = "connectionString";
-static const char* ConfigOption_IDScope = "IDScope";
-static const char* ConfigOption_DeviceId = "deviceId";
-static const char* ConfigOption_DeviceKey = "deviceKey";
-static const char* ConfigValue_ConnectionString = "ConnectionString";
-static const char* ConfigValue_DPSSymmetricKey = "DPS_SymmetricKey";
-static const char* ConfigValue_DPSSX509 = "DPS_X509";
+static const char ConfigOption_SecurityType[] = "securityType";
+static const char ConfigOption_ConnectionString[] = "connectionString";
+static const char ConfigOption_IDScope[] = "IDScope";
+static const char ConfigOption_DeviceId[] = "deviceId";
+static const char ConfigOption_DeviceKey[] = "deviceKey";
+static const char ConfigValue_ConnectionString[] = "ConnectionString";
+static const char ConfigValue_DPSSymmetricKey[] = "DPS_SymmetricKey";
+static const char ConfigValue_DPSSX509[] = "DPS_X509";
 
 
 // Number of DigitalTwin Interfaces that this DigitalTwin device supports.
@@ -432,7 +432,7 @@ static int DigitalTwinSampleDevice_LL_ParseConfigFile(const char* configFileName
     }
     else
     {
-        if (strcmp(securityType, ConfigValue_ConnectionString) == 0)
+        if (strncmp(securityType, ConfigValue_ConnectionString, sizeof(ConfigValue_ConnectionString) -1) == 0)
         {
             if ((digitaltwinSampleConfig.connectionString = json_object_get_string(json_config_object, ConfigOption_ConnectionString)) == NULL)
             {
@@ -445,7 +445,7 @@ static int DigitalTwinSampleDevice_LL_ParseConfigFile(const char* configFileName
                 result = 0;
             }
         }
-        else if (strcmp(securityType, ConfigValue_DPSSymmetricKey) == 0)
+        else if (strncmp(securityType, ConfigValue_DPSSymmetricKey, sizeof(ConfigValue_DPSSymmetricKey) - 1) == 0)
         {
             if (((digitaltwinSampleConfig.IDScope = json_object_get_string(json_config_object, ConfigOption_IDScope)) == NULL) ||
                 ((digitaltwinSampleConfig.deviceId = json_object_get_string(json_config_object, ConfigOption_DeviceId)) == NULL) ||
@@ -460,7 +460,7 @@ static int DigitalTwinSampleDevice_LL_ParseConfigFile(const char* configFileName
                 result = 0;
             }
         }
-        else if (strcmp(securityType, ConfigValue_DPSSX509) == 0)
+        else if (strncmp(securityType, ConfigValue_DPSSX509, sizeof(ConfigValue_DPSSX509) - 1) == 0)
         {
             if ((digitaltwinSampleConfig.IDScope = json_object_get_string(json_config_object, ConfigOption_IDScope)) == NULL)
             {

--- a/digitaltwin_client/samples/digitaltwin_sample_ll_device/digitaltwin_sample_ll_device.c
+++ b/digitaltwin_client/samples/digitaltwin_sample_ll_device/digitaltwin_sample_ll_device.c
@@ -103,8 +103,8 @@ static const char* ConfigOption_IDScope = "IDScope";
 static const char* ConfigOption_DeviceId = "deviceId";
 static const char* ConfigOption_DeviceKey = "deviceKey";
 static const char* ConfigValue_ConnectionString = "ConnectionString";
-static const char* ConfigValue_DPSSymmetricKey = "DPSSymmetricKey";
-static const char* ConfigValue_DPSSX509 = "DPSX509";
+static const char* ConfigValue_DPSSymmetricKey = "DPS_SymmetricKey";
+static const char* ConfigValue_DPSSX509 = "DPS_X509";
 
 
 // Number of DigitalTwin Interfaces that this DigitalTwin device supports.

--- a/digitaltwin_client/samples/digitaltwin_sample_ll_device/readme.md
+++ b/digitaltwin_client/samples/digitaltwin_sample_ll_device/readme.md
@@ -14,10 +14,10 @@ To use this sample:
 
 The sample takes a single command line argument, which is the name of a JSON file containing configuration.  The JSON file requires a field named "securityType" which indicates how the connection to IoTHub (optionally via DPS) is to be established.
 
-Samples of all types of connection are included in the [./sample_config](./sample_config) directory.  Chose the appropriate file type and fill in the [TODO] sections.  The security types / samples are:  
+Samples of all types of connection are included in the [./sample_config](./sample_config) directory.  Choose the appropriate file type and fill in the [TODO] sections.  The security types / samples are:  
 
 * **ConnectionString** indicates that the device connection string is specified in the "connectionString" JSON field.  This connects directly to IoTHub, not DPS.  A sample file is [here](./sample_config/connectionString.json).
-* **DPS_SymmetricKey** indicates the device is connectiong to DPS, using a symmetric key as the authentication mechanism.  A sample file is [here](./sample_config/dpsSymmKey.json).
-* **DPS_X509** indicates the device is connectiong to DPS, using X509 certificates.  A sample file is [here](./sample_config/dpsX509.json).  This may require additional setup, e.g. using the TPM simulator during initial development.
+* **DPS_SymmetricKey** indicates the device is connecting to DPS, using a symmetric key as the authentication mechanism.  A sample file is [here](./sample_config/dpsSymmKey.json).
+* **DPS_X509** indicates the device is connecting to DPS, using X509 certificates.  A sample file is [here](./sample_config/dpsX509.json).  This may require additional setup, e.g. using the TPM simulator during initial development.
 
 IoT Central requires DPS based connections.  You will need to setup either **DPS_SymmetricKey** or **DPS_X509** to connect.

--- a/digitaltwin_client/samples/digitaltwin_sample_ll_device/readme.md
+++ b/digitaltwin_client/samples/digitaltwin_sample_ll_device/readme.md
@@ -5,17 +5,19 @@ This sample in this directory is almost identical to [digitaltwin_sample_device]
 * This sample can connect using Device Provisioning Service (DPS), including to IoT Central.  The other sample [digitaltwin_sample_device](../digital_sample_device) currently cannot.
 * This sample is designed to use the \_LL\_ layer, appropriate for single threaded applications and devices.
 
-To connect to IoT Central:  
+To use this sample:
+* Modify in `digitaltwin_sample_ll_device.c` the `DIGITALTWIN_SAMPLE_DEVICE_CAPABILITY_MODEL_ID` value to reference the DCM name you have setup, if you are using a different one.
 
-* Open [digitaltwin_sample_ll_device.c](./digitaltwin_sample_ll_device.c). **Specify parameters requested by the commented TODO's for your configuration.**
-* Run `digitaltwin_sample_ll_device InitialRegistrationWithIoTCentral`.  When running `digitaltwin_sample_ll_device` with any other command parameter, the application will treat this as an IoTHub connection string.  `InitialRegistrationWithIoTCentral` forces the app to use provisioning.
+* Create a configuration file, per the instructions below.
 
-To use Device Provisioning Service without IoT Central:
+## Configuration file setup
 
-* If you provisioned using IoT Central, the DPS instance IoT Central uses will automatically be whitelisted correctly.
+The sample takes a single command line argument, which is the name of a JSON file containing configuration.  The JSON file requires a field named "securityType" which indicates how the connection to IoTHub (optionally via DPS) is to be established.
 
-To connect to IoTHub directly, without provisioning or IoT Central involvement:
+Samples of all types of connection are included in the [./sample_config](./sample_config) directory.  Chose the appropriate file type and fill in the [TODO] sections.  The security types / samples are:  
 
-* Compile and run the application and run `digitaltwin_sample_ll_device`, passing your device's IoTHub connection string as the only paramater.
+* **ConnectionString** indicates that the device connection string is specified in the "connectionString" JSON field.  This connects directly to IoTHub, not DPS.  A sample file is [here](./sample_config/connectionString.json).
+* **DPS_SymmetricKey** indicates the device is connectiong to DPS, using a symmetric key as the authentication mechanism.  A sample file is [here](./sample_config/dpsSymmKey.json).
+* **DPS_X509** indicates the device is connectiong to DPS, using X509 certificates.  A sample file is [here](./sample_config/dpsX509.json).  This may require additional setup, e.g. using the TPM simulator during initial development.
 
-Other than the ability to connect to IoT Central, the  \_LL\_ samples are otherwise almost identical to the ../digitaltwin_sample directory.  The other large difference is that they use the \_LL\_ layer of Digital Twin instead of the convenience layer.  See [here](../../doc/threading_notes.md) for more details about the differences.
+IoT Central requires DPS based connections.  You will need to setup either **DPS_SymmetricKey** or **DPS_X509** to connect.

--- a/digitaltwin_client/samples/digitaltwin_sample_ll_device/sample_config/connectionString.json
+++ b/digitaltwin_client/samples/digitaltwin_sample_ll_device/sample_config/connectionString.json
@@ -1,0 +1,4 @@
+{
+    "securityType": "ConnectionString",
+    "connectionString": "[TODO]"
+}

--- a/digitaltwin_client/samples/digitaltwin_sample_ll_device/sample_config/dpsSymmKey.json
+++ b/digitaltwin_client/samples/digitaltwin_sample_ll_device/sample_config/dpsSymmKey.json
@@ -1,0 +1,6 @@
+{
+    "securityType": "DPS_SymmetricKey",
+    "IDScope": "[TODO]",
+    "deviceId": "[TODO]",
+    "deviceKey": "[TODO]"
+}

--- a/digitaltwin_client/samples/digitaltwin_sample_ll_device/sample_config/dpsX509.json
+++ b/digitaltwin_client/samples/digitaltwin_sample_ll_device/sample_config/dpsX509.json
@@ -1,0 +1,4 @@
+{
+    "securityType": "DPS_X509",
+    "IDScope": "[TODO]"
+}


### PR DESCRIPTION
No longer require customers hard-code values into .c file.  Read a JSON config file instead.