### PR TITLE
Move longhaul timeoutInSeconds to correct place in yml, change to a snug 800-min limit

### DIFF
--- a/build/longhaul.vsts-ci.yml
+++ b/build/longhaul.vsts-ci.yml
@@ -4,11 +4,11 @@ resources:
   clean: true
 jobs:
 - job: longhaul_linux
+  timeoutInMinutes: 800
   variables:
     _PREVIEW_VSTS_DOCKER_IMAGE: "aziotbld/linux-c-ubuntu"
   pool: 
     name: 'aziotbld-lin01'
-    timeoutInMinutes: 1200
   displayName: 'longhaul_linux'
   steps:
   - script: |
@@ -37,9 +37,9 @@ jobs:
     displayName: 'cleanup'
     condition: always()
 - job: longhaul_windows
+  timeoutInMinutes: 800
   pool:
     name: 'aziotbld-win10'
-    timeoutInMinutes: 1200
   steps:
   - script: |
       call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
Longhaul tests are timing out after the default 60 min limit that devops allow.

# Description of the solution
Make the changes according to the link below to give enough time for tests to complete (12h + 80 min wiggle room).
https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#timeouts