### PR TITLE
iothubtransport_mqtt_common: fix compiler issue

### DIFF
--- a/iothub_client/src/iothubtransport_mqtt_common.c
+++ b/iothub_client/src/iothubtransport_mqtt_common.c
@@ -524,12 +524,18 @@ static int parse_device_twin_topic_info(const char* resp_topic, bool* patch_msg,
                 else if (token_count == 3)
                 {
                     *status_code = (int)atol(STRING_c_str(token_value));
+                    *patch_msg = false;
                     if (STRING_TOKENIZER_get_next_token(token_handle, token_value, "/?$rid=") == 0)
                     {
                         *request_id = (size_t)atol(STRING_c_str(token_value));
+                        result = 0;
                     }
-                    *patch_msg = false;
-                    result = 0;
+                    else
+                    {
+                        LogError("Could not parse request_id.");
+                        *request_id = 0;
+                        result = MU_FAILURE;
+                    }
                     break;
                 }
                 token_count++;

--- a/iothub_client/src/iothubtransport_mqtt_common.c
+++ b/iothub_client/src/iothubtransport_mqtt_common.c
@@ -533,7 +533,6 @@ static int parse_device_twin_topic_info(const char* resp_topic, bool* patch_msg,
                     else
                     {
                         LogError("Could not parse request_id.");
-                        *request_id = 0;
                         result = MU_FAILURE;
                     }
                     break;
@@ -1520,7 +1519,7 @@ static void mqtt_notification_callback(MQTT_MESSAGE_HANDLE msgHandle, void* call
             IOTHUB_IDENTITY_TYPE type = retrieve_topic_type(topic_resp, STRING_c_str(transportData->topic_InputQueue));
             if (type == IOTHUB_TYPE_DEVICE_TWIN)
             {
-                size_t request_id;
+                size_t request_id = 0;
                 int status_code;
                 bool notification_msg;
                 if (parse_device_twin_topic_info(topic_resp, &notification_msg, &request_id, &status_code) != 0)


### PR DESCRIPTION
The source file `src/iothubtransport_mqtt_common.c` may fail to compile
in some stricter compiler environment (flag -Wmaybe-unitialized
enabled).

Fix the issue by explicitly initialize all the variables in all the
possile combinations of code path of execution.

Signed-off-by: Francesco Giancane <francesco.giancane@accenture.com>

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] ~~I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).~~
- ~~If this is a modification that impacts the behavior of a public API~~
  - [ ] ~~I edited the corresponding document in the `devdoc` folder and added or modified requirements.~~
- I submitted this PR against the correct branch: 
  - [X] This pull-request is submitted against the `master` branch. 
  - [X] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [X] I have squashed my changes into one with a clear description of the change.

# Description of the problem
`src/iothubtransport_mqtt_common.c` failed to compile because not every code path lead to correct variable assignment.

# Description of the solution
Fixing the issue by explicitly set variables in appropriate manner in every code path.