### PR TITLE
rename iothub-interface-name to dt-subject

### DIFF
--- a/digitaltwin_client/src/dt_interface_client.c
+++ b/digitaltwin_client/src/dt_interface_client.c
@@ -48,7 +48,7 @@ static const char DT_JSON_COMMAND_REQUEST_ID[] = "commandRequest.requestId";
 static const char DT_JSON_COMMAND_REQUEST_PAYLOAD[] = "commandRequest.value";
 static const char DT_JSON_NULL[] = "null";
 
-static const char DT_PropertyWithResponseSchema[] =  "{\""  DT_INTERFACE_PREFIX "%s\": { \"%s\": { \"value\":  %.*s, \"sc\": %d, \"sd\": \"%s\", \"sv\": %d } } }";
+static const char DT_PropertyWithResponseSchema[] =  "{\""  DT_INTERFACE_PREFIX "%s\": { \"%s\": { \"value\":  %.*s, \"ac\": %d, \"ad\": \"%s\", \"av\": %d } } }";
 static const char DT_PropertyWithoutResponseSchema[] = "{\""  DT_INTERFACE_PREFIX "%s\": { \"%s\": { \"value\": %.*s } } }";
 static const char DT_AsyncResultSchema[] = "asyncResult";
 

--- a/digitaltwin_client/src/dt_interface_client.c
+++ b/digitaltwin_client/src/dt_interface_client.c
@@ -34,7 +34,7 @@ static const char commandSeparator = '*';
 static const char* DT_PROPERTY_UPDATE_JSON_VERSON = "$version";
 // Using MQTT property directly because we don't support AMQP presently and cannot support HTTP.
 static const char DT_INTERFACE_ID_PROPERTY[] = "$.ifid";
-static const char DT_INTERFACE_NAME_PROPERTY[] = "$.ifname";
+static const char DT_SUBJECT_PROPERTY[] = "$.sub";
 static const char DT_MESSAGE_SCHEMA_PROPERTY[] = "$.schema";
 static const char DT_JSON_MESSAGE_CONTENT_TYPE[] = "application/json";
 static const char DT_JSON_MESSAGE_CONTENT_ENCODING[] = "utf-8";
@@ -933,9 +933,9 @@ DIGITALTWIN_CLIENT_RESULT DT_InterfaceClient_CreateTelemetryMessage(const char* 
             LogError("Cannot set property %s, error = %d", DT_INTERFACE_ID_PROPERTY, iothubMessageResult);
             result = DIGITALTWIN_CLIENT_ERROR;
         }
-        else if ((iothubMessageResult = IoTHubMessage_SetProperty(*telemetryMessageHandle, DT_INTERFACE_NAME_PROPERTY, componentName)) != IOTHUB_MESSAGE_OK)
+        else if ((iothubMessageResult = IoTHubMessage_SetProperty(*telemetryMessageHandle, DT_SUBJECT_PROPERTY, componentName)) != IOTHUB_MESSAGE_OK)
         {
-            LogError("Cannot set property %s, error = %d", DT_INTERFACE_NAME_PROPERTY, iothubMessageResult);
+            LogError("Cannot set property %s, error = %d", DT_SUBJECT_PROPERTY, iothubMessageResult);
             result = DIGITALTWIN_CLIENT_ERROR;
         }        
         else if ((telemetryName != NULL) && ((iothubMessageResult = IoTHubMessage_SetProperty(*telemetryMessageHandle, DT_MESSAGE_SCHEMA_PROPERTY, telemetryName)) != IOTHUB_MESSAGE_OK))

--- a/digitaltwin_client/tests/dt_e2e/service/dt_e2e_test.ts
+++ b/digitaltwin_client/tests/dt_e2e/service/dt_e2e_test.ts
@@ -327,7 +327,7 @@ function runTestCommandAndCheckMessageAtEventHub(testData:CommandTestData, numbe
     };
     const onEventHubMessage = (receivedMsg) => {
         if((receivedMsg.annotations['iothub-connection-device-id'] === testDeviceInfo.deviceId) &&
-        (receivedMsg.annotations['iothub-interface-name'] === testData.interfaceName)){
+        (receivedMsg.annotations['dt-subject'] === testData.interfaceName)){
             console.log('received a message from the test device: ');
             console.log(JSON.stringify(receivedMsg.body));
             if (receivedMsg.body && receivedMsg.body === testData.payload) {


### PR DESCRIPTION
This has been tested against private deployment.  Service deployment to canary is required before merge can happen.  