### PR TITLE
Incorporate latest DTDL changes

### DIFF
--- a/digitaltwin_client/samples/SampleDevice.model.json
+++ b/digitaltwin_client/samples/SampleDevice.model.json
@@ -1,11 +1,11 @@
 {
-  "@id": "dtmi:com:examples:SampleDevice;1",
+  "@id": "dtmi:com:example:SampleDevice;1",
   "@type": "Interface",
   "displayName": "My Sample Model",
   "contents": [
     {
       "@type": "Component",
-      "schema": "dtmi:com:examples:EnvironmentalSensorl;1",
+      "schema": "dtmi:com:example:EnvironmentalSensor;1",
       "name": "sensor"
     },
     {

--- a/digitaltwin_client/samples/SampleDevice.model.json
+++ b/digitaltwin_client/samples/SampleDevice.model.json
@@ -1,22 +1,22 @@
 {
-  "@id": "dtmi:my_company:com:sample_device;1",
+  "@id": "dtmi:com:examples:SampleDevice;1",
   "@type": "Interface",
   "displayName": "My Sample Model",
   "contents": [
     {
       "@type": "Component",
-      "schema": "dtmi:my_company:com:EnvironmentalSensor;1",
+      "schema": "dtmi:com:examples:EnvironmentalSensorl;1",
       "name": "sensor"
     },
     {
       "@type": "Component",
-      "schema": "dtmi:azureiot:DeviceManagement:DeviceInformation;1",
-      "name": "DeviceInformation"
+      "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1",
+      "name": "deviceInformation"
     },
     {
       "@type": "Component",
-      "schema": "dtmi:azureiot:Client:SDKInformation;1",
-      "name": "SDKInformation"
+      "schema": "dtmi:azure:Client:SDKInformation;1",
+      "name": "sdkInformation"
     }
   ],
   "@context": "dtmi:dtdl:context;2"

--- a/digitaltwin_client/samples/digitaltwin_sample_device/digitaltwin_sample_device.c
+++ b/digitaltwin_client/samples/digitaltwin_sample_device/digitaltwin_sample_device.c
@@ -56,7 +56,7 @@ static const int digitalTwinSampleDevice_sendTelemetryFrequency = 20;
 //
 
 // TODO: Fill in DIGITALTWIN_SAMPLE_MODEL_ID. E.g. 
-#define DIGITALTWIN_SAMPLE_MODEL_ID "dtmi:my_company:com:sample_device;1"
+#define DIGITALTWIN_SAMPLE_MODEL_ID "dtmi:com:example:EnvironmentalSensor;1"
 
 //
 // END TODO section

--- a/digitaltwin_client/samples/digitaltwin_sample_device_info/digitaltwin_sample_device_info.c
+++ b/digitaltwin_client/samples/digitaltwin_sample_device_info/digitaltwin_sample_device_info.c
@@ -30,7 +30,7 @@ DIGITALTWIN_SAMPLE_DEVICEINFO_STATE digitaltwinSample_DeviceInfoState;
 
 // DigitalTwin interface name from service perspective.
 static const char digitaltwinSampleDeviceInfo_InterfaceId[] = "dtmi:azure:DeviceManagement:DeviceInformation;1";
-static const char digitaltwinSampleDeviceInfo_InterfaceName[] = "Deviceinformation";
+static const char digitaltwinSampleDeviceInfo_InterfaceName[] = "deviceInformation";
 
 // DigitalTwinSampleDeviceInfo_PropertyCallback is invoked when a property is updated (or failed) going to server.
 // In this sample, we route ALL property callbacks to this function and just have the userContextCallback set

--- a/digitaltwin_client/samples/digitaltwin_sample_environmental_sensor/EnvironmentalSensor.interface.json
+++ b/digitaltwin_client/samples/digitaltwin_sample_environmental_sensor/EnvironmentalSensor.interface.json
@@ -1,5 +1,5 @@
 {
-  "@id": "dtmi:my_company:com:EnvironmentalSensor;1",
+  "@id": "dtmi:com:examples:EnvironmentalSensorl;1",
   "@type": "Interface",
   "displayName": "Environmental Sensor",
   "description": "Provides functionality to report temperature, humidity. Provides telemetry, commands and read-write properties",
@@ -50,7 +50,7 @@
     },
     {
       "@type": "Command",
-      "description": "This command will begin blinking the LED for given time interval.",
+      "description": "This Command will begin blinking the LED for given time interval.",
       "name": "blink",
       "request": {
         "name": "interval",
@@ -72,12 +72,12 @@
     {
       "@type": "Command",
       "name": "turnon",
-      "comment": "This Commands will turn-on the LED light on the device.",
+      "comment": "This Command will turn-on the LED light on the device."
     },
     {
       "@type": "Command",
       "name": "turnoff",
-      "comment": "This Commands will turn-off the LED light on the device.",
+      "comment": "This Command will turn-off the LED light on the device."
     }
   ],
   "@context": "dtmi:dtdl:context;2"

--- a/digitaltwin_client/samples/digitaltwin_sample_environmental_sensor/EnvironmentalSensor.interface.json
+++ b/digitaltwin_client/samples/digitaltwin_sample_environmental_sensor/EnvironmentalSensor.interface.json
@@ -1,5 +1,5 @@
 {
-  "@id": "dtmi:com:examples:EnvironmentalSensorl;1",
+  "@id": "dtmi:com:example:EnvironmentalSensor;1",
   "@type": "Interface",
   "displayName": "Environmental Sensor",
   "description": "Provides functionality to report temperature, humidity. Provides telemetry, commands and read-write properties",
@@ -8,7 +8,7 @@
     {
       "@type": "Property",
       "displayName": "Device State",
-      "description": "The state of the device. Two states online/offline are available.",
+      "description": "The state of the device. Two states are available or not available.",
       "name": "state",
       "schema": "boolean"
     },
@@ -26,27 +26,29 @@
       "description": "The brightness level for the light on the device. Can be specified as 1 (high), 2 (medium), 3 (low)",
       "name": "brightness",
       "writable": true,
-      "schema": "long"
+      "schema": "integer"
     },
     {
       "@type": [
         "Telemetry",
-        "SemanticType/Temperature"
+        "Temperature"
       ],
       "description": "Current temperature on the device",
       "displayName": "Temperature",
       "name": "temp",
-      "schema": "double"
+      "schema": "double",
+      "unit": "degreeCelsius"
     },
     {
       "@type": [
         "Telemetry",
-        "SemanticType/Humidity"
+        "RelativeHumidity"
       ],
       "description": "Current humidity on the device",
       "displayName": "Humidity",
-      "name": "humid",
-      "schema": "double"
+      "name": "humidity",
+      "schema": "double",
+      "unit": "percent"
     },
     {
       "@type": "Command",
@@ -54,7 +56,7 @@
       "name": "blink",
       "request": {
         "name": "interval",
-        "schema": "long"
+        "schema": "integer"
       },
       "response": {
         "name": "blinkResponse",
@@ -71,13 +73,13 @@
     },
     {
       "@type": "Command",
-      "name": "turnon",
-      "comment": "This Command will turn-on the LED light on the device."
+      "name": "turnOn",
+      "comment": "This Command will turn on the LED light on the device."
     },
     {
       "@type": "Command",
-      "name": "turnoff",
-      "comment": "This Command will turn-off the LED light on the device."
+      "name": "turnOff",
+      "comment": "This Command will turn off the LED light on the device."
     }
   ],
   "@context": "dtmi:dtdl:context;2"

--- a/digitaltwin_client/samples/digitaltwin_sample_environmental_sensor/digitaltwin_sample_environmental_sensor.c
+++ b/digitaltwin_client/samples/digitaltwin_sample_environmental_sensor/digitaltwin_sample_environmental_sensor.c
@@ -35,7 +35,7 @@ static const char DigitalTwinSampleEnvironmentalSensor_ComponentName[] = "sensor
 //  Telemetry names for this interface.
 //
 static const char* DigitalTwinSampleEnvironmentalSensor_TemperatureTelemetry = "temp";
-static const char* DigitalTwinSampleEnvironmentalSensor_HumidityTelemetry = "humid";
+static const char* DigitalTwinSampleEnvironmentalSensor_HumidityTelemetry = "humidity";
 
 
 //
@@ -50,8 +50,8 @@ static const int digitaltwinSample_DeviceStateDataLen = sizeof(digitaltwinSample
 //  Callback command names for this interface.
 //
 static const char digitaltwinSample_EnvironmentalSensorCommandBlink[] = "blink";
-static const char digitaltwinSample_EnvironmentalSensorCommandTurnOn[] =  "turnon";
-static const char digitaltwinSample_EnvironmentalSensorCommandTurnOff[] =  "turnoff";
+static const char digitaltwinSample_EnvironmentalSensorCommandTurnOn[] =  "turnOn";
+static const char digitaltwinSample_EnvironmentalSensorCommandTurnOff[] =  "turnOff";
 
 //
 // Command status codes
@@ -144,7 +144,7 @@ static void DigitalTwinSampleEnvironmentalSensor_BlinkCallback(const DIGITALTWIN
     (void)DigitalTwinSampleEnvironmentalSensor_SetCommandResponse(dtCommandResponse, digitaltwinSample_EnviromentalSensor_BlinkResponse, commandStatusSuccess);
 }
 
-// Implement the callback to process the command "turnon".
+// Implement the callback to process the command "turnOn".
 static void DigitalTwinSampleEnvironmentalSensor_TurnOnLightCallback(const DIGITALTWIN_CLIENT_COMMAND_REQUEST* dtCommandRequest, DIGITALTWIN_CLIENT_COMMAND_RESPONSE* dtCommandResponse, void* commandCallbackContext)
 {
     DIGITALTWIN_SAMPLE_ENVIRONMENTAL_SENSOR_STATE* sensorState = (DIGITALTWIN_SAMPLE_ENVIRONMENTAL_SENSOR_STATE*)commandCallbackContext;
@@ -156,7 +156,7 @@ static void DigitalTwinSampleEnvironmentalSensor_TurnOnLightCallback(const DIGIT
     (void)DigitalTwinSampleEnvironmentalSensor_SetCommandResponseEmptyBody(dtCommandResponse, commandStatusSuccess);
 }
 
-// Implement the callback to process the command "turnoff".
+// Implement the callback to process the command "turnOff".
 static void DigitalTwinSampleEnvironmentalSensor_TurnOffLightCallback(const DIGITALTWIN_CLIENT_COMMAND_REQUEST* dtCommandRequest, DIGITALTWIN_CLIENT_COMMAND_RESPONSE* dtCommandResponse, void* commandCallbackContext)
 {
     DIGITALTWIN_SAMPLE_ENVIRONMENTAL_SENSOR_STATE* sensorState = (DIGITALTWIN_SAMPLE_ENVIRONMENTAL_SENSOR_STATE*)commandCallbackContext;

--- a/digitaltwin_client/samples/digitaltwin_sample_ll_device/digitaltwin_sample_ll_device.c
+++ b/digitaltwin_client/samples/digitaltwin_sample_ll_device/digitaltwin_sample_ll_device.c
@@ -44,7 +44,7 @@
 #include <../digitaltwin_sample_environmental_sensor/digitaltwin_sample_environmental_sensor.h>
 
 // TODO: Fill in DIGITALTWIN_SAMPLE_MODEL_ID
-#define DIGITALTWIN_SAMPLE_MODEL_ID "dtmi:my_company:com:sample_device;1"
+#define DIGITALTWIN_SAMPLE_MODEL_ID "dtmi:com:examples:EnvironmentalSensorl;1"
 
 typedef enum DIGITALTWIN_SAMPLE_SECURITY_TYPE_TAG
 {

--- a/digitaltwin_client/samples/digitaltwin_sample_ll_device/digitaltwin_sample_ll_device.c
+++ b/digitaltwin_client/samples/digitaltwin_sample_ll_device/digitaltwin_sample_ll_device.c
@@ -44,7 +44,7 @@
 #include <../digitaltwin_sample_environmental_sensor/digitaltwin_sample_environmental_sensor.h>
 
 // TODO: Fill in DIGITALTWIN_SAMPLE_MODEL_ID
-#define DIGITALTWIN_SAMPLE_MODEL_ID "dtmi:com:examples:EnvironmentalSensorl;1"
+#define DIGITALTWIN_SAMPLE_MODEL_ID "dtmi:com:example:EnvironmentalSensor;1"
 
 typedef enum DIGITALTWIN_SAMPLE_SECURITY_TYPE_TAG
 {


### PR DESCRIPTION
There has been additional late breaking requests to change the sample DTDL files, mostly around naming convention (prefer `example:com` to `examples:com`) and various Pascal and Camel casing conventions.

The PR we're inspired by is [this](https://github.com/Azure/IoTPlugandPlay/pull/54), which has been signed off on and merged.