### PR TITLE
Rename device capability model to root interface ID

### DIFF
--- a/digitaltwin_client/inc/digitaltwin_device_client.h
+++ b/digitaltwin_client/inc/digitaltwin_device_client.h
@@ -51,11 +51,11 @@ typedef void* DIGITALTWIN_DEVICE_CLIENT_HANDLE;
   @param    deviceHandle[in]            An IOTHUB_DEVICE_CLIENT_HANDLE that has been already created and bound to a specific connection string (or transport, or DPS handle, or whatever
                                         mechanism is preferred).  See remarks about its lifetime management.
   @param    dtDeviceClientHandle[out]   A <c>DIGITALTWIN_DEVICE_CLIENT_HANDLE</c> to be used by the application.
-  @param    deviceCapabilityModel[in]   The Device Capability Model (DCM) identifier. 
+  @param    rootInterfaceId[in]         The interfaceId of the root interface of the device.  For example, dtmi:YOUR_COMPANY_NAME_HERE:sample_device;1.
 
   @returns  A DIGITALTWIN_CLIENT_RESULT.
 */
-MOCKABLE_FUNCTION(, DIGITALTWIN_CLIENT_RESULT, DigitalTwin_DeviceClient_CreateFromDeviceHandle, IOTHUB_DEVICE_CLIENT_HANDLE, deviceHandle, const char*, deviceCapabilityModel, DIGITALTWIN_DEVICE_CLIENT_HANDLE*, dtDeviceClientHandle);
+MOCKABLE_FUNCTION(, DIGITALTWIN_CLIENT_RESULT, DigitalTwin_DeviceClient_CreateFromDeviceHandle, IOTHUB_DEVICE_CLIENT_HANDLE, deviceHandle, const char*, rootInterfaceId, DIGITALTWIN_DEVICE_CLIENT_HANDLE*, dtDeviceClientHandle);
 
 
 /**

--- a/digitaltwin_client/inc/digitaltwin_device_client_ll.h
+++ b/digitaltwin_client/inc/digitaltwin_device_client_ll.h
@@ -52,7 +52,7 @@ typedef struct DIGITALTWIN_DEVICE_CLIENT_LL* DIGITALTWIN_DEVICE_CLIENT_LL_HANDLE
 
   @see      DigitalTwin_DeviceClient_CreateFromDeviceHandle
 */
-MOCKABLE_FUNCTION(, DIGITALTWIN_CLIENT_RESULT, DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle, IOTHUB_DEVICE_CLIENT_LL_HANDLE, deviceHandle, const char*, deviceCapabilityModel, DIGITALTWIN_DEVICE_CLIENT_LL_HANDLE*, dtDeviceLLClientHandle);
+MOCKABLE_FUNCTION(, DIGITALTWIN_CLIENT_RESULT, DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle, IOTHUB_DEVICE_CLIENT_LL_HANDLE, deviceHandle, const char*, rootInterfaceId, DIGITALTWIN_DEVICE_CLIENT_LL_HANDLE*, dtDeviceLLClientHandle);
 
 
 /**

--- a/digitaltwin_client/samples/SampleDevice.capabilitymodel.json
+++ b/digitaltwin_client/samples/SampleDevice.capabilitymodel.json
@@ -1,7 +1,7 @@
 {
   "@id": "dtmi:YOUR_COMPANY_NAME_HERE:sample_device;1",
   "@type": "Interface",
-  "displayName": "My Sample Capability Model",
+  "displayName": "My Sample Root Interface",
   "contents": [
     {
       "@type": "Component",

--- a/digitaltwin_client/samples/digitaltwin_sample_device/digitaltwin_sample_device.c
+++ b/digitaltwin_client/samples/digitaltwin_sample_device/digitaltwin_sample_device.c
@@ -55,8 +55,8 @@ static const int digitalTwinSampleDevice_sendTelemetryFrequency = 20;
 // TODO`s: Configure core settings of application for your Digital Twin
 //
 
-// TODO: Fill in DIGITALTWIN_SAMPLE_DEVICE_CAPABILITY_MODEL_ID. E.g. 
-#define DIGITALTWIN_SAMPLE_DEVICE_CAPABILITY_MODEL_ID "dtmi:YOUR_COMPANY_NAME_HERE:sample_device;1"
+// TODO: Fill in DIGITALTWIN_SAMPLE_ROOT_INTERFACE_ID. E.g. 
+#define DIGITALTWIN_SAMPLE_ROOT_INTERFACE_ID "dtmi:YOUR_COMPANY_NAME_HERE:sample_device;1"
 
 //
 // END TODO section
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
     // The call to DigitalTwin_DeviceClient_CreateFromDeviceHandle() transfers ownership
     // of this handle (including destroying it) to the DigitalTwin layer, analogous to a .release()
     // in some C++ helpers.  DO NOT USE deviceHandle after this point.
-    else if ((result = DigitalTwin_DeviceClient_CreateFromDeviceHandle(deviceHandle, DIGITALTWIN_SAMPLE_DEVICE_CAPABILITY_MODEL_ID, &dtDeviceClientHandle)) != DIGITALTWIN_CLIENT_OK)
+    else if ((result = DigitalTwin_DeviceClient_CreateFromDeviceHandle(deviceHandle, DIGITALTWIN_SAMPLE_ROOT_INTERFACE_ID, &dtDeviceClientHandle)) != DIGITALTWIN_CLIENT_OK)
     {
         LogError("DigitalTwin_DeviceClient_CreateFromDeviceHandle failed, error=<%s>", MU_ENUM_TO_STRING(DIGITALTWIN_CLIENT_RESULT, result));
     }

--- a/digitaltwin_client/samples/digitaltwin_sample_ll_device/digitaltwin_sample_ll_device.c
+++ b/digitaltwin_client/samples/digitaltwin_sample_ll_device/digitaltwin_sample_ll_device.c
@@ -43,8 +43,8 @@
 #include <../digitaltwin_sample_sdk_info/digitaltwin_sample_sdk_info.h>
 #include <../digitaltwin_sample_environmental_sensor/digitaltwin_sample_environmental_sensor.h>
 
-// TODO: Fill in DIGITALTWIN_SAMPLE_DEVICE_CAPABILITY_MODEL_ID
-#define DIGITALTWIN_SAMPLE_DEVICE_CAPABILITY_MODEL_ID "dtmi:YOUR_COMPANY_NAME_HERE:sample_device;1"
+// TODO: Fill in DIGITALTWIN_SAMPLE_ROOT_INTERFACE_ID
+#define DIGITALTWIN_SAMPLE_ROOT_INTERFACE_ID "dtmi:YOUR_COMPANY_NAME_HERE:sample_device;1"
 
 typedef enum DIGITALTWIN_SAMPLE_SECURITY_TYPE_TAG
 {
@@ -84,7 +84,7 @@ static const int digitalTwinSampleDevice_dpsRegistrationMaxPolls = 60;
 static const char* digitaltwinSample_CustomProvisioningData = "{"
                                                           "\"__iot:interfaces\":"
                                                           "{"
-                                                              "\"CapabilityModelId\": \"" DIGITALTWIN_SAMPLE_DEVICE_CAPABILITY_MODEL_ID "\""
+                                                              "\"CapabilityModelId\": \"" DIGITALTWIN_SAMPLE_ROOT_INTERFACE_ID "\""
                                                           "}"
                                                       "}";
 
@@ -433,7 +433,7 @@ int main(int argc, char *argv[])
     // of this handle (including destroying it) to the DigitalTwin layer, analogous to a .release()
     // in some C++ helpers.  DO NOT USE deviceLLHandle after this point.  Note this behavior
     // will change once DPS integration becomes available later.
-    else if ((result = DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle(deviceLLHandle, DIGITALTWIN_SAMPLE_DEVICE_CAPABILITY_MODEL_ID, &digitaltwinDeviceClientLLHandle)) != DIGITALTWIN_CLIENT_OK)
+    else if ((result = DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle(deviceLLHandle, DIGITALTWIN_SAMPLE_ROOT_INTERFACE_ID, &digitaltwinDeviceClientLLHandle)) != DIGITALTWIN_CLIENT_OK)
     {
         LogError("DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle failed, error=<%s>", MU_ENUM_TO_STRING(DIGITALTWIN_CLIENT_RESULT, result));
     }

--- a/digitaltwin_client/samples/digitaltwin_sample_ll_device/readme.md
+++ b/digitaltwin_client/samples/digitaltwin_sample_ll_device/readme.md
@@ -6,7 +6,7 @@ This sample in this directory is almost identical to [digitaltwin_sample_device]
 * This sample is designed to use the \_LL\_ layer, appropriate for single threaded applications and devices.
 
 To use this sample:
-* Modify in `digitaltwin_sample_ll_device.c` the `DIGITALTWIN_SAMPLE_DEVICE_CAPABILITY_MODEL_ID` value to reference the DCM name you have setup, if you are using a different one.
+* Modify in `digitaltwin_sample_ll_device.c` the `DIGITALTWIN_SAMPLE_ROOT_INTERFACE_ID` value to reference the DCM name you have setup, if you are using a different one.
 
 * Create a configuration file, per the instructions below.
 

--- a/digitaltwin_client/src/dt_device.c
+++ b/digitaltwin_client/src/dt_device.c
@@ -98,15 +98,15 @@ static void DeviceClientDestroy(void* iothubClientHandle)
     IoTHubDeviceClient_Destroy((IOTHUB_DEVICE_CLIENT_HANDLE)iothubClientHandle);
 }
 
-DIGITALTWIN_CLIENT_RESULT DigitalTwin_DeviceClient_CreateFromDeviceHandle(IOTHUB_DEVICE_CLIENT_HANDLE deviceHandle, const char* deviceCapabilityModel, DIGITALTWIN_DEVICE_CLIENT_HANDLE* dtDeviceClientHandle)
+DIGITALTWIN_CLIENT_RESULT DigitalTwin_DeviceClient_CreateFromDeviceHandle(IOTHUB_DEVICE_CLIENT_HANDLE deviceHandle, const char* rootInterfaceId, DIGITALTWIN_DEVICE_CLIENT_HANDLE* dtDeviceClientHandle)
 {
     DIGITALTWIN_CLIENT_RESULT result;
     IOTHUB_CLIENT_RESULT iothubClientResult;
     bool urlEncodeOn = true;
 
-    if ((deviceHandle == NULL) || (deviceCapabilityModel == NULL) || (dtDeviceClientHandle == NULL) )
+    if ((deviceHandle == NULL) || (rootInterfaceId == NULL) || (dtDeviceClientHandle == NULL) )
     {
-        LogError("DeviceHandle=%p, deviceCapabilityModel=%p, dtDeviceClientHandle=%p", deviceHandle, deviceCapabilityModel, dtDeviceClientHandle);
+        LogError("DeviceHandle=%p, rootInterfaceId=%p, dtDeviceClientHandle=%p", deviceHandle, rootInterfaceId, dtDeviceClientHandle);
         result = DIGITALTWIN_CLIENT_ERROR_INVALID_ARG;
     }
     else if ((iothubClientResult = IoTHubDeviceClient_SetOption(deviceHandle, OPTION_AUTO_URL_ENCODE_DECODE, &urlEncodeOn)) != IOTHUB_CLIENT_OK)
@@ -115,9 +115,9 @@ DIGITALTWIN_CLIENT_RESULT DigitalTwin_DeviceClient_CreateFromDeviceHandle(IOTHUB
         LogError("NOTE: This error typically occurs when trying to use a non-supported DigitalTwin protocol.  You MUST use MQTT or MQTT_WS.  AMQP(_WS) and HTTP are not supported");
         result = DIGITALTWIN_CLIENT_ERROR;
     }
-    else if ((iothubClientResult = IoTHubDeviceClient_SetOption(deviceHandle, OPTION_DT_MODEL_ID, deviceCapabilityModel)) != IOTHUB_CLIENT_OK)
+    else if ((iothubClientResult = IoTHubDeviceClient_SetOption(deviceHandle, OPTION_DT_ROOT_INTERFACE_ID, rootInterfaceId)) != IOTHUB_CLIENT_OK)
     {
-        LogError("Failed to set option %s, error=%d", OPTION_DT_MODEL_ID, iothubClientResult);
+        LogError("Failed to set option %s, error=%d", OPTION_DT_ROOT_INTERFACE_ID, iothubClientResult);
         result = DIGITALTWIN_CLIENT_ERROR;
     }
     else 

--- a/digitaltwin_client/src/dt_device_ll.c
+++ b/digitaltwin_client/src/dt_device_ll.c
@@ -97,15 +97,15 @@ static void DeviceClient_LL_DoWork(void* iothubClientHandle)
     IoTHubDeviceClient_LL_DoWork((IOTHUB_DEVICE_CLIENT_LL_HANDLE)iothubClientHandle);
 }
 
-DIGITALTWIN_CLIENT_RESULT DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle(IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceLLHandle, const char* deviceCapabilityModel, DIGITALTWIN_DEVICE_CLIENT_LL_HANDLE* dtDeviceLLClientHandle)
+DIGITALTWIN_CLIENT_RESULT DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle(IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceLLHandle, const char* rootInterfaceId, DIGITALTWIN_DEVICE_CLIENT_LL_HANDLE* dtDeviceLLClientHandle)
 {
     DIGITALTWIN_CLIENT_RESULT result;
     IOTHUB_CLIENT_RESULT iothubClientResult;
     bool urlEncodeOn = true;
 
-    if ((deviceLLHandle == NULL) || (deviceCapabilityModel == NULL) || (dtDeviceLLClientHandle == NULL))
+    if ((deviceLLHandle == NULL) || (rootInterfaceId == NULL) || (dtDeviceLLClientHandle == NULL))
     {
-        LogError("deviceLLHandle=%p, deviceCapabilityModel=%p, dtDeviceLLClientHandle=%p", deviceLLHandle, deviceCapabilityModel, dtDeviceLLClientHandle);
+        LogError("deviceLLHandle=%p, rootInterfaceId=%p, dtDeviceLLClientHandle=%p", deviceLLHandle, rootInterfaceId, dtDeviceLLClientHandle);
         result = DIGITALTWIN_CLIENT_ERROR_INVALID_ARG;
     }
     else if ((iothubClientResult = IoTHubDeviceClient_LL_SetOption(deviceLLHandle, OPTION_AUTO_URL_ENCODE_DECODE, &urlEncodeOn)) != IOTHUB_CLIENT_OK)
@@ -114,9 +114,9 @@ DIGITALTWIN_CLIENT_RESULT DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle(IOT
         LogError("NOTE: This error typically occurs when trying to use a non-supported DigitalTwin protocol.  You MUST use MQTT or MQTT_WS.  AMQP(_WS) and HTTP are not supported");
         result = DIGITALTWIN_CLIENT_ERROR;
     }
-    else if ((iothubClientResult = IoTHubDeviceClient_LL_SetOption(deviceLLHandle, OPTION_DT_MODEL_ID, deviceCapabilityModel)) != IOTHUB_CLIENT_OK)
+    else if ((iothubClientResult = IoTHubDeviceClient_LL_SetOption(deviceLLHandle, OPTION_DT_ROOT_INTERFACE_ID, rootInterfaceId)) != IOTHUB_CLIENT_OK)
     {
-        LogError("Failed to set option %s, error=%d", OPTION_DT_MODEL_ID, iothubClientResult);
+        LogError("Failed to set option %s, error=%d", OPTION_DT_ROOT_INTERFACE_ID, iothubClientResult);
         result = DIGITALTWIN_CLIENT_ERROR;
     }
     else 

--- a/digitaltwin_client/tests/dt_device_ll_ut/dt_device_ll_ut.c
+++ b/digitaltwin_client/tests/dt_device_ll_ut/dt_device_ll_ut.c
@@ -37,7 +37,7 @@ IMPLEMENT_UMOCK_C_ENUM_TYPE(DIGITALTWIN_CLIENT_RESULT, DIGITALTWIN_CLIENT_RESULT
 static DIGITALTWIN_INTERFACE_CLIENT_HANDLE testDTInterfacesToRegister[] = {DT_TEST_INTERFACE_HANDLE1, DT_TEST_INTERFACE_HANDLE2, DT_TEST_INTERFACE_HANDLE3 };
 static const int testDTInterfacesToRegisterLen = sizeof(testDTInterfacesToRegister) / sizeof(testDTInterfacesToRegister[0]);
 static void* dtTestDeviceRegisterInterfaceCallbackContext = (void*)0x1236;
-static const char* testDTDeviceCapabilityModel = "http://testDeviceCapabilityModel/1.0.0";
+static const char* testDTRootInterfaceId = "dtmi:test_interface;1";
 
 static const IOTHUB_DEVICE_CLIENT_LL_HANDLE testIotHubDeviceLLHandle = (IOTHUB_DEVICE_CLIENT_LL_HANDLE)0x1236;
 
@@ -116,7 +116,7 @@ TEST_FUNCTION(DigitalTwin_DeviceClient_LL_LL_CreateFromDeviceHandle_ok)
     set_expected_calls_for_DT_DeviceClient_LL_CreateFromDeviceHandle();
 
     //act
-    result = DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle(testIotHubDeviceLLHandle, testDTDeviceCapabilityModel, &h);
+    result = DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle(testIotHubDeviceLLHandle, testDTRootInterfaceId, &h);
 
     //assert
     ASSERT_ARE_EQUAL(DIGITALTWIN_CLIENT_RESULT, DIGITALTWIN_CLIENT_OK, result);
@@ -134,7 +134,7 @@ TEST_FUNCTION(DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle_NULL_iothub_han
     DIGITALTWIN_CLIENT_RESULT result;
 
     //act
-    result = DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle(NULL, testDTDeviceCapabilityModel, &h);
+    result = DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle(NULL, testDTRootInterfaceId, &h);
 
     //assert
     ASSERT_ARE_EQUAL(DIGITALTWIN_CLIENT_RESULT, DIGITALTWIN_CLIENT_ERROR_INVALID_ARG, result);
@@ -147,7 +147,7 @@ TEST_FUNCTION(DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle_NULL_dt_handle_
     DIGITALTWIN_CLIENT_RESULT result;
 
     //act
-    result = DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle(testIotHubDeviceLLHandle, testDTDeviceCapabilityModel, NULL);
+    result = DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle(testIotHubDeviceLLHandle, testDTRootInterfaceId, NULL);
 
     //assert
     ASSERT_ARE_EQUAL(DIGITALTWIN_CLIENT_RESULT, DIGITALTWIN_CLIENT_ERROR_INVALID_ARG, result);
@@ -175,7 +175,7 @@ TEST_FUNCTION(DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle_fail)
         umock_c_negative_tests_reset();
         umock_c_negative_tests_fail_call(i);
 
-        result = DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle(testIotHubDeviceLLHandle, testDTDeviceCapabilityModel, &h);
+        result = DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle(testIotHubDeviceLLHandle, testDTRootInterfaceId, &h);
         
         //assert
         ASSERT_ARE_NOT_EQUAL(DIGITALTWIN_CLIENT_RESULT, DIGITALTWIN_CLIENT_OK, result, message);
@@ -192,7 +192,7 @@ static DIGITALTWIN_DEVICE_CLIENT_LL_HANDLE allocate_DIGITALTWIN_DEVICE_CLIENT_LL
     DIGITALTWIN_CLIENT_RESULT result;
     DIGITALTWIN_DEVICE_CLIENT_LL_HANDLE h = NULL;
 
-    result = DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle(testIotHubDeviceLLHandle, testDTDeviceCapabilityModel, &h);
+    result = DigitalTwin_DeviceClient_LL_CreateFromDeviceHandle(testIotHubDeviceLLHandle, testDTRootInterfaceId, &h);
 
     ASSERT_ARE_EQUAL(DIGITALTWIN_CLIENT_RESULT, DIGITALTWIN_CLIENT_OK, result);
     ASSERT_IS_NOT_NULL(h);

--- a/digitaltwin_client/tests/dt_device_ut/dt_device_ut.c
+++ b/digitaltwin_client/tests/dt_device_ut/dt_device_ut.c
@@ -37,7 +37,7 @@ IMPLEMENT_UMOCK_C_ENUM_TYPE(DIGITALTWIN_CLIENT_RESULT, DIGITALTWIN_CLIENT_RESULT
 static DIGITALTWIN_INTERFACE_CLIENT_HANDLE testDTInterfacesToRegister[] = {DT_TEST_INTERFACE_HANDLE1, DT_TEST_INTERFACE_HANDLE2, DT_TEST_INTERFACE_HANDLE3 };
 static const int testDTInterfacesToRegisterLen = sizeof(testDTInterfacesToRegister) / sizeof(testDTInterfacesToRegister[0]);
 static void* dtTestDeviceRegisterInterfaceCallbackContext = (void*)0x1236;
-static const char* testDTDeviceCapabilityModel = "http://testDeviceCapabilityModel/1.0.0";
+static const char* testDTRootInterfaceId = "dtmi:test_interface;1";
 
 static const IOTHUB_DEVICE_CLIENT_HANDLE testIotHubDeviceHandle = (IOTHUB_DEVICE_CLIENT_HANDLE)0x1236;
 
@@ -115,7 +115,7 @@ TEST_FUNCTION(DigitalTwin_DeviceClient_CreateFromDeviceHandle_ok)
     set_expected_calls_for_DT_DeviceClient_CreateFromDeviceHandle();
 
     //act
-    result = DigitalTwin_DeviceClient_CreateFromDeviceHandle(testIotHubDeviceHandle, testDTDeviceCapabilityModel, &h);
+    result = DigitalTwin_DeviceClient_CreateFromDeviceHandle(testIotHubDeviceHandle, testDTRootInterfaceId, &h);
 
     //assert
     ASSERT_ARE_EQUAL(DIGITALTWIN_CLIENT_RESULT, DIGITALTWIN_CLIENT_OK, result);
@@ -133,7 +133,7 @@ TEST_FUNCTION(DigitalTwin_DeviceClient_CreateFromDeviceHandle_NULL_iothub_handle
     DIGITALTWIN_CLIENT_RESULT result;
 
     //act
-    result = DigitalTwin_DeviceClient_CreateFromDeviceHandle(NULL, testDTDeviceCapabilityModel, &h);
+    result = DigitalTwin_DeviceClient_CreateFromDeviceHandle(NULL, testDTRootInterfaceId, &h);
 
     //assert
     ASSERT_ARE_EQUAL(DIGITALTWIN_CLIENT_RESULT, DIGITALTWIN_CLIENT_ERROR_INVALID_ARG, result);
@@ -146,7 +146,7 @@ TEST_FUNCTION(DigitalTwin_DeviceClient_CreateFromDeviceHandle_NULL_dt_handle_fai
     DIGITALTWIN_CLIENT_RESULT result;
 
     //act
-    result = DigitalTwin_DeviceClient_CreateFromDeviceHandle(testIotHubDeviceHandle, testDTDeviceCapabilityModel, NULL);
+    result = DigitalTwin_DeviceClient_CreateFromDeviceHandle(testIotHubDeviceHandle, testDTRootInterfaceId, NULL);
 
     //assert
     ASSERT_ARE_EQUAL(DIGITALTWIN_CLIENT_RESULT, DIGITALTWIN_CLIENT_ERROR_INVALID_ARG, result);
@@ -174,7 +174,7 @@ TEST_FUNCTION(DigitalTwin_DeviceClient_CreateFromDeviceHandle_fail)
         umock_c_negative_tests_reset();
         umock_c_negative_tests_fail_call(i);
 
-        result = DigitalTwin_DeviceClient_CreateFromDeviceHandle(testIotHubDeviceHandle, testDTDeviceCapabilityModel, &h);
+        result = DigitalTwin_DeviceClient_CreateFromDeviceHandle(testIotHubDeviceHandle, testDTRootInterfaceId, &h);
         
         //assert
         ASSERT_ARE_NOT_EQUAL(DIGITALTWIN_CLIENT_RESULT, DIGITALTWIN_CLIENT_OK, result, message);
@@ -191,7 +191,7 @@ static DIGITALTWIN_DEVICE_CLIENT_HANDLE allocate_DIGITALTWIN_DEVICE_CLIENT_HANDL
     DIGITALTWIN_CLIENT_RESULT result;
     DIGITALTWIN_DEVICE_CLIENT_HANDLE h = NULL;
 
-    result = DigitalTwin_DeviceClient_CreateFromDeviceHandle(testIotHubDeviceHandle, testDTDeviceCapabilityModel, &h);
+    result = DigitalTwin_DeviceClient_CreateFromDeviceHandle(testIotHubDeviceHandle, testDTRootInterfaceId, &h);
 
     ASSERT_IS_NOT_NULL(h);
     ASSERT_ARE_EQUAL(DIGITALTWIN_CLIENT_RESULT, DIGITALTWIN_CLIENT_OK, result);

--- a/digitaltwin_client/tests/dt_e2e/device/main.c
+++ b/digitaltwin_client/tests/dt_e2e/device/main.c
@@ -48,7 +48,7 @@
 //
 // DCM for the E2E test 
 //
-#define DIGITALTWIN_E2E_DEVICE_CAPABILITY_MODEL_URI "dtmi:azureiot:testinterfaces:cdevicesdk:DCM;1"
+#define DIGITALTWIN_E2E_ROOT_INTERFACE_ID "dtmi:azureiot:testinterfaces:cdevicesdk:DCM;1"
 
 // Amount to sleep between querying state from the register interface loop
 static const int digitalTwin_E2E_registerInterfacePollSleep = 1000;
@@ -192,7 +192,7 @@ int main(int argc, char** argv)
         result = MU_FAILURE;
     }
 #endif
-    else if ((result = (int)DigitalTwin_DeviceClient_CreateFromDeviceHandle(deviceHandle, DIGITALTWIN_E2E_DEVICE_CAPABILITY_MODEL_URI, &dtDeviceClientHandle)) != DIGITALTWIN_CLIENT_OK)
+    else if ((result = (int)DigitalTwin_DeviceClient_CreateFromDeviceHandle(deviceHandle, DIGITALTWIN_E2E_ROOT_INTERFACE_ID, &dtDeviceClientHandle)) != DIGITALTWIN_CLIENT_OK)
     {
         LogError("DigitalTwin_DeviceClient_CreateFromDeviceHandle failed, error=<%s>", MU_ENUM_TO_STRING(DIGITALTWIN_CLIENT_RESULT, (DIGITALTWIN_CLIENT_RESULT)result));
     }    

--- a/digitaltwin_client/tests/dt_e2e/service/dt_e2e_test.ts
+++ b/digitaltwin_client/tests/dt_e2e/service/dt_e2e_test.ts
@@ -464,7 +464,7 @@ describe("DigitalTwin Properties E2E tests", function() {
     })
 
     // Disable test requires updates from node service client sdk and the test code to support changes for Refresh.
-    // Should verify capability model id instead of interfaces.  The interfaces info will be in the capability model definition.
+    // Should verify root interface id instead of interfaces.  The interfaces info will be in the root interface definition.
 
     //it("Verify all interfaces registered", function(done) {
     //    veryAllInterfacesAreRegistered(done)

--- a/iothub_client/inc/internal/iothub_transport_ll_private.h
+++ b/iothub_client/inc/internal/iothub_transport_ll_private.h
@@ -38,7 +38,7 @@ extern "C"
     typedef void (*pfTransport_Twin_ReportedStateComplete_Callback)(uint32_t item_id, int status_code, void* ctx);
     typedef void (*pfTransport_Twin_RetrievePropertyComplete_Callback)(DEVICE_TWIN_UPDATE_STATE update_state, const unsigned char* payLoad, size_t size, void* ctx);
     typedef int (*pfTransport_DeviceMethod_Complete_Callback)(const char* method_name, const unsigned char* payLoad, size_t size, METHOD_HANDLE response_id, void* ctx);
-    typedef const char* (*pfTransport_GetOption_DT_Model_Id_Callback)(void* ctx);
+    typedef const char* (*pfTransport_GetOPTION_DT_ROOT_INTERFACE_ID_Callback)(void* ctx);
 
     /** @brief    This struct captures device configuration. */
     typedef struct IOTHUB_DEVICE_CONFIG_TAG
@@ -68,7 +68,7 @@ extern "C"
         pfTransport_Twin_ReportedStateComplete_Callback twin_rpt_state_complete_cb;
         pfTransport_Twin_RetrievePropertyComplete_Callback twin_retrieve_prop_complete_cb;
         pfTransport_DeviceMethod_Complete_Callback method_complete_cb;
-        pfTransport_GetOption_DT_Model_Id_Callback dt_model_id_cb;
+        pfTransport_GetOPTION_DT_ROOT_INTERFACE_ID_Callback dt_root_interface_id_cb;
     } TRANSPORT_CALLBACKS_INFO;
 
     typedef STRING_HANDLE (*pfIoTHubTransport_GetHostname)(TRANSPORT_LL_HANDLE handle);

--- a/iothub_client/inc/iothub_client_options.h
+++ b/iothub_client/inc/iothub_client_options.h
@@ -42,7 +42,7 @@ extern "C"
     static STATIC_VAR_UNUSED const char* OPTION_MESSAGE_TIMEOUT = "messageTimeout";
     static STATIC_VAR_UNUSED const char* OPTION_BLOB_UPLOAD_TIMEOUT_SECS = "blob_upload_timeout_secs";
     static STATIC_VAR_UNUSED const char* OPTION_PRODUCT_INFO = "product_info";
-    static STATIC_VAR_UNUSED const char* OPTION_DT_MODEL_ID = "dt_model_id";
+    static STATIC_VAR_UNUSED const char* OPTION_DT_ROOT_INTERFACE_ID = "dt_root_interface_id";
 
     /*
     * @brief    Turns on automatic URL encoding of message properties + system properties. Only valid for use with MQTT Transport

--- a/iothub_client/src/iothub_client_core_ll.c
+++ b/iothub_client/src/iothub_client_core_ll.c
@@ -615,7 +615,7 @@ static const char* IoTHubClientCore_LL_GetProductInfo(void* ctx)
     return result;
 }
 
-static const char* IoTHubClientCore_LL_GetDTModelId(void* ctx)
+static const char* IoTHubClientCore_LL_GetRootInterfaceId(void* ctx)
 {
     const char* result;
     if (ctx == NULL)
@@ -844,7 +844,7 @@ static IOTHUB_CLIENT_CORE_LL_HANDLE_DATA* initialize_iothub_client(const IOTHUB_
             transport_cb.msg_input_cb = IoTHubClientCore_LL_MessageCallbackFromInput;
             transport_cb.msg_cb = IoTHubClientCore_LL_MessageCallback;
             transport_cb.method_complete_cb = IoTHubClientCore_LL_DeviceMethodComplete;
-            transport_cb.dt_root_interface_id_cb = IoTHubClientCore_LL_GetDTModelId;
+            transport_cb.dt_root_interface_id_cb = IoTHubClientCore_LL_GetRootInterfaceId;
 
             if (client_config != NULL)
             {
@@ -2341,7 +2341,7 @@ IOTHUB_CLIENT_RESULT IoTHubClientCore_LL_SetOption(IOTHUB_CLIENT_CORE_LL_HANDLE 
         {
             if (handleData->dt_root_interface_id != NULL)
             {
-                LogError("DT Model Id already specified.");
+                LogError("DT Root Interface Id already specified.");
                 result = IOTHUB_CLIENT_ERROR;
             } 
             else if ((handleData->dt_root_interface_id = STRING_construct((const char*)value)) == NULL)
@@ -3009,7 +3009,7 @@ int IoTHubClientCore_LL_GetTransportCallbacks(TRANSPORT_CALLBACKS_INFO* transpor
         transport_cb->msg_input_cb = IoTHubClientCore_LL_MessageCallbackFromInput;
         transport_cb->msg_cb = IoTHubClientCore_LL_MessageCallback;
         transport_cb->method_complete_cb = IoTHubClientCore_LL_DeviceMethodComplete;
-        transport_cb->dt_root_interface_id_cb = IoTHubClientCore_LL_GetDTModelId;
+        transport_cb->dt_root_interface_id_cb = IoTHubClientCore_LL_GetRootInterfaceId;
         result = 0;
     }
     return result;

--- a/iothub_client/src/iothub_client_core_ll.c
+++ b/iothub_client/src/iothub_client_core_ll.c
@@ -128,7 +128,7 @@ typedef struct IOTHUB_CLIENT_CORE_LL_HANDLE_DATA_TAG
     STRING_HANDLE product_info;
     IOTHUB_DIAGNOSTIC_SETTING_DATA diagnostic_setting;
     SINGLYLINKEDLIST_HANDLE event_callbacks;  // List of IOTHUB_EVENT_CALLBACK's
-    STRING_HANDLE dt_model_id;
+    STRING_HANDLE dt_root_interface_id;
 }IOTHUB_CLIENT_CORE_LL_HANDLE_DATA;
 
 static const char HOSTNAME_TOKEN[] = "HostName";
@@ -626,7 +626,7 @@ static const char* IoTHubClientCore_LL_GetDTModelId(void* ctx)
     else
     {
         IOTHUB_CLIENT_CORE_LL_HANDLE_DATA* iothub_data = (IOTHUB_CLIENT_CORE_LL_HANDLE_DATA*)ctx;
-        result = STRING_c_str(iothub_data->dt_model_id);
+        result = STRING_c_str(iothub_data->dt_root_interface_id);
     }
     return result;
 }
@@ -844,7 +844,7 @@ static IOTHUB_CLIENT_CORE_LL_HANDLE_DATA* initialize_iothub_client(const IOTHUB_
             transport_cb.msg_input_cb = IoTHubClientCore_LL_MessageCallbackFromInput;
             transport_cb.msg_cb = IoTHubClientCore_LL_MessageCallback;
             transport_cb.method_complete_cb = IoTHubClientCore_LL_DeviceMethodComplete;
-            transport_cb.dt_model_id_cb = IoTHubClientCore_LL_GetDTModelId;
+            transport_cb.dt_root_interface_id_cb = IoTHubClientCore_LL_GetDTModelId;
 
             if (client_config != NULL)
             {
@@ -1764,7 +1764,7 @@ void IoTHubClientCore_LL_Destroy(IOTHUB_CLIENT_CORE_LL_HANDLE iotHubClientHandle
         IoTHubClient_EdgeHandle_Destroy(handleData->methodHandle);
 #endif
         STRING_delete(handleData->product_info);
-        STRING_delete(handleData->dt_model_id);
+        STRING_delete(handleData->dt_root_interface_id);
         free(handleData);
     }
 }
@@ -2337,14 +2337,14 @@ IOTHUB_CLIENT_RESULT IoTHubClientCore_LL_SetOption(IOTHUB_CLIENT_CORE_LL_HANDLE 
                 result = IOTHUB_CLIENT_OK;
             }
         }
-        else if (strcmp(optionName, OPTION_DT_MODEL_ID) == 0)
+        else if (strcmp(optionName, OPTION_DT_ROOT_INTERFACE_ID) == 0)
         {
-            if (handleData->dt_model_id != NULL)
+            if (handleData->dt_root_interface_id != NULL)
             {
                 LogError("DT Model Id already specified.");
                 result = IOTHUB_CLIENT_ERROR;
             } 
-            else if ((handleData->dt_model_id = STRING_construct((const char*)value)) == NULL)
+            else if ((handleData->dt_root_interface_id = STRING_construct((const char*)value)) == NULL)
             {
                 LogError("STRING_c_str failed");
                 result = IOTHUB_CLIENT_ERROR;
@@ -3009,7 +3009,7 @@ int IoTHubClientCore_LL_GetTransportCallbacks(TRANSPORT_CALLBACKS_INFO* transpor
         transport_cb->msg_input_cb = IoTHubClientCore_LL_MessageCallbackFromInput;
         transport_cb->msg_cb = IoTHubClientCore_LL_MessageCallback;
         transport_cb->method_complete_cb = IoTHubClientCore_LL_DeviceMethodComplete;
-        transport_cb->dt_model_id_cb = IoTHubClientCore_LL_GetDTModelId;
+        transport_cb->dt_root_interface_id_cb = IoTHubClientCore_LL_GetDTModelId;
         result = 0;
     }
     return result;

--- a/iothub_client/src/iothubtransport_mqtt_common.c
+++ b/iothub_client/src/iothubtransport_mqtt_common.c
@@ -2189,7 +2189,7 @@ static int append_optional_connect_parameters(PMQTTTRANSPORT_HANDLE_DATA transpo
 
         STRING_HANDLE clone = NULL;
         STRING_HANDLE param = NULL;
-        STRING_HANDLE urlEncodedModelId = NULL;
+        STRING_HANDLE urlEncodedRootInterfaceId = NULL;
         const char* dt_root_interface_id;
         const char* product_info = transport_data->transport_callbacks.prod_info_cb(transport_data->transport_ctx);
 
@@ -2205,19 +2205,19 @@ static int append_optional_connect_parameters(PMQTTTRANSPORT_HANDLE_DATA transpo
         }           
         else if ((dt_root_interface_id = transport_data->transport_callbacks.dt_root_interface_id_cb(transport_data->transport_ctx)) != NULL)
         {
-            if ((urlEncodedModelId = URL_EncodeString(dt_root_interface_id)) == NULL)
+            if ((urlEncodedRootInterfaceId = URL_EncodeString(dt_root_interface_id)) == NULL)
             {
-                LogError("Failed to URL encode the device capability model id string");
+                LogError("Failed to URL encode the root interface id string");
                 result = MU_FAILURE;
             }
-            else if ((param = STRING_construct_sprintf("&%s=%s", DT_ROOT_INTERFACE_ID_TOKEN, STRING_c_str(urlEncodedModelId))) == NULL)
+            else if ((param = STRING_construct_sprintf("&%s=%s", DT_ROOT_INTERFACE_ID_TOKEN, STRING_c_str(urlEncodedRootInterfaceId))) == NULL)
             {
-                LogError("Cannot build device capability model id string");
+                LogError("Cannot build root interface id string");
                 result = MU_FAILURE;
             }
             else if (STRING_concat_with_STRING(transport_data->configPassedThroughUsername, param) != 0)
             {
-                LogError("Failed to set device capability model id parameter in connect");
+                LogError("Failed to set device capability root interface id parameter in connect");
                 result = MU_FAILURE;
             }
             else
@@ -2235,7 +2235,7 @@ static int append_optional_connect_parameters(PMQTTTRANSPORT_HANDLE_DATA transpo
 
         STRING_delete(clone);
         STRING_delete(param);
-        STRING_delete(urlEncodedModelId);
+        STRING_delete(urlEncodedRootInterfaceId);
     }
     else
     {

--- a/iothub_client/src/iothubtransport_mqtt_common.c
+++ b/iothub_client/src/iothubtransport_mqtt_common.c
@@ -91,7 +91,7 @@ static const char* CONNECTION_MODULE_ID_PROPERTY = "cmid";
 
 static const char* DIAGNOSTIC_CONTEXT_CREATION_TIME_UTC_PROPERTY = "creationtimeutc";
 
-static const char DT_MODEL_ID_TOKEN[] = "digital-twin-model-id";
+static const char DT_ROOT_INTERFACE_ID_TOKEN[] = "digital-twin-model-id";
 
 #define TOLOWER(c) (((c>='A') && (c<='Z'))?c-'A'+'a':c)
 
@@ -2190,7 +2190,7 @@ static int append_optional_connect_parameters(PMQTTTRANSPORT_HANDLE_DATA transpo
         STRING_HANDLE clone = NULL;
         STRING_HANDLE param = NULL;
         STRING_HANDLE urlEncodedModelId = NULL;
-        const char* dt_model_id;
+        const char* dt_root_interface_id;
         const char* product_info = transport_data->transport_callbacks.prod_info_cb(transport_data->transport_ctx);
 
         if ((clone = (product_info == NULL) ? STRING_construct_sprintf("%s%%2F%s", CLIENT_DEVICE_TYPE_PREFIX, IOTHUB_SDK_VERSION) : URL_EncodeString(product_info)) == NULL)
@@ -2203,14 +2203,14 @@ static int append_optional_connect_parameters(PMQTTTRANSPORT_HANDLE_DATA transpo
             LogError("Failed concatenating the product info");
             result = 0;
         }           
-        else if ((dt_model_id = transport_data->transport_callbacks.dt_model_id_cb(transport_data->transport_ctx)) != NULL)
+        else if ((dt_root_interface_id = transport_data->transport_callbacks.dt_root_interface_id_cb(transport_data->transport_ctx)) != NULL)
         {
-            if ((urlEncodedModelId = URL_EncodeString(dt_model_id)) == NULL)
+            if ((urlEncodedModelId = URL_EncodeString(dt_root_interface_id)) == NULL)
             {
                 LogError("Failed to URL encode the device capability model id string");
                 result = MU_FAILURE;
             }
-            else if ((param = STRING_construct_sprintf("&%s=%s", DT_MODEL_ID_TOKEN, STRING_c_str(urlEncodedModelId))) == NULL)
+            else if ((param = STRING_construct_sprintf("&%s=%s", DT_ROOT_INTERFACE_ID_TOKEN, STRING_c_str(urlEncodedModelId))) == NULL)
             {
                 LogError("Cannot build device capability model id string");
                 result = MU_FAILURE;

--- a/iothub_client/tests/iothubclientcore_ll_ut/iothub_client_core_ll_ut.c
+++ b/iothub_client/tests/iothubclientcore_ll_ut/iothub_client_core_ll_ut.c
@@ -120,7 +120,7 @@ MOCKABLE_FUNCTION(, const char*, Transport_GetOption_Product_Info_Callback, void
 MOCKABLE_FUNCTION(, void, Transport_Twin_ReportedStateComplete_Callback, uint32_t, item_id, int, status_code, void*, ctx);
 MOCKABLE_FUNCTION(, void, Transport_Twin_RetrievePropertyComplete_Callback, DEVICE_TWIN_UPDATE_STATE, update_state, const unsigned char*, payLoad, size_t, size, void*, ctx);
 MOCKABLE_FUNCTION(, int, Transport_DeviceMethod_Complete_Callback, const char*, method_name, const unsigned char*, payLoad, size_t, size, METHOD_HANDLE, response_id, void*, ctx);
-MOCKABLE_FUNCTION(, const char*, Transport_GetOption_DT_Model_Id_Callback, void*, ctx);
+MOCKABLE_FUNCTION(, const char*, Transport_GetOPTION_DT_ROOT_INTERFACE_ID_Callback, void*, ctx);
 
 static int bool_Compare(bool left, bool right)
 {
@@ -5536,7 +5536,7 @@ TEST_FUNCTION(IoTHubClientCore_LL_SetOption_product_info_fails_case1)
     IoTHubClientCore_LL_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClientCore_LL_SetOption_dt_model_id_succeeds)
+TEST_FUNCTION(IoTHubClientCore_LL_SetOPTION_DT_ROOT_INTERFACE_ID_succeeds)
 {
     //arrange
     IOTHUB_CLIENT_CORE_LL_HANDLE h = IoTHubClientCore_LL_Create(&TEST_CONFIG);
@@ -5544,7 +5544,7 @@ TEST_FUNCTION(IoTHubClientCore_LL_SetOption_dt_model_id_succeeds)
     STRICT_EXPECTED_CALL(STRING_construct(IGNORED_PTR_ARG));
 
     //act
-    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_DT_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:1");
+    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_DT_ROOT_INTERFACE_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:1");
 
     //assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -5554,7 +5554,7 @@ TEST_FUNCTION(IoTHubClientCore_LL_SetOption_dt_model_id_succeeds)
     IoTHubClientCore_LL_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClientCore_LL_SetOption_dt_model_id_string_construct_fails)
+TEST_FUNCTION(IoTHubClientCore_LL_SetOPTION_DT_ROOT_INTERFACE_ID_string_construct_fails)
 {
     //arrange
     IOTHUB_CLIENT_CORE_LL_HANDLE h = IoTHubClientCore_LL_Create(&TEST_CONFIG);
@@ -5563,7 +5563,7 @@ TEST_FUNCTION(IoTHubClientCore_LL_SetOption_dt_model_id_string_construct_fails)
 
     //act
     g_fail_string_construct = true;
-    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_DT_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:1");
+    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_DT_ROOT_INTERFACE_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:1");
 
     //assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_ERROR, result);
@@ -5573,17 +5573,17 @@ TEST_FUNCTION(IoTHubClientCore_LL_SetOption_dt_model_id_string_construct_fails)
     IoTHubClientCore_LL_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClientCore_LL_SetOption_dt_model_id_twice_fails)
+TEST_FUNCTION(IoTHubClientCore_LL_SetOPTION_DT_ROOT_INTERFACE_ID_twice_fails)
 {
     //arrange
     IOTHUB_CLIENT_CORE_LL_HANDLE h = IoTHubClientCore_LL_Create(&TEST_CONFIG);
     umock_c_reset_all_calls();
     STRICT_EXPECTED_CALL(STRING_construct(IGNORED_PTR_ARG));
-    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_DT_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:1");
+    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_DT_ROOT_INTERFACE_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:1");
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
 
     //act
-    result = IoTHubClientCore_LL_SetOption(h, OPTION_DT_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:2");
+    result = IoTHubClientCore_LL_SetOption(h, OPTION_DT_ROOT_INTERFACE_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:2");
 
     //assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_ERROR, result);

--- a/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
+++ b/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
@@ -76,7 +76,7 @@ MOCKABLE_FUNCTION(, const char*, Transport_GetOption_Product_Info_Callback, void
 MOCKABLE_FUNCTION(, void, Transport_Twin_ReportedStateComplete_Callback, uint32_t, item_id, int, status_code, void*, ctx);
 MOCKABLE_FUNCTION(, void, Transport_Twin_RetrievePropertyComplete_Callback, DEVICE_TWIN_UPDATE_STATE, update_state, const unsigned char*, payLoad, size_t, size, void*, ctx);
 MOCKABLE_FUNCTION(, int, Transport_DeviceMethod_Complete_Callback, const char*, method_name, const unsigned char*, payLoad, size_t, size, METHOD_HANDLE, response_id, void*, ctx);
-MOCKABLE_FUNCTION(, const char*, Transport_GetOption_DT_Model_Id_Callback, void*, ctx);
+MOCKABLE_FUNCTION(, const char*, Transport_GetOPTION_DT_ROOT_INTERFACE_ID_Callback, void*, ctx);
 
 #undef ENABLE_MOCKS
 
@@ -151,7 +151,7 @@ static const char* my_Transport_GetOption_Product_Info_Callback(void* ctx)
     return "product_info";
 }
 
-static const char* my_Transport_GetOption_DT_Model_Id_Callback(void* ctx)
+static const char* my_Transport_GetOPTION_DT_ROOT_INTERFACE_ID_Callback(void* ctx)
 {
     (void)ctx;
     return "http://testDeviceCapabilityModel/1.0.0";
@@ -717,7 +717,7 @@ TEST_SUITE_INITIALIZE(suite_init)
     transport_cb_info.msg_input_cb = Transport_MessageCallbackFromInput;
     transport_cb_info.msg_cb = Transport_MessageCallback;
     transport_cb_info.method_complete_cb = Transport_DeviceMethod_Complete_Callback;
-    transport_cb_info.dt_model_id_cb = Transport_GetOption_DT_Model_Id_Callback;
+    transport_cb_info.dt_root_interface_id_cb = Transport_GetOPTION_DT_ROOT_INTERFACE_ID_Callback;
 
     g_cbuff.buffer = appMessage;
     g_cbuff.size = appMsgSize;
@@ -796,8 +796,8 @@ TEST_SUITE_INITIALIZE(suite_init)
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(URL_DecodeString, NULL);
     REGISTER_GLOBAL_MOCK_HOOK(Transport_GetOption_Product_Info_Callback, my_Transport_GetOption_Product_Info_Callback);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(Transport_GetOption_Product_Info_Callback, NULL);
-    REGISTER_GLOBAL_MOCK_HOOK(Transport_GetOption_DT_Model_Id_Callback, my_Transport_GetOption_DT_Model_Id_Callback);
-    REGISTER_GLOBAL_MOCK_FAIL_RETURN(Transport_GetOption_DT_Model_Id_Callback, NULL);
+    REGISTER_GLOBAL_MOCK_HOOK(Transport_GetOPTION_DT_ROOT_INTERFACE_ID_Callback, my_Transport_GetOPTION_DT_ROOT_INTERFACE_ID_Callback);
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(Transport_GetOPTION_DT_ROOT_INTERFACE_ID_Callback, NULL);
 
     REGISTER_GLOBAL_MOCK_RETURN(IoTHub_Transport_ValidateCallbacks, 0);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(IoTHub_Transport_ValidateCallbacks, __LINE__);
@@ -1215,7 +1215,7 @@ static void setup_initialize_connection_mocks()
     STRICT_EXPECTED_CALL(Transport_GetOption_Product_Info_Callback(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(URL_EncodeString(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(STRING_concat_with_STRING(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
-    STRICT_EXPECTED_CALL(Transport_GetOption_DT_Model_Id_Callback(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(Transport_GetOPTION_DT_ROOT_INTERFACE_ID_Callback(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(URL_EncodeString(IGNORED_PTR_ARG));
     EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)).SetReturn(TEST_STRING_VALUE);
     STRICT_EXPECTED_CALL(STRING_concat_with_STRING(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
@@ -3927,7 +3927,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_mqtt_client_connect_fail)
     STRICT_EXPECTED_CALL(Transport_GetOption_Product_Info_Callback(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(URL_EncodeString(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(STRING_concat_with_STRING(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
-    STRICT_EXPECTED_CALL(Transport_GetOption_DT_Model_Id_Callback(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(Transport_GetOPTION_DT_ROOT_INTERFACE_ID_Callback(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(URL_EncodeString(IGNORED_PTR_ARG));
     EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)).SetReturn(TEST_STRING_VALUE);
     STRICT_EXPECTED_CALL(STRING_concat_with_STRING(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
@@ -4462,7 +4462,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_SAS_token_from_user_succeed)
     STRICT_EXPECTED_CALL(Transport_GetOption_Product_Info_Callback(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(URL_EncodeString(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(STRING_concat_with_STRING(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
-    STRICT_EXPECTED_CALL(Transport_GetOption_DT_Model_Id_Callback(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(Transport_GetOPTION_DT_ROOT_INTERFACE_ID_Callback(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(URL_EncodeString(IGNORED_PTR_ARG));
     EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)).SetReturn(TEST_STRING_VALUE);
     STRICT_EXPECTED_CALL(STRING_concat_with_STRING(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
@@ -4567,7 +4567,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_x509_succeed)
     STRICT_EXPECTED_CALL(Transport_GetOption_Product_Info_Callback(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(URL_EncodeString(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(STRING_concat_with_STRING(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
-    STRICT_EXPECTED_CALL(Transport_GetOption_DT_Model_Id_Callback(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(Transport_GetOPTION_DT_ROOT_INTERFACE_ID_Callback(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(URL_EncodeString(IGNORED_PTR_ARG));
     EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)).SetReturn(TEST_STRING_VALUE);
     STRICT_EXPECTED_CALL(STRING_concat_with_STRING(IGNORED_PTR_ARG, IGNORED_PTR_ARG));


### PR DESCRIPTION
The term "device capability model" is a DTDLv1 concept that in DTDLv2 is being replaced with concept of the root interface ID.

Replace code, samples, docs, tests with appropriate wording.