### PR TITLE
Fix for memory leak in _GetTwinAsync (gh issue #1478)

### DIFF
--- a/iothub_client/src/iothub_client_core.c
+++ b/iothub_client/src/iothub_client_core.c
@@ -570,6 +570,8 @@ static void iothub_ll_get_device_twin_async_callback(DEVICE_TWIN_UPDATE_STATE up
                 free(queue_cb_info.iothub_callback.dev_twin_cb_info.payLoad);
             }
         }
+
+        free(queue_context);
     }
     else
     {

--- a/iothub_client/tests/common_dt_e2e/iothubclient_common_dt_e2e.h
+++ b/iothub_client/tests/common_dt_e2e/iothubclient_common_dt_e2e.h
@@ -13,5 +13,6 @@ extern void dt_e2e_send_reported_test(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol,
 extern void dt_e2e_get_complete_desired_test(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol, IOTHUB_ACCOUNT_AUTH_METHOD accountAuthMethod);
 extern void dt_e2e_send_reported_test_svc_fault_ctrl_kill_Tcp(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol, IOTHUB_ACCOUNT_AUTH_METHOD accountAuthMethod);
 extern void dt_e2e_get_complete_desired_test_svc_fault_ctrl_kill_Tcp(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol, IOTHUB_ACCOUNT_AUTH_METHOD accountAuthMethod);
+extern void dt_e2e_get_twin_async_test(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol, IOTHUB_ACCOUNT_AUTH_METHOD accountAuthMethod);
 
 #endif /* IOTHUBCLIENT_COMMON_DT_E2E_H */

--- a/iothub_client/tests/iothubclient_amqp_dt_e2e/iothubclient_amqp_dt_e2e.c
+++ b/iothub_client/tests/iothubclient_amqp_dt_e2e/iothubclient_amqp_dt_e2e.c
@@ -31,6 +31,11 @@ TEST_FUNCTION(IoTHub_AMQP_GetFullDesired_e2e_sas)
     dt_e2e_get_complete_desired_test(AMQP_Protocol, IOTHUB_ACCOUNT_AUTH_CONNSTRING);
 }
 
+TEST_FUNCTION(IoTHub_AMQP_GetTwinAsync_e2e_sas)
+{
+    dt_e2e_get_twin_async_test(AMQP_Protocol, IOTHUB_ACCOUNT_AUTH_CONNSTRING);
+}
+
 #ifndef __APPLE__
 TEST_FUNCTION(IoTHub_AMQP_SendReported_e2e_x509)
 {
@@ -40,6 +45,11 @@ TEST_FUNCTION(IoTHub_AMQP_SendReported_e2e_x509)
 TEST_FUNCTION(IoTHub_AMQP_GetFullDesired_e2e_x509)
 {
     dt_e2e_get_complete_desired_test(AMQP_Protocol, IOTHUB_ACCOUNT_AUTH_X509);
+}
+
+TEST_FUNCTION(IoTHub_AMQP_GetTwinAsync_e2e_x509)
+{
+    dt_e2e_get_twin_async_test(AMQP_Protocol, IOTHUB_ACCOUNT_AUTH_X509);
 }
 #endif
 
@@ -56,6 +66,11 @@ TEST_FUNCTION(IoTHub_AMQP_WS_GetFullDesired_e2e_sas)
     dt_e2e_get_complete_desired_test(AMQP_Protocol_over_WebSocketsTls, IOTHUB_ACCOUNT_AUTH_CONNSTRING);
 }
 
+TEST_FUNCTION(IoTHub_AMQP_WS_GetTwinAsync_e2e_sas)
+{
+    dt_e2e_get_twin_async_test(AMQP_Protocol_over_WebSocketsTls, IOTHUB_ACCOUNT_AUTH_CONNSTRING);
+}
+
 #ifndef __APPLE__
 TEST_FUNCTION(IoTHub_AMQP_WS_SendReported_e2e_x509)
 {
@@ -65,6 +80,11 @@ TEST_FUNCTION(IoTHub_AMQP_WS_SendReported_e2e_x509)
 TEST_FUNCTION(IoTHub_AMQP_WS_GetFullDesired_e2e_x509)
 {
     dt_e2e_get_complete_desired_test(AMQP_Protocol_over_WebSocketsTls, IOTHUB_ACCOUNT_AUTH_X509);
+}
+
+TEST_FUNCTION(IoTHub_AMQP_WS_GetTwinAsync_e2e_x509)
+{
+    dt_e2e_get_twin_async_test(AMQP_Protocol_over_WebSocketsTls, IOTHUB_ACCOUNT_AUTH_X509);
 }
 #endif
 #endif

--- a/iothub_client/tests/iothubclient_mqtt_dt_e2e/iothubclient_mqtt_dt_e2e.c
+++ b/iothub_client/tests/iothubclient_mqtt_dt_e2e/iothubclient_mqtt_dt_e2e.c
@@ -31,6 +31,11 @@ TEST_FUNCTION(IoTHub_MQTT_GetFullDesired_e2e_sas)
     dt_e2e_get_complete_desired_test(MQTT_Protocol, IOTHUB_ACCOUNT_AUTH_CONNSTRING);
 }
 
+TEST_FUNCTION(IoTHub_MQTT_GetTwinAsync_e2e_sas)
+{
+    dt_e2e_get_twin_async_test(MQTT_Protocol, IOTHUB_ACCOUNT_AUTH_CONNSTRING);
+}
+
 #ifndef __APPLE__
 TEST_FUNCTION(IoTHub_MQTT_SendReported_e2e_x509)
 {
@@ -40,6 +45,11 @@ TEST_FUNCTION(IoTHub_MQTT_SendReported_e2e_x509)
 TEST_FUNCTION(IoTHub_MQTT_GetFullDesired_e2e_x509)
 {
     dt_e2e_get_complete_desired_test(MQTT_Protocol, IOTHUB_ACCOUNT_AUTH_X509);
+}
+
+TEST_FUNCTION(IoTHub_MQTT_GetTwinAsync_e2e_x509)
+{
+    dt_e2e_get_twin_async_test(MQTT_Protocol, IOTHUB_ACCOUNT_AUTH_X509);
 }
 #endif
 
@@ -57,6 +67,11 @@ TEST_FUNCTION(IoTHub_MQTT_WS_GetFullDesired_e2e_sas)
     dt_e2e_get_complete_desired_test(MQTT_WebSocket_Protocol, IOTHUB_ACCOUNT_AUTH_CONNSTRING);
 }
 
+TEST_FUNCTION(IoTHub_MQTT_WS_GetTwinAsync_e2e_sas)
+{
+    dt_e2e_get_twin_async_test(MQTT_WebSocket_Protocol, IOTHUB_ACCOUNT_AUTH_CONNSTRING);
+}
+
 #ifndef __APPLE__
 TEST_FUNCTION(IoTHub_MQTT_WS_GetFullDesired_e2e_x509)
 {
@@ -66,6 +81,11 @@ TEST_FUNCTION(IoTHub_MQTT_WS_GetFullDesired_e2e_x509)
 TEST_FUNCTION(IoTHub_MQTT_WS_SendReported_e2e_x509)
 {
     dt_e2e_send_reported_test(MQTT_WebSocket_Protocol, IOTHUB_ACCOUNT_AUTH_X509);
+}
+
+TEST_FUNCTION(IoTHub_MQTT_WS_GetTwinAsync_e2e_x509)
+{
+    dt_e2e_get_twin_async_test(MQTT_WebSocket_Protocol, IOTHUB_ACCOUNT_AUTH_X509);
 }
 #endif
 #endif


### PR DESCRIPTION
This bug is in the iothub_client_core.c layer.
Tracked by github issue https://github.com/Azure/azure-iot-sdk-c/issues/1478

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
Please see description [here](https://github.com/Azure/azure-iot-sdk-c/issues/1478).
Also, there where no tests exercising the defective code path.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Add proper free() and tests (which run under valgrind).