### PR TITLE
Disable test & spot fix bad DTDL

### DIFF
--- a/digitaltwin_client/samples/SampleDevice.capabilitymodel.json
+++ b/digitaltwin_client/samples/SampleDevice.capabilitymodel.json
@@ -1,14 +1,11 @@
 {
   "@id": "dtmi:YOUR_COMPANY_NAME_HERE:sample_device;1",
-  "@type": "CapabilityModel",
+  "@type": "Interface",
   "displayName": "My Sample Capability Model",
-  "implements": [
+  "contents": [
     {
-      "schema": "urn:azureiot:DeviceManagement:DeviceInformation:1",
-      "name": "deviceinfo"
-    },
-    {
-      "schema": "urn:YOUR_COMPANY_NAME_HERE:EnvironmentalSensor:1",
+      "@type": "Component",
+      "schema": "dtmi:YOUR_COMPANY_NAME_HERE:EnvironmentalSensor;1",
       "name": "sensor"
     }
   ],

--- a/digitaltwin_client/samples/digitaltwin_sample_environmental_sensor/EnvironmentalSensor.interface.json
+++ b/digitaltwin_client/samples/digitaltwin_sample_environmental_sensor/EnvironmentalSensor.interface.json
@@ -36,8 +36,7 @@
       "description": "Current temperature on the device",
       "displayName": "Temperature",
       "name": "temp",
-      "schema": "double",
-      "unit": "Units/Temperature/fahrenheit"
+      "schema": "double"
     },
     {
       "@type": [
@@ -47,8 +46,7 @@
       "description": "Current humidity on the device",
       "displayName": "Humidity",
       "name": "humid",
-      "schema": "double",
-      "unit": "Units/Humidity/percent"
+      "schema": "double"
     },
     {
       "@type": "Command",

--- a/digitaltwin_client/tests/CMakeLists.txt
+++ b/digitaltwin_client/tests/CMakeLists.txt
@@ -20,4 +20,5 @@ add_unittest_directory(dt_interface_client_ut)
 add_unittest_directory(dt_interface_list_ut)
 add_unittest_directory(dt_version_ut)
 
-add_e2etest_directory(dt_e2e)
+# TODO: https://github.com/Azure/azure-iot-sdk-c/issues/1503 tracks bringing back temporarily disabled tests.
+# add_e2etest_directory(dt_e2e)


### PR DESCRIPTION
Disabling e2e PnP tests.  Rationale as well as IOU to re-enable in #1503.

Also spot fix invalid DTDL in samples that missed checkin on #1500.