### PR TITLE
Fix for telemetry message explosion (part 1)

### DIFF
--- a/digitaltwin_client/inc/digitaltwin_interface_client.h
+++ b/digitaltwin_client/inc/digitaltwin_interface_client.h
@@ -282,7 +282,6 @@ MOCKABLE_FUNCTION(, DIGITALTWIN_CLIENT_RESULT, DigitalTwin_InterfaceClient_SetCo
   @warning The data specified in <c>messageData</c> must be valid JSON.  See conceptual documentation on data_format.md for more information.
 
   @param[in] dtInterfaceClientHandle            Handle for the interface client.
-  @param[in] telemetryName                      Name of the telemetry message to send.  This should match the model associated with this interface.
   @param[in] messageData                        Value of the telemetry data to send.  The schema must match the data specified in the model document.
   @param[in] messageDataLen                     Length of the telemetry data to send.
   @param[in] telemetryConfirmationCallback      (Optional) Function pointer to be invoked when the telemetry message is successfully delivered or fails.
@@ -290,7 +289,7 @@ MOCKABLE_FUNCTION(, DIGITALTWIN_CLIENT_RESULT, DigitalTwin_InterfaceClient_SetCo
 
   @returns  A DIGITALTWIN_CLIENT_RESULT.
 */
-MOCKABLE_FUNCTION(, DIGITALTWIN_CLIENT_RESULT, DigitalTwin_InterfaceClient_SendTelemetryAsync, DIGITALTWIN_INTERFACE_CLIENT_HANDLE, dtInterfaceClientHandle, const char*, telemetryName, const unsigned char*, messageData, size_t, messageDataLen, DIGITALTWIN_CLIENT_TELEMETRY_CONFIRMATION_CALLBACK, telemetryConfirmationCallback, void*, userContextCallback);
+MOCKABLE_FUNCTION(, DIGITALTWIN_CLIENT_RESULT, DigitalTwin_InterfaceClient_SendTelemetryAsync, DIGITALTWIN_INTERFACE_CLIENT_HANDLE, dtInterfaceClientHandle, const unsigned char*, messageData, size_t, messageDataLen, DIGITALTWIN_CLIENT_TELEMETRY_CONFIRMATION_CALLBACK, telemetryConfirmationCallback, void*, userContextCallback);
 
 /** 
   @brief Sends a Digital Twin property to the server.

--- a/digitaltwin_client/samples/digitaltwin_sample_environmental_sensor/digitaltwin_sample_environmental_sensor.c
+++ b/digitaltwin_client/samples/digitaltwin_sample_environmental_sensor/digitaltwin_sample_environmental_sensor.c
@@ -581,6 +581,8 @@ DIGITALTWIN_INTERFACE_CLIENT_HANDLE DigitalTwinSampleEnvironmentalSensor_CreateI
 // more detailed state information as part of this callback.
 static void DigitalTwinSampleEnvironmentalSensor_TelemetryCallback(DIGITALTWIN_CLIENT_RESULT dtTelemetryStatus, void* userContextCallback)
 {
+    (void)userContextCallback;
+
     if (dtTelemetryStatus == DIGITALTWIN_CLIENT_OK)
     {
         // This tends to overwhelm the logging on output based on how frequently this function is invoked, so removing by default.
@@ -588,7 +590,7 @@ static void DigitalTwinSampleEnvironmentalSensor_TelemetryCallback(DIGITALTWIN_C
     }
     else
     {
-        LogError("ENVIRONMENTAL_SENSOR_INTERFACE: DigitalTwin failed delivered telemetry message for <%s>, error=<%s>", (const char*)userContextCallback, MU_ENUM_TO_STRING(DIGITALTWIN_CLIENT_RESULT,dtTelemetryStatus));
+        LogError("ENVIRONMENTAL_SENSOR_INTERFACE: DigitalTwin failed delivered telemetry message, error=<%s>", MU_ENUM_TO_STRING(DIGITALTWIN_CLIENT_RESULT,dtTelemetryStatus));
     }
 }
 
@@ -604,23 +606,16 @@ DIGITALTWIN_CLIENT_RESULT DigitalTwinSampleEnvironmentalSensor_SendTelemetryMess
     float currentTemperature = 20.0f + ((float)rand() / RAND_MAX) * 15.0f;
     float currentHumidity = 60.0f + ((float)rand() / RAND_MAX) * 20.0f;
 
-    char currentTemperatureMessage[128];
-    char currentHumidityMessage[128];
+    char currentMessage[128];
 
-    sprintf(currentTemperatureMessage, "%.3f", currentTemperature);
-    sprintf(currentHumidityMessage, "%.3f", currentHumidity);
+    sprintf(currentMessage, "{\"%s\":%.3f, \"%s\":%.3f}", 
+            DigitalTwinSampleEnvironmentalSensor_TemperatureTelemetry, currentTemperature,
+            DigitalTwinSampleEnvironmentalSensor_HumidityTelemetry, currentHumidity);
 
-    if ((result = DigitalTwin_InterfaceClient_SendTelemetryAsync(interfaceHandle, DigitalTwinSampleEnvironmentalSensor_TemperatureTelemetry, 
-                                                         (unsigned char *)currentTemperatureMessage, strlen(currentTemperatureMessage), DigitalTwinSampleEnvironmentalSensor_TelemetryCallback,
-                                                         (void*)DigitalTwinSampleEnvironmentalSensor_TemperatureTelemetry)) != DIGITALTWIN_CLIENT_OK)
+    if ((result = DigitalTwin_InterfaceClient_SendTelemetryAsync(interfaceHandle, (unsigned char*)currentMessage, strlen(currentMessage),
+                                                                 DigitalTwinSampleEnvironmentalSensor_TelemetryCallback, NULL)) != DIGITALTWIN_CLIENT_OK)
     {
-        LogError("ENVIRONMENTAL_SENSOR_INTERFACE: DigitalTwin_InterfaceClient_SendTelemetryAsync failed for sending %s", DigitalTwinSampleEnvironmentalSensor_TemperatureTelemetry);
-    }
-    else if ((result = DigitalTwin_InterfaceClient_SendTelemetryAsync(interfaceHandle, DigitalTwinSampleEnvironmentalSensor_HumidityTelemetry, 
-                                                         (unsigned char*)currentHumidityMessage, strlen(currentHumidityMessage), DigitalTwinSampleEnvironmentalSensor_TelemetryCallback,
-                                                         (void*)DigitalTwinSampleEnvironmentalSensor_HumidityTelemetry)) != DIGITALTWIN_CLIENT_OK)
-    {
-        LogError("ENVIRONMENTAL_SENSOR_INTERFACE: DigitalTwin_InterfaceClient_SendTelemetryAsync failed for sending %s", DigitalTwinSampleEnvironmentalSensor_HumidityTelemetry);
+        LogError("ENVIRONMENTAL_SENSOR_INTERFACE: DigitalTwin_InterfaceClient_SendTelemetryAsync failed for sending.");
     }
 
     return result;

--- a/digitaltwin_client/tests/dt_e2e/device/dt_e2e_telemetry.c
+++ b/digitaltwin_client/tests/dt_e2e/device/dt_e2e_telemetry.c
@@ -142,8 +142,8 @@ static void DT_E2E_SendTelemetryMessage(const DIGITALTWIN_CLIENT_COMMAND_REQUEST
 
     DIGITALTWIN_CLIENT_RESULT result;
 
-    if ((result = DigitalTwin_InterfaceClient_SendTelemetryAsync(telemetryTestContext->interfaceHandle, DT_E2E_Telemetry_MessageName,
-                                                                 dtCommandRequest->requestData, dtCommandRequest->requestDataLen, DT_E2E_TelemetryConfirmationCallback, telemetryTestContext)) != DIGITALTWIN_CLIENT_OK)
+    if ((result = DigitalTwin_InterfaceClient_SendTelemetryAsync(telemetryTestContext->interfaceHandle, dtCommandRequest->requestData, dtCommandRequest->requestDataLen,
+                                                                 DT_E2E_TelemetryConfirmationCallback, telemetryTestContext)) != DIGITALTWIN_CLIENT_OK)
     {
         LogError("TEST_TELEMETRY_INTERFACE: DigitalTwin_InterfaceClient_SendTelemetryAsync fails, error=<%d>", result);
         DT_E2E_Util_Fatal_Error_Occurred();


### PR DESCRIPTION
- removed schema message header from all messages
- the expected payload for telemetry messageData is now a valid json string
- add default component index as input to Registration
- skip setting iothub-interface-name (@ifname) for default component for telemetry and async  command updates.