### PR TITLE
Remove incorrect const qualifier in serializer methodreturn

### DIFF
--- a/serializer/inc/methodreturn.h
+++ b/serializer/inc/methodreturn.h
@@ -8,13 +8,10 @@ typedef struct METHODRETURN_HANDLE_DATA_TAG* METHODRETURN_HANDLE;
 
 #include "azure_macro_utils/macro_utils.h"
 
-/*the following macro expands to "const" if X is defined. If X is not defined, then it expands to nothing*/
-#define CONST_BY_COMPILATION_UNIT(X) MU_IF(MU_COUNT_ARG(X),const,)
-
 typedef struct METHODRETURN_DATA_TAG
 {
-    CONST_BY_COMPILATION_UNIT(METHODRETURN_C) int statusCode;
-    CONST_BY_COMPILATION_UNIT(METHODRETURN_C) char* jsonValue;
+    int statusCode;
+    char* jsonValue;
 }METHODRETURN_DATA;
 
 #include "umock_c/umock_c_prod.h"

--- a/serializer/src/methodreturn.c
+++ b/serializer/src/methodreturn.c
@@ -10,9 +10,7 @@
 #include "azure_c_shared_utility/strings.h"
 #include "parson.h"
 
-#define METHODRETURN_C
 #include "methodreturn.h"
-#undef METHODRETURN_C
 
 typedef struct METHODRETURN_HANDLE_DATA_TAG
 {


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

Compilation fails on Mac OS with:

Testing with `xcodebuild`.
 -> AzureIoTHubClient (1.3.6-public-preview-c)
    - WARN  | source: Git sources should specify a tag.
    - ERROR | xcodebuild: Returned an unsuccessful exit code.
    - ERROR | xcodebuild:  AzureIoTHubClient/serializer/src/methodreturn.c:70:41: error: cannot assign to non-static data member 'statusCode' with const-qualified type 'const int'
    - NOTE  | xcodebuild:  AzureIoTHubClient/inc/methodreturn.h:16:51: note: non-static data member 'statusCode' declared const here

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Remove the const qualifiers.