### PR TITLE
Fix GetSendStatus in AMQP transport (github issue #1039)

### DIFF
--- a/iothub_client/src/iothubtransport_amqp_common.c
+++ b/iothub_client/src/iothubtransport_amqp_common.c
@@ -1936,28 +1936,37 @@ IOTHUB_CLIENT_RESULT IoTHubTransport_AMQP_Common_GetSendStatus(IOTHUB_DEVICE_HAN
         AMQP_TRANSPORT_DEVICE_INSTANCE* amqp_device_state = (AMQP_TRANSPORT_DEVICE_INSTANCE*)handle;
 
         DEVICE_SEND_STATUS device_send_status;
-        // Codes_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_097: [IoTHubTransport_AMQP_Common_GetSendStatus shall invoke amqp_device_get_send_status()]
-        if (amqp_device_get_send_status(amqp_device_state->device_handle, &device_send_status) != RESULT_OK)
+
+        if (!DList_IsListEmpty(amqp_device_state->waiting_to_send))
         {
-            // Codes_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_098: [If amqp_device_get_send_status() fails, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_ERROR]
-            LogError("Failed retrieving the device send status (amqp_device_get_send_status failed)");
-            result = IOTHUB_CLIENT_ERROR;
+            *iotHubClientStatus = IOTHUB_CLIENT_SEND_STATUS_BUSY;
+            result = IOTHUB_CLIENT_OK;
         }
         else
         {
-            // Codes_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_099: [If amqp_device_get_send_status() returns DEVICE_SEND_STATUS_BUSY, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_OK and status IOTHUB_CLIENT_SEND_STATUS_BUSY]
-            if (device_send_status == DEVICE_SEND_STATUS_BUSY)
+            // Codes_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_097: [IoTHubTransport_AMQP_Common_GetSendStatus shall invoke amqp_device_get_send_status()]
+            if (amqp_device_get_send_status(amqp_device_state->device_handle, &device_send_status) != RESULT_OK)
             {
-                *iotHubClientStatus = IOTHUB_CLIENT_SEND_STATUS_BUSY;
+                // Codes_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_098: [If amqp_device_get_send_status() fails, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_ERROR]
+                LogError("Failed retrieving the device send status (amqp_device_get_send_status failed)");
+                result = IOTHUB_CLIENT_ERROR;
             }
-            // Codes_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_100: [If amqp_device_get_send_status() returns DEVICE_SEND_STATUS_IDLE, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_OK and status IOTHUB_CLIENT_SEND_STATUS_IDLE]
-            else // DEVICE_SEND_STATUS_IDLE
+            else
             {
-                *iotHubClientStatus = IOTHUB_CLIENT_SEND_STATUS_IDLE;
-            }
+                // Codes_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_099: [If amqp_device_get_send_status() returns DEVICE_SEND_STATUS_BUSY, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_OK and status IOTHUB_CLIENT_SEND_STATUS_BUSY]
+                if (device_send_status == DEVICE_SEND_STATUS_BUSY)
+                {
+                    *iotHubClientStatus = IOTHUB_CLIENT_SEND_STATUS_BUSY;
+                }
+                // Codes_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_100: [If amqp_device_get_send_status() returns DEVICE_SEND_STATUS_IDLE, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_OK and status IOTHUB_CLIENT_SEND_STATUS_IDLE]
+                else // DEVICE_SEND_STATUS_IDLE
+                {
+                    *iotHubClientStatus = IOTHUB_CLIENT_SEND_STATUS_IDLE;
+                }
 
-            // Codes_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_109: [If no failures occur, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_OK]
-            result = IOTHUB_CLIENT_OK;
+                // Codes_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_109: [If no failures occur, IoTHubTransport_AMQP_Common_GetSendStatus shall return IOTHUB_CLIENT_OK]
+                result = IOTHUB_CLIENT_OK;
+            }
         }
     }
 


### PR DESCRIPTION
Relates to: https://github.com/Azure/azure-iot-sdk-c/issues/1039

The iothub client layer shares the waiting_to_send list with the AMQP transport, which then sends its elements down through individual function calls
to telemetry_messenger_send_async. In case the transport is reconnecting, it should look into waiting_to_send list instead of consulting the telemetry_messenger module.

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 