### PR TITLE
fix setting hsm_* variable for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,11 +139,13 @@ endif()
 # Set Provisioning Information.  This will also setup appropriate HSM
 if (${use_prov_client})
     set(use_prov_client_core ON)
-
     if ("${hsm_custom_lib}" STREQUAL "")
-        set(hsm_type_x509 ON)
-        set(hsm_type_sastoken ON)
-        set(hsm_type_symm_key ON)
+        if ((NOT ${hsm_type_x509}) AND (NOT ${hsm_type_sastoken}) AND (NOT ${hsm_type_symm_key}))
+            # If the cmake option did not explicitly configure an hsm type, then enable them all.
+            set(hsm_type_x509 ON)
+            set(hsm_type_sastoken ON)
+            set(hsm_type_symm_key ON)
+        endif()
     else()
         set(hsm_type_custom ON)
     endif()

--- a/jenkins/linux_c_option_test.sh
+++ b/jenkins/linux_c_option_test.sh
@@ -57,6 +57,9 @@ declare -a arr=(
     "-Duse_prov_client=ON -Dhsm_custom_lib=$custom_hsm_lib"
     "-Drun_e2e_tests=ON -Drun_sfc_tests=ON -Duse_edge_modules=ON"
     "-Drun_e2e_tests=ON -Duse_baltimore_cert=ON"
+    "-Duse_prov_client:BOOL=ON -Dhsm_type_symm_key:BOOL=ON"
+    "-Duse_prov_client:BOOL=ON -Dhsm_type_x509:BOOL=ON"
+    "-Duse_prov_client:BOOL=ON -hsm_type_sastoken:BOOL=ON"
 )
 
 for item in "${arr[@]}"


### PR DESCRIPTION
apply patch file to configure hsm type explicitly with cmake option and add tests on Linux accordingly.