### PR TITLE
Samples: fixed and unified comment related to setting the trusted cer…

### DIFF
--- a/iothub_client/samples/iothub_client_sample_amqp_shared_methods/iothub_client_sample_amqp_shared_methods.c
+++ b/iothub_client/samples/iothub_client_sample_amqp_shared_methods/iothub_client_sample_amqp_shared_methods.c
@@ -122,7 +122,7 @@ int main(void)
             //IoTHubDeviceClient_SetOption(device_handle1, OPTION_LOG_TRACE, &traceOn);
             //IoTHubDeviceClient_SetOption(device_handle2, OPTION_LOG_TRACE, &traceOn);
 #ifdef SET_TRUSTED_CERT_IN_SAMPLES
-            // Setting the Trusted Certificate.  This is only necessary on system without
+            // Setting the Trusted Certificate. This is only necessary on systems without
             // built in certificate stores.
             IoTHubDeviceClient_SetOption(device_handle1, OPTION_TRUSTED_CERT, certificates);
             IoTHubDeviceClient_SetOption(device_handle2, OPTION_TRUSTED_CERT, certificates);

--- a/iothub_client/samples/iothub_client_sample_upload_to_blob/iothub_client_sample_upload_to_blob.c
+++ b/iothub_client/samples/iothub_client_sample_upload_to_blob/iothub_client_sample_upload_to_blob.c
@@ -58,7 +58,7 @@ int main(void)
 #endif // !WIN32
 
 #ifdef SET_TRUSTED_CERT_IN_SAMPLES
-        // Setting the Trusted Certificate.  This is only necessary on system with without
+        // Setting the Trusted Certificate. This is only necessary on systems without
         // built in certificate stores.
         IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_TRUSTED_CERT, certificates);
 #endif // SET_TRUSTED_CERT_IN_SAMPLES

--- a/iothub_client/samples/iothub_client_sample_upload_to_blob_mb/iothub_client_sample_upload_to_blob_mb.c
+++ b/iothub_client/samples/iothub_client_sample_upload_to_blob_mb/iothub_client_sample_upload_to_blob_mb.c
@@ -95,7 +95,7 @@ int main(void)
     else
     {
 #ifdef SET_TRUSTED_CERT_IN_SAMPLES
-        // Setting the Trusted Certificate.  This is only necessary on system with without
+        // Setting the Trusted Certificate. This is only necessary on systems without
         // built in certificate stores.
         IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_TRUSTED_CERT, certificates);
 #endif // SET_TRUSTED_CERT_IN_SAMPLES

--- a/iothub_client/samples/iothub_convenience_sample/iothub_convenience_sample.c
+++ b/iothub_client/samples/iothub_convenience_sample/iothub_convenience_sample.c
@@ -279,7 +279,7 @@ int main(void)
         (void)IoTHubDeviceClient_SetOption(device_handle, OPTION_DO_WORK_FREQUENCY_IN_MS, &ms_delay);
 
 #ifdef SET_TRUSTED_CERT_IN_SAMPLES
-        // Setting the Trusted Certificate.  This is only necessary on system with without
+        // Setting the Trusted Certificate. This is only necessary on systems without
         // built in certificate stores.
         (void)IoTHubDeviceClient_SetOption(device_handle, OPTION_TRUSTED_CERT, certificates);
 #endif // SET_TRUSTED_CERT_IN_SAMPLES

--- a/iothub_client/samples/iothub_ll_c2d_sample/iothub_ll_c2d_sample.c
+++ b/iothub_client/samples/iothub_ll_c2d_sample/iothub_ll_c2d_sample.c
@@ -148,7 +148,7 @@ int main(void)
         //bool traceOn = true;
         //IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_LOG_TRACE, &traceOn);
 #ifdef SET_TRUSTED_CERT_IN_SAMPLES
-        // Setting the Trusted Certificate.  This is only necessary on system with without
+        // Setting the Trusted Certificate. This is only necessary on systems without
         // built in certificate stores.
         IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_TRUSTED_CERT, certificates);
 #endif // SET_TRUSTED_CERT_IN_SAMPLES

--- a/iothub_client/samples/iothub_ll_client_shared_sample/iothub_ll_client_shared_sample.c
+++ b/iothub_client/samples/iothub_ll_client_shared_sample/iothub_ll_client_shared_sample.c
@@ -227,7 +227,7 @@ int main(void)
             //IoTHubDeviceClient_LL_SetOption(device_ll_handle1, OPTION_LOG_TRACE, &traceOn);
             //IoTHubDeviceClient_LL_SetOption(device_ll_handle2, OPTION_LOG_TRACE, &traceOn);
 #ifdef SET_TRUSTED_CERT_IN_SAMPLES
-            // Setting the Trusted Certificate.  This is only necessary on system without
+            // Setting the Trusted Certificate. This is only necessary on systems without
             // built in certificate stores.
             IoTHubDeviceClient_LL_SetOption(device_ll_handle1, OPTION_TRUSTED_CERT, certificates);
             IoTHubDeviceClient_LL_SetOption(device_ll_handle2, OPTION_TRUSTED_CERT, certificates);

--- a/iothub_client/samples/iothub_ll_client_x509_sample/iothub_ll_client_x509_sample.c
+++ b/iothub_client/samples/iothub_ll_client_x509_sample/iothub_ll_client_x509_sample.c
@@ -136,7 +136,7 @@ int main(void)
         //bool traceOn = true;
         //IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_LOG_TRACE, &traceOn);
 
-        // Setting the Trusted Certificate.  This is only necessary on system with without
+        // Setting the Trusted Certificate. This is only necessary on systems without
         // built in certificate stores.
 #ifdef SET_TRUSTED_CERT_IN_SAMPLES
         IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_TRUSTED_CERT, certificates);

--- a/iothub_client/samples/iothub_ll_telemetry_sample/iothub_ll_telemetry_sample.c
+++ b/iothub_client/samples/iothub_ll_telemetry_sample/iothub_ll_telemetry_sample.c
@@ -126,7 +126,7 @@ int main(void)
 #endif
 
 #ifdef SET_TRUSTED_CERT_IN_SAMPLES
-        // Setting the Trusted Certificate.  This is only necessary on system with without
+        // Setting the Trusted Certificate. This is only necessary on systems without
         // built in certificate stores.
             IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_TRUSTED_CERT, certificates);
 #endif // SET_TRUSTED_CERT_IN_SAMPLES

--- a/provisioning_client/samples/iothub_client_sample_hsm/iothub_client_sample_hsm.c
+++ b/provisioning_client/samples/iothub_client_sample_hsm/iothub_client_sample_hsm.c
@@ -105,7 +105,7 @@ int main(void)
         // For available options please see the iothub_sdk_options.md documentation
         //bool traceOn = true;
         //IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_LOG_TRACE, &traceOn);
-        // Setting the Trusted Certificate.  This is only necessary on system with without
+        // Setting the Trusted Certificate. This is only necessary on systems without
         // built in certificate stores.
 #ifdef SET_TRUSTED_CERT_IN_SAMPLES
         IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_TRUSTED_CERT, certificates);

--- a/provisioning_client/samples/prov_dev_client_ll_sample/prov_dev_client_ll_sample.c
+++ b/provisioning_client/samples/prov_dev_client_ll_sample/prov_dev_client_ll_sample.c
@@ -216,7 +216,7 @@ int main()
 
         Prov_Device_LL_SetOption(handle, PROV_OPTION_LOG_TRACE, &traceOn);
 #ifdef SET_TRUSTED_CERT_IN_SAMPLES
-        // Setting the Trusted Certificate.  This is only necessary on system with without
+        // Setting the Trusted Certificate. This is only necessary on systems without
         // built in certificate stores.
         Prov_Device_LL_SetOption(handle, OPTION_TRUSTED_CERT, certificates);
 #endif // SET_TRUSTED_CERT_IN_SAMPLES
@@ -287,7 +287,7 @@ int main()
             IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_LOG_TRACE, &traceOn);
 
 #ifdef SET_TRUSTED_CERT_IN_SAMPLES
-            // Setting the Trusted Certificate.  This is only necessary on system with without
+            // Setting the Trusted Certificate. This is only necessary on systems without
             // built in certificate stores.
             IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_TRUSTED_CERT, certificates);
 #endif // SET_TRUSTED_CERT_IN_SAMPLES

--- a/provisioning_client/samples/prov_dev_client_sample/prov_dev_client_sample.c
+++ b/provisioning_client/samples/prov_dev_client_sample/prov_dev_client_sample.c
@@ -151,7 +151,7 @@ int main()
         //bool traceOn = true;
         //Prov_Device_SetOption(prov_device_handle, PROV_OPTION_LOG_TRACE, &traceOn);
 #ifdef SET_TRUSTED_CERT_IN_SAMPLES
-        // Setting the Trusted Certificate.  This is only necessary on system with without
+        // Setting the Trusted Certificate. This is only necessary on systems without
         // built in certificate stores.
         Prov_Device_SetOption(prov_device_handle, OPTION_TRUSTED_CERT, certificates);
 #endif // SET_TRUSTED_CERT_IN_SAMPLES

--- a/samples/dockerbuilds/myapp/iothub_cross_compile_simple_sample.c
+++ b/samples/dockerbuilds/myapp/iothub_cross_compile_simple_sample.c
@@ -72,7 +72,7 @@ int main(void)
     else
     {
 #ifdef SET_TRUSTED_CERT_IN_SAMPLES
-        // Setting the Trusted Certificate.  This is only necessary on system with without
+        // Setting the Trusted Certificate. This is only necessary on systems without
         // built in certificate stores.
         (void)IoTHubDeviceClient_SetOption(device_handle, OPTION_TRUSTED_CERT, certificates);
 #endif // SET_TRUSTED_CERT_IN_SAMPLES


### PR DESCRIPTION
…tificate

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [X] This pull-request is submitted against the `master` branch. 
  - [X] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [X] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
The comment was ambiguous in some files, saying that, setting the Trusted
Certificate is only necessary on systems "with" and "without" built in
certificate store.

# Description of the solution
As already stated in other files, it is only necessary on systems without
certificate store (for example: on small embedded systems).

The comment has been then unified all over the files containing it, for
consistency and uniformity.