### PR TITLE
Handle unexpected states in dev provisioning messagesender and messagereceiver state cb (issue #1254)

### DIFF
--- a/provisioning_client/src/prov_transport_amqp_common.c
+++ b/provisioning_client/src/prov_transport_amqp_common.c
@@ -195,6 +195,15 @@ static void on_message_sender_state_changed_callback(void* context, MESSAGE_SEND
                     amqp_info->transport_state = TRANSPORT_CLIENT_STATE_ERROR;
                     amqp_info->amqp_state = AMQP_STATE_ERROR;
                     break;
+                default:
+                    LogError("on_message_sender_state_changed_callback received unexpected state %d", amqp_info->msg_recv_state);
+
+                    amqp_info->amqp_state = AMQP_STATE_ERROR;
+                    amqp_info->transport_state = TRANSPORT_CLIENT_STATE_ERROR;
+                    if (amqp_info->status_cb != NULL)
+                    {
+                        amqp_info->status_cb(PROV_DEVICE_TRANSPORT_STATUS_ERROR, amqp_info->retry_after_value, amqp_info->status_ctx);
+                    }
             }
         }
     }
@@ -233,6 +242,15 @@ static void on_message_receiver_state_changed_callback(const void* user_ctx, MES
                 amqp_info->transport_state = TRANSPORT_CLIENT_STATE_ERROR;
                 amqp_info->amqp_state = AMQP_STATE_ERROR;
                 break;
+            default:
+                LogError("on_message_receiver_state_changed_callback received unexpected state %d", amqp_info->msg_recv_state);
+
+                amqp_info->amqp_state = AMQP_STATE_ERROR;
+                amqp_info->transport_state = TRANSPORT_CLIENT_STATE_ERROR;
+                if (amqp_info->status_cb != NULL)
+                {
+                    amqp_info->status_cb(PROV_DEVICE_TRANSPORT_STATUS_ERROR, amqp_info->retry_after_value, amqp_info->status_ctx);
+                }
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
https://github.com/Azure/azure-iot-sdk-c/issues/1254

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Added code to handle unexpected enum values on state callbacks