### PR TITLE
add zero out initialized padding bytes in src directory source files

### DIFF
--- a/serializer/src/agenttypesystem.c
+++ b/serializer/src/agenttypesystem.c
@@ -2733,6 +2733,7 @@ AGENT_DATA_TYPES_RESULT Create_AGENT_DATA_TYPE_from_AGENT_DATA_TYPE(AGENT_DATA_T
                                 }
                                 else
                                 {
+                                    (void)memset(dest->value.edmComplexType.fields[i].value, 0, sizeof(AGENT_DATA_TYPE));
                                     if (Create_AGENT_DATA_TYPE_from_AGENT_DATA_TYPE(dest->value.edmComplexType.fields[i].value, src->value.edmComplexType.fields[i].value) != AGENT_DATA_TYPES_OK)
                                     {
                                         result = AGENT_DATA_TYPES_ERROR;
@@ -2787,6 +2788,7 @@ AGENT_DATA_TYPES_RESULT Create_AGENT_DATA_TYPE_from_MemberPointers(AGENT_DATA_TY
         }
         else
         {
+            (void)memset(values, 0, (nMembers* sizeof(AGENT_DATA_TYPE)));
             size_t i;
             for (i = 0; i < nMembers; i++)
             {
@@ -2916,6 +2918,7 @@ AGENT_DATA_TYPES_RESULT Create_AGENT_DATA_TYPE_from_Members(AGENT_DATA_TYPE* age
                     }
                     else
                     {
+                        (void)memset(agentData->value.edmComplexType.fields[i].value, 0, sizeof(AGENT_DATA_TYPE));
                         /*copy the values*/
                         if (Create_AGENT_DATA_TYPE_from_AGENT_DATA_TYPE(agentData->value.edmComplexType.fields[i].value, &(memberValues[i])) != AGENT_DATA_TYPES_OK)
                         {

--- a/serializer/src/codefirst.c
+++ b/serializer/src/codefirst.c
@@ -903,6 +903,7 @@ void* CodeFirst_CreateDevice(SCHEMA_MODEL_TYPE_HANDLE model, const REFLECTED_DAT
         /* Codes_SRS_CODEFIRST_99_082: [ CodeFirst_CreateDevice shall pass to Device_Create the function CodeFirst_InvokeAction, action callback argument and the CodeFirst_InvokeMethod ] */
         else
         {
+            (void)memset(deviceHeader, 0, sizeof(DEVICE_HEADER_DATA));
             if ((deviceHeader->data = malloc(dataSize)) == NULL)
             {
                 free(deviceHeader);

--- a/serializer/src/commanddecoder.c
+++ b/serializer/src/commanddecoder.c
@@ -66,6 +66,7 @@ static int DecodeValueFromNode(SCHEMA_HANDLE schemaHandle, AGENT_DATA_TYPE* agen
                 }
                 else
                 {
+                    (void)memset(memberValues, 0, (sizeof(AGENT_DATA_TYPE)* propertyCount));
                     const char** memberNames = (const char**)malloc(sizeof(const char*)* propertyCount);
                     if (memberNames == NULL)
                     {
@@ -236,6 +237,7 @@ static EXECUTE_COMMAND_RESULT DecodeAndExecuteModelAction(COMMAND_DECODER_HANDLE
                 }
                 else
                 {
+                    (void)memset(arguments, 0, (sizeof(AGENT_DATA_TYPE)* argCount));
                     size_t i;
                     size_t j;
                     result = EXECUTE_COMMAND_ERROR;
@@ -342,6 +344,7 @@ static METHODRETURN_HANDLE DecodeAndExecuteModelMethod(COMMAND_DECODER_HANDLE_DA
                 }
                 else
                 {
+                    (void)memset(arguments, 0, (sizeof(AGENT_DATA_TYPE)* argCount));
                     size_t i;
                     size_t j;
                     result = NULL;

--- a/serializer/src/datamarshaller.c
+++ b/serializer/src/datamarshaller.c
@@ -54,6 +54,7 @@ DATA_MARSHALLER_HANDLE DataMarshaller_Create(SCHEMA_MODEL_TYPE_HANDLE modelHandl
     }
     else
     {
+        (void)memset(result, 0, sizeof(DATA_MARSHALLER_HANDLE_DATA));
         /*everything ok*/
         /*Codes_SRS_DATA_MARSHALLER_99_018:[ DataMarshaller_Create shall create a new DataMarshaller instance and on success it shall return a non NULL handle.]*/
         result->ModelHandle = modelHandle;

--- a/serializer/src/methodreturn.c
+++ b/serializer/src/methodreturn.c
@@ -61,6 +61,7 @@ METHODRETURN_HANDLE MethodReturn_Create(int statusCode, const char* jsonValue)
         }
         else
         {
+            (void)memset(result, 0, sizeof(METHODRETURN_HANDLE_DATA));
             if (jsonValue == NULL)
             {
                 /*Codes_SRS_METHODRETURN_02_001: [ MethodReturn_Create shall create a non-NULL handle containing statusCode and a clone of jsonValue. ]*/

--- a/serializer/src/multitree.c
+++ b/serializer/src/multitree.c
@@ -46,6 +46,7 @@ MULTITREE_HANDLE MultiTree_Create(MULTITREE_CLONE_FUNCTION cloneFunction, MULTIT
         result = (MULTITREE_HANDLE_DATA*)malloc(sizeof(MULTITREE_HANDLE_DATA));
         if (result != NULL)
         {
+            (void)memset(result, 0, sizeof(MULTITREE_HANDLE_DATA));
             result->name = NULL;
             result->value = NULL;
             result->cloneFunction = cloneFunction;
@@ -134,6 +135,7 @@ static CREATELEAF_RESULT createLeaf(MULTITREE_HANDLE_DATA* node, const char*name
         }
         else
         {
+            (void)memset(newNode, 0, sizeof(MULTITREE_HANDLE_DATA));
             newNode->nChildren = 0;
             newNode->children = NULL;
             if (mallocAndStrcpy_s(&(newNode->name), name) != 0)

--- a/serializer/src/schema.c
+++ b/serializer/src/schema.c
@@ -387,33 +387,40 @@ SCHEMA_HANDLE Schema_Create(const char* schemaNamespace, void* metadata)
             result = NULL;
             LogError("(Error code:%s)", MU_ENUM_TO_STRING(SCHEMA_RESULT, SCHEMA_ERROR));
         }
-        else if ((result = (SCHEMA_HANDLE_DATA*)malloc(sizeof(SCHEMA_HANDLE_DATA))) == NULL)
-        {
-            /* Codes_SRS_SCHEMA_99_003:[On failure, NULL shall be returned.] */
-            LogError("(Error code:%s)", MU_ENUM_TO_STRING(SCHEMA_RESULT, SCHEMA_ERROR));
-        }
-        else if (mallocAndStrcpy_s((char**)&result->Namespace, schemaNamespace) != 0)
-        {
-            /* Codes_SRS_SCHEMA_99_003:[On failure, NULL shall be returned.] */
-            free(result);
-            result = NULL;
-            LogError("(Error code:%s)", MU_ENUM_TO_STRING(SCHEMA_RESULT, SCHEMA_ERROR));
-        }
-        else if (VECTOR_push_back(g_schemas, &result, 1) != 0)
-        {
-            free((void*)result->Namespace);
-            free(result);
-            result = NULL;
-            LogError("(Error code:%s)", MU_ENUM_TO_STRING(SCHEMA_RESULT, SCHEMA_ERROR));
-        }
         else
         {
-            /* Codes_SRS_SCHEMA_99_002:[On success a non-NULL handle to the newly created schema shall be returned.] */
-            result->ModelTypes = NULL;
-            result->ModelTypeCount = 0;
-            result->StructTypes = NULL;
-            result->StructTypeCount = 0;
-            result->metadata = metadata;
+            if ((result = (SCHEMA_HANDLE_DATA*)malloc(sizeof(SCHEMA_HANDLE_DATA))) == NULL)
+            {
+                /* Codes_SRS_SCHEMA_99_003:[On failure, NULL shall be returned.] */
+                LogError("(Error code:%s)", MU_ENUM_TO_STRING(SCHEMA_RESULT, SCHEMA_ERROR));
+            }
+            else
+            {
+                (void)memset(result, 0, sizeof(SCHEMA_HANDLE_DATA));
+                if (mallocAndStrcpy_s((char**)&result->Namespace, schemaNamespace) != 0)
+                {
+                    /* Codes_SRS_SCHEMA_99_003:[On failure, NULL shall be returned.] */
+                    free(result);
+                    result = NULL;
+                    LogError("(Error code:%s)", MU_ENUM_TO_STRING(SCHEMA_RESULT, SCHEMA_ERROR));
+                }
+                else if (VECTOR_push_back(g_schemas, &result, 1) != 0)
+                {
+                    free((void*)result->Namespace);
+                    free(result);
+                    result = NULL;
+                    LogError("(Error code:%s)", MU_ENUM_TO_STRING(SCHEMA_RESULT, SCHEMA_ERROR));
+                }
+                else
+                {
+                    /* Codes_SRS_SCHEMA_99_002:[On success a non-NULL handle to the newly created schema shall be returned.] */
+                    result->ModelTypes = NULL;
+                    result->ModelTypeCount = 0;
+                    result->StructTypes = NULL;
+                    result->StructTypeCount = 0;
+                    result->metadata = metadata;
+                }
+            }
         }
     }
 
@@ -650,54 +657,45 @@ SCHEMA_MODEL_TYPE_HANDLE Schema_CreateModelType(SCHEMA_HANDLE schemaHandle, cons
                     result = NULL;
                     LogError("(Error code:%s)", MU_ENUM_TO_STRING(SCHEMA_RESULT, SCHEMA_ERROR));
                 }
-                else if (mallocAndStrcpy_s((char**)&modelType->Name, modelName) != 0)
-                {
-                    /* Codes_SRS_SCHEMA_99_009:[On failure, Schema_CreateModelType shall return NULL.] */
-                    result = NULL;
-                    free(modelType);
-                    LogError("(Error code:%s)", MU_ENUM_TO_STRING(SCHEMA_RESULT, SCHEMA_ERROR));
-                }
                 else
                 {
-                    modelType->models = VECTOR_create(sizeof(MODEL_IN_MODEL));
-                    if (modelType->models == NULL)
+                    (void)memset(modelType, 0, sizeof(SCHEMA_MODEL_TYPE_HANDLE_DATA));
+                    if (mallocAndStrcpy_s((char**)&modelType->Name, modelName) != 0)
                     {
                         /* Codes_SRS_SCHEMA_99_009:[On failure, Schema_CreateModelType shall return NULL.] */
-                        LogError("unable to VECTOR_create");
-                        free((void*)modelType->Name);
-                        free((void*)modelType);
                         result = NULL;
+                        free(modelType);
+                        LogError("(Error code:%s)", MU_ENUM_TO_STRING(SCHEMA_RESULT, SCHEMA_ERROR));
                     }
                     else
                     {
-                        if ((modelType->reportedProperties = VECTOR_create(sizeof(SCHEMA_REPORTED_PROPERTY_HANDLE))) == NULL)
+                        modelType->models = VECTOR_create(sizeof(MODEL_IN_MODEL));
+                        if (modelType->models == NULL)
                         {
                             /* Codes_SRS_SCHEMA_99_009:[On failure, Schema_CreateModelType shall return NULL.] */
-                            LogError("failed to VECTOR_create (reported properties)");
-                            VECTOR_destroy(modelType->models);
+                            LogError("unable to VECTOR_create");
                             free((void*)modelType->Name);
                             free((void*)modelType);
                             result = NULL;
-
                         }
                         else
                         {
-                            /* Codes_SRS_SCHEMA_99_009:[On failure, Schema_CreateModelType shall return NULL.] */
-                            if ((modelType->desiredProperties = VECTOR_create(sizeof(SCHEMA_DESIRED_PROPERTY_HANDLE))) == NULL)
+                            if ((modelType->reportedProperties = VECTOR_create(sizeof(SCHEMA_REPORTED_PROPERTY_HANDLE))) == NULL)
                             {
-                                LogError("failure in VECTOR_create (desired properties)");
-                                VECTOR_destroy(modelType->reportedProperties);
+                                /* Codes_SRS_SCHEMA_99_009:[On failure, Schema_CreateModelType shall return NULL.] */
+                                LogError("failed to VECTOR_create (reported properties)");
                                 VECTOR_destroy(modelType->models);
                                 free((void*)modelType->Name);
                                 free((void*)modelType);
                                 result = NULL;
+
                             }
                             else
                             {
-                                if ((modelType->methods = VECTOR_create(sizeof(SCHEMA_METHOD_HANDLE))) == NULL)
+                                /* Codes_SRS_SCHEMA_99_009:[On failure, Schema_CreateModelType shall return NULL.] */
+                                if ((modelType->desiredProperties = VECTOR_create(sizeof(SCHEMA_DESIRED_PROPERTY_HANDLE))) == NULL)
                                 {
                                     LogError("failure in VECTOR_create (desired properties)");
-                                    VECTOR_destroy(modelType->desiredProperties);
                                     VECTOR_destroy(modelType->reportedProperties);
                                     VECTOR_destroy(modelType->models);
                                     free((void*)modelType->Name);
@@ -706,17 +704,30 @@ SCHEMA_MODEL_TYPE_HANDLE Schema_CreateModelType(SCHEMA_HANDLE schemaHandle, cons
                                 }
                                 else
                                 {
-                                    modelType->PropertyCount = 0;
-                                    modelType->Properties = NULL;
-                                    modelType->ActionCount = 0;
-                                    modelType->Actions = NULL;
-                                    modelType->SchemaHandle = schemaHandle;
-                                    modelType->DeviceCount = 0;
+                                    if ((modelType->methods = VECTOR_create(sizeof(SCHEMA_METHOD_HANDLE))) == NULL)
+                                    {
+                                        LogError("failure in VECTOR_create (desired properties)");
+                                        VECTOR_destroy(modelType->desiredProperties);
+                                        VECTOR_destroy(modelType->reportedProperties);
+                                        VECTOR_destroy(modelType->models);
+                                        free((void*)modelType->Name);
+                                        free((void*)modelType);
+                                        result = NULL;
+                                    }
+                                    else
+                                    {
+                                        modelType->PropertyCount = 0;
+                                        modelType->Properties = NULL;
+                                        modelType->ActionCount = 0;
+                                        modelType->Actions = NULL;
+                                        modelType->SchemaHandle = schemaHandle;
+                                        modelType->DeviceCount = 0;
 
-                                    schema->ModelTypes[schema->ModelTypeCount] = modelType;
-                                    schema->ModelTypeCount++;
-                                    /* Codes_SRS_SCHEMA_99_008:[On success, a non-NULL handle shall be returned.] */
-                                    result = (SCHEMA_MODEL_TYPE_HANDLE)modelType;
+                                        schema->ModelTypes[schema->ModelTypeCount] = modelType;
+                                        schema->ModelTypeCount++;
+                                        /* Codes_SRS_SCHEMA_99_008:[On success, a non-NULL handle shall be returned.] */
+                                        result = (SCHEMA_MODEL_TYPE_HANDLE)modelType;
+                                    }
                                 }
                             }
                         }
@@ -905,6 +916,7 @@ SCHEMA_ACTION_HANDLE Schema_CreateModelAction(SCHEMA_MODEL_TYPE_HANDLE modelType
                 }
                 else
                 {
+                    (void)memset(newAction, 0, sizeof(SCHEMA_ACTION_HANDLE_DATA));
                     if (mallocAndStrcpy_s((char**)&newAction->ActionName, actionName) != 0)
                     {
                         /* Codes_SRS_SCHEMA_99_106: [On any other error, Schema_CreateModelAction shall return NULL.]*/
@@ -1809,23 +1821,27 @@ SCHEMA_STRUCT_TYPE_HANDLE Schema_CreateStructType(SCHEMA_HANDLE schemaHandle, co
                     result = NULL;
                     LogError("(Error code:%s)", MU_ENUM_TO_STRING(SCHEMA_RESULT, SCHEMA_ERROR));
                 }
-                else if (mallocAndStrcpy_s((char**)&structType->Name, typeName) != 0)
-                {
-                    /* Codes_SRS_SCHEMA_99_066:[On any other error, Schema_CreateStructType shall return NULL.] */
-                    result = NULL;
-                    free(structType);
-                    LogError("(Error code:%s)", MU_ENUM_TO_STRING(SCHEMA_RESULT, SCHEMA_ERROR));
-                }
                 else
                 {
-                    /* Codes_SRS_SCHEMA_99_057:[Schema_CreateStructType shall create a new struct type and return a handle to it.] */
-                    schema->StructTypes[schema->StructTypeCount] = structType;
-                    schema->StructTypeCount++;
-                    structType->PropertyCount = 0;
-                    structType->Properties = NULL;
+                    (void)memset(structType, 0, sizeof(SCHEMA_STRUCT_TYPE_HANDLE_DATA));
+                    if (mallocAndStrcpy_s((char**)&structType->Name, typeName) != 0)
+                    {
+                        /* Codes_SRS_SCHEMA_99_066:[On any other error, Schema_CreateStructType shall return NULL.] */
+                        result = NULL;
+                        free(structType);
+                        LogError("(Error code:%s)", MU_ENUM_TO_STRING(SCHEMA_RESULT, SCHEMA_ERROR));
+                    }
+                    else
+                    {
+                        /* Codes_SRS_SCHEMA_99_057:[Schema_CreateStructType shall create a new struct type and return a handle to it.] */
+                        schema->StructTypes[schema->StructTypeCount] = structType;
+                        schema->StructTypeCount++;
+                        structType->PropertyCount = 0;
+                        structType->Properties = NULL;
 
-                    /* Codes_SRS_SCHEMA_99_058:[On success, a non-NULL handle shall be returned.] */
-                    result = (SCHEMA_STRUCT_TYPE_HANDLE)structType;
+                        /* Codes_SRS_SCHEMA_99_058:[On success, a non-NULL handle shall be returned.] */
+                        result = (SCHEMA_STRUCT_TYPE_HANDLE)structType;
+                    }
                 }
 
                 /* If possible, reduce the memory of over allocation */
@@ -2775,6 +2791,7 @@ SCHEMA_RESULT Schema_AddModelDesiredProperty(SCHEMA_MODEL_TYPE_HANDLE modelTypeH
             }
             else
             {
+                (void)memset(desiredProperty, 0, sizeof(SCHEMA_DESIRED_PROPERTY_HANDLE_DATA));
                 if (mallocAndStrcpy_s((char**)&desiredProperty->desiredPropertyName, desiredPropertyName) != 0)
                 {
                     /*Codes_SRS_SCHEMA_02_028: [ If any failure occurs then Schema_AddModelDesiredProperty shall fail and return SCHEMA_ERROR. ]*/


### PR DESCRIPTION
Add memset() for malloc() calls to initialize bytes to zero in:
agenttypesystem.c, codefirst.c, commanddecoder.c, datamarshaller.c, datapublisher.c, methodreturn.c, multitree.c, schema.c
Refactored if/else blocks to allow for proper memset() in:
datapublisher.c, schema.c