### PR TITLE
Fix the cancellation of the longhaul jobs in the gate for Windows platforms

### DIFF
--- a/build_all/windows/build.cmd
+++ b/build_all/windows/build.cmd
@@ -220,7 +220,7 @@ if %MAKE_NUGET_PKG% == yes (
         if !ERRORLEVEL! neq 0 exit /b !ERRORLEVEL!
 
         if %build-platform% neq arm (
-            ctest -T test --no-compress-output -C "debug" -V -j 8
+            ctest -T test --no-compress-output -C "debug" -V -j 16
             if not !ERRORLEVEL!==0 exit /b !ERRORLEVEL!
         )
     )
@@ -282,3 +282,4 @@ if "%~4" neq "" set build-platform=%~4
 msbuild /m %build-target% "/p:Configuration=%build-config%;Platform=%build-platform%" %2
 if not !ERRORLEVEL!==0 exit /b !ERRORLEVEL!
 goto :eof
+


### PR DESCRIPTION
The longhaul tests on Windows have been cancelled by devops after 12h, because not all Windows LH tests run in parallel.
There are 10 tests, but on our scripts we restrict the max number of parallel tests to 8.
We could fix this in different ways, but this is the cheapest and most straightforward.
Also, on Linux we run up to 16 tests in parallel, so increasing by that much on Windows should be acceptable.

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 