### PR TITLE
wrong include in provision sample

### DIFF
--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -16,7 +16,7 @@ jobs:
       python-software-properties \
       build-essential \
       pkg-config
-      sudo curl -sL https://deb.nodesource.com/setup_6.x | bash -
+      sudo curl -sL https://deb.nodesource.com/setup_10.x | bash -
       sudo apt-get install -y nodejs
     displayName: 'setup'
   - script: |
@@ -61,8 +61,8 @@ jobs:
     condition: always()
 - job: raspberrypi
   variables:
-    _PREVIEW_VSTS_DOCKER_IMAGE: "aziotbld/raspberrypi-c"
-  pool: aziotbld-lin01
+    _PREVIEW_VSTS_DOCKER_IMAGE: "aziotbld/raspberrypi-c-buster:brown"
+  pool: Hosted Ubuntu 1604
   displayName: raspberrypi
   steps:
   - script: |
@@ -70,7 +70,8 @@ jobs:
      whoami
      ls -lr
      pwd
-     sudo ./jenkins/raspberrypi_c.sh
+     chmod +x jenkins/raspberrypi_c_buster.sh
+      ./jenkins/raspberrypi_c_buster.sh
     displayName: 'build'
   - script: sudo rm -rf $(Agent.BuildDirectory)/*
     displayName: 'cleanup'

--- a/build_all/mbed5/build.sh
+++ b/build_all/mbed5/build.sh
@@ -15,7 +15,6 @@ sudo iotz update
 #sudo git checkout -- mbed-iot-devkit-sdk/cores/arduino/azure-iot-sdk-c/provisioning_client/deps/RIoT/Reference/RIoT/Core/RIoTCrypt/RiotDerEnc.c
 #sudo git checkout -- mbed-iot-devkit-sdk/cores/arduino/azure-iot-sdk-c/provisioning_client/deps/RIoT/Reference/RIoT/Core/RIoTCrypt/RiotEcc.c
 #sudo git checkout -- mbed-iot-devkit-sdk/cores/arduino/azure-iot-sdk-c/provisioning_client/deps/RIoT/Reference/RIoT/Core/RIoTCrypt/RiotSha256.c
-
 sudo iotz init mbed
 sudo iotz compile
 

--- a/jenkins/raspberrypi/raspi.yaml
+++ b/jenkins/raspberrypi/raspi.yaml
@@ -15,7 +15,7 @@ variables:
 jobs:
 - job: Cross_Compile
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-18.04
   steps:
   - task: UsePythonVersion@0
     inputs:

--- a/jenkins/raspberrypi_c.sh
+++ b/jenkins/raspberrypi_c.sh
@@ -3,8 +3,6 @@
 # license. See LICENSE file in the project root for full license 
 # information.
 
-# Tested on RPi2 debian verion 7.8
-
 install_root="/home/jenkins" 
 build_root=$(cd "$(dirname "$0")/.." && pwd) 
 cd $build_root
@@ -45,7 +43,7 @@ fi
 # ----------------------------------------------------------------------------- 
 # -- Set environment variable
 # -----------------------------------------------------------------------------
-cd $install_root/RPiTools/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/arm-linux-gnueabihf 
+cd $install_root/RPiTools/tools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/arm-linux-gnueabihf 
 export RPI_ROOT=$(pwd)
 
 # ----------------------------------------------------------------------------- 
@@ -59,12 +57,12 @@ INCLUDE(CMakeForceCompiler)
 
 SET(CMAKE_SYSTEM_NAME Linux) # this one is important 
 SET(CMAKE_SYSTEM_VERSION 1) # this one not so much
-
+SET(CMAKE_SYSROOT ${RPI_ROOT}/sysroot) # This is how it finds our cross compiled libs (openssl, curl, utilslinux)
 # this is the location of the amd64 toolchain targeting the Raspberry Pi
-SET(CMAKE_C_COMPILER ${RPI_ROOT}/../bin/arm-linux-gnueabihf-gcc)
+SET(CMAKE_C_COMPILER /home/jenkins/RPiTools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc)
 
 # this is the file system root of the target
-SET(CMAKE_FIND_ROOT_PATH ${RPI_ROOT})
+SET(CMAKE_FIND_ROOT_PATH ${RPI_ROOT}/sysroot)
 
 # search for programs in the build host directories
 SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
@@ -86,5 +84,5 @@ sed -i 's/\[device connection string\]/'$IOTHUB_DEVICE_CONN_STR'/g' iothub_clien
 # -----------------------------------------------------------------------------
 echo ---------- Building the SDK by executing build.sh script ---------- 
 cd $build_root/build_all/linux 
-./build.sh --toolchain-file toolchain-rpi.cmake -cl --sysroot=$RPI_ROOT 
+./build.sh --toolchain-file toolchain-rpi.cmake -cl --sysroot=$RPI_ROOT/sysroot
 [ $? -eq 0 ] || exit $?

--- a/jenkins/raspberrypi_c_buster.sh
+++ b/jenkins/raspberrypi_c_buster.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# assume directory is root of downloaded repo
+mkdir cmake
+cd cmake
+ls -al
+
+# Create a cmake toolchain file on the fly
+echo "SET(CMAKE_SYSTEM_NAME Linux)     # this one is important" > toolchain.cmake
+echo "SET(CMAKE_SYSTEM_VERSION 1)      # this one not so much" >> toolchain.cmake
+
+echo "SET(CMAKE_C_COMPILER ${TOOLCHAIN_EXES}/${TOOLCHAIN_NAME}-gcc)" >> toolchain.cmake
+echo "SET(CMAKE_CXX_COMPILER ${TOOLCHAIN_EXES}/${TOOLCHAIN_NAME}-g++)" >> toolchain.cmake
+echo "SET(CMAKE_FIND_ROOT_PATH ${TOOLCHAIN_SYSROOT})" >> toolchain.cmake
+echo "SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> toolchain.cmake
+echo "SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> toolchain.cmake
+echo "SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)" >> toolchain.cmake
+ls -al
+
+# Build the SDK. This will use the OpenSSL, cURL and uuid binaries that we built before
+cmake -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake -Duse_prov_client:BOOL=OFF -DCMAKE_INSTALL_PREFIX=${TOOLCHAIN_PREFIX} -Drun_e2e_tests:BOOL=ON -Drun_unittests=:BOOL=ON ..
+make -j 2
+ls -al

--- a/provisioning_client/samples/prov_dev_client_ll_sample/prov_dev_client_ll_sample.c
+++ b/provisioning_client/samples/prov_dev_client_ll_sample/prov_dev_client_ll_sample.c
@@ -50,7 +50,7 @@
 #include "azure_prov_client/prov_transport_amqp_ws_client.h"
 #endif // SAMPLE_AMQP_OVER_WEBSOCKETS
 #ifdef SAMPLE_HTTP
-#include "iothubtransportmqtt.h"
+#include "iothubtransporthttp.h"
 #include "azure_prov_client/prov_transport_http_client.h"
 #endif // SAMPLE_HTTP
 

--- a/provisioning_client/samples/prov_dev_client_sample/prov_dev_client_sample.c
+++ b/provisioning_client/samples/prov_dev_client_sample/prov_dev_client_sample.c
@@ -46,7 +46,7 @@
 #include "azure_prov_client/prov_transport_amqp_ws_client.h"
 #endif // SAMPLE_AMQP_OVER_WEBSOCKETS
 #ifdef SAMPLE_HTTP
-#include "iothubtransportmqtt.h"
+#include "iothubtransporthttp.h"
 #include "azure_prov_client/prov_transport_http_client.h"
 #endif // SAMPLE_HTTP
 


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

#1485

# Description of the problem
HTTP include path should be iothubtransporthttp.h

