### PR TITLE
Cap the maximum delay between attemps of reconnection (retry policy)

### DIFF
--- a/iothub_client/inc/internal/iothub_client_retry_control.h
+++ b/iothub_client/inc/internal/iothub_client_retry_control.h
@@ -19,6 +19,7 @@ extern "C"
 
 static STATIC_VAR_UNUSED const char* RETRY_CONTROL_OPTION_INITIAL_WAIT_TIME_IN_SECS = "initial_wait_time_in_secs";
 static STATIC_VAR_UNUSED const char* RETRY_CONTROL_OPTION_MAX_JITTER_PERCENT = "max_jitter_percent";
+static STATIC_VAR_UNUSED const char* RETRY_CONTROL_OPTION_MAX_DELAY_IN_SECS = "max_delay_in_secs";
 static STATIC_VAR_UNUSED const char* RETRY_CONTROL_OPTION_SAVED_OPTIONS = "retry_control_saved_options";
 
 typedef enum RETRY_ACTION_TAG

--- a/iothub_client/inc/iothub_client_options.h
+++ b/iothub_client/inc/iothub_client_options.h
@@ -19,6 +19,7 @@ extern "C"
     } IOTHUB_PROXY_OPTIONS;
 
     static STATIC_VAR_UNUSED const char* OPTION_RETRY_INTERVAL_SEC = "retry_interval_sec";
+    static STATIC_VAR_UNUSED const char* OPTION_RETRY_MAX_DELAY_SECS = "retry_max_delay_secs";
 
     static STATIC_VAR_UNUSED const char* OPTION_LOG_TRACE = "logtrace";
     static STATIC_VAR_UNUSED const char* OPTION_X509_CERT = "x509certificate";

--- a/iothub_client/src/iothubtransport_amqp_common.c
+++ b/iothub_client/src/iothubtransport_amqp_common.c
@@ -2028,6 +2028,18 @@ IOTHUB_CLIENT_RESULT IoTHubTransport_AMQP_Common_SetOption(TRANSPORT_LL_HANDLE h
                 result = IOTHUB_CLIENT_OK;
             }
         }
+        else if (strcmp(OPTION_RETRY_MAX_DELAY_SECS, option) == 0)
+        {
+            if (retry_control_set_option(transport_instance->connection_retry_control, RETRY_CONTROL_OPTION_MAX_DELAY_IN_SECS, value) != 0)
+            {
+                LogError("Failure setting retry max delay option");
+                result = IOTHUB_CLIENT_ERROR;
+            }
+            else
+            {
+                result = IOTHUB_CLIENT_OK;
+            }
+        }
         else if ((strcmp(OPTION_SERVICE_SIDE_KEEP_ALIVE_FREQ_SECS, option) == 0) || (strcmp(OPTION_C2D_KEEP_ALIVE_FREQ_SECS, option) == 0))
         {
             transport_instance->svc2cl_keep_alive_timeout_secs = *(size_t*)value;

--- a/iothub_client/src/iothubtransport_mqtt_common.c
+++ b/iothub_client/src/iothubtransport_mqtt_common.c
@@ -3297,6 +3297,18 @@ IOTHUB_CLIENT_RESULT IoTHubTransport_MQTT_Common_SetOption(TRANSPORT_LL_HANDLE h
                 result = IOTHUB_CLIENT_OK;
             }
         }
+        else if (strcmp(OPTION_RETRY_MAX_DELAY_SECS, option) == 0)
+        {
+            if (retry_control_set_option(transport_data->retry_control_handle, RETRY_CONTROL_OPTION_MAX_DELAY_IN_SECS, value) != 0)
+            {
+                LogError("Failure setting retry max delay option");
+                result = IOTHUB_CLIENT_ERROR;
+            }
+            else
+            {
+                result = IOTHUB_CLIENT_OK;
+            }
+        }
         else if (strcmp(OPTION_HTTP_PROXY, option) == 0)
         {
             /* Codes_SRS_IOTHUB_TRANSPORT_MQTT_COMMON_01_001: [ If `option` is `proxy_data`, `value` shall be used as an `HTTP_PROXY_OPTIONS*`. ]*/

--- a/iothub_client/tests/iothub_client_retry_control_ut/iothub_client_retry_control_ut.c
+++ b/iothub_client/tests/iothub_client_retry_control_ut/iothub_client_retry_control_ut.c
@@ -903,9 +903,9 @@ TEST_FUNCTION(Should_Retry_EXPONENTIAL_BACKOFF_WITH_JITTER_success)
     unsigned int option_value = 1;
     int set_option_result = retry_control_set_option(handle, RETRY_CONTROL_OPTION_MAX_JITTER_PERCENT, &option_value);
 
-    int expected_retry_times[] = { 0, 1, 2, 4, 8 };
+    int expected_retry_times[] = { 0, 1, 2, 4, 8, 16, 30, 30 };
 
-    run_and_verify_should_retry_times(handle, expected_retry_times, 5, 10);
+    run_and_verify_should_retry_times(handle, expected_retry_times, 8, 10);
 
     // assert
     ASSERT_ARE_EQUAL(int, 0, set_option_result);
@@ -925,9 +925,9 @@ TEST_FUNCTION(Should_Retry_EXPONENTIAL_BACKOFF_success)
     unsigned int option_value = 2;
     int set_option_result = retry_control_set_option(handle, RETRY_CONTROL_OPTION_INITIAL_WAIT_TIME_IN_SECS, &option_value);
 
-    int expected_retry_times[] = { 0, 2, 4, 8, 16 };
+    int expected_retry_times[] = { 0, 2, 4, 8, 16, 30, 30 };
 
-    run_and_verify_should_retry_times(handle, expected_retry_times, 5, max_retry_time_in_secs);
+    run_and_verify_should_retry_times(handle, expected_retry_times, 7, max_retry_time_in_secs);
 
     // assert
     ASSERT_ARE_EQUAL(int, 0, set_option_result);
@@ -943,11 +943,11 @@ TEST_FUNCTION(Should_Retry_INTERVAL_success)
     unsigned int max_retry_time_in_secs = 19;
     RETRY_CONTROL_HANDLE handle = create_retry_control(IOTHUB_CLIENT_RETRY_INTERVAL, max_retry_time_in_secs);
 
-    int expected_retry_times[] = { 0, 5, 10, 15, 20 };
+    int expected_retry_times[] = { 0, 5, 10, 15, 20, 25, 30, 30 };
 
     // act
     // assert
-    run_and_verify_should_retry_times(handle, expected_retry_times, 5, max_retry_time_in_secs);
+    run_and_verify_should_retry_times(handle, expected_retry_times, 8, max_retry_time_in_secs);
 
     // cleanup
     retry_control_destroy(handle);

--- a/iothub_client/tests/iothubtransport_amqp_common_ut/iothubtransport_amqp_common_ut.c
+++ b/iothub_client/tests/iothubtransport_amqp_common_ut/iothubtransport_amqp_common_ut.c
@@ -3845,6 +3845,32 @@ TEST_FUNCTION(SetOption_retry_interval_succeed)
     destroy_transport(handle, device_handle, NULL);
 }
 
+TEST_FUNCTION(SetOption_retry_max_delay_succeed)
+{
+    // arrange
+    initialize_test_variables();
+    TRANSPORT_LL_HANDLE handle = create_transport();
+
+    IOTHUB_DEVICE_CONFIG* device_config = create_device_config(TEST_DEVICE_ID_CHAR_PTR, true);
+    IOTHUB_DEVICE_HANDLE device_handle = register_device(handle, device_config, &TEST_waitingToSend, true);
+    ASSERT_IS_NOT_NULL(device_handle);
+
+    // act
+    umock_c_reset_all_calls();
+
+    STRICT_EXPECTED_CALL(retry_control_set_option(IGNORED_PTR_ARG, RETRY_CONTROL_OPTION_MAX_DELAY_IN_SECS, IGNORED_PTR_ARG));
+
+    int retry_interval = 10;
+    IOTHUB_CLIENT_RESULT result = IoTHubTransport_AMQP_Common_SetOption(handle, OPTION_RETRY_MAX_DELAY_SECS, &retry_interval);
+
+    // assert
+    ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    destroy_transport(handle, device_handle, NULL);
+}
+
 TEST_FUNCTION(SetOption_retry_interval_fail)
 {
     // arrange

--- a/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
+++ b/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
@@ -3797,6 +3797,30 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_SetOption_retry_interval_succeed)
     IoTHubTransport_MQTT_Common_Destroy(handle);
 }
 
+TEST_FUNCTION(IoTHubTransport_MQTT_Common_SetOption_retry_max_delay_succeed)
+{
+    // arrange
+    IOTHUBTRANSPORT_CONFIG config = { 0 };
+    SetupIothubTransportConfigWithKeyAndSasToken(&config, TEST_DEVICE_ID, NULL, NULL, TEST_IOTHUB_NAME, TEST_IOTHUB_SUFFIX, TEST_PROTOCOL_GATEWAY_HOSTNAME, NULL);
+
+    TRANSPORT_LL_HANDLE handle = IoTHubTransport_MQTT_Common_Create(&config, get_IO_transport, &transport_cb_info, transport_cb_ctx);
+    umock_c_reset_all_calls();
+
+    STRICT_EXPECTED_CALL(IoTHubClient_Auth_Get_Credential_Type(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(retry_control_set_option(IGNORED_PTR_ARG, RETRY_CONTROL_OPTION_MAX_DELAY_IN_SECS, IGNORED_PTR_ARG));
+
+    // act
+    int retry_interval = 10;
+    IOTHUB_CLIENT_RESULT result = IoTHubTransport_MQTT_Common_SetOption(handle, OPTION_RETRY_MAX_DELAY_SECS, &retry_interval);
+
+    // assert
+    ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    //cleanup
+    IoTHubTransport_MQTT_Common_Destroy(handle);
+}
+
 TEST_FUNCTION(IoTHubTransport_MQTT_Common_SetOption_retry_interval_fail)
 {
     // arrange


### PR DESCRIPTION
This change caps the maximum delay between attempts of reconnection to thirty seconds.
Such constraint applies to the following
- Retry policies: IOTHUB_CLIENT_RETRY_LINEAR_BACKOFF, IOTHUB_CLIENT_RETRY_EXPONENTIAL_BACKOFF, IOTHUB_CLIENT_RETRY_EXPONENTIAL_BACKOFF_WITH_JITTER.
- Transports: AMQP, AMQP/WS, MQTT, MQTT/WS.

This has been a long-time request, and now it aligns with other Azure IoT SDKs (e.g., https://github.com/Azure/azure-iot-sdk-csharp/blob/f65988b6122cd43df32c123d707395d1bb4367b3/iothub/device/src/TransientFaultHandling/RetryStrategy.cs#L43)

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 