### PR TITLE
Document fields as doubles, not longs

### DIFF
--- a/digitaltwin_client/samples/digitaltwin_sample_device_info/digitaltwin_sample_device_info.c
+++ b/digitaltwin_client/samples/digitaltwin_sample_device_info/digitaltwin_sample_device_info.c
@@ -204,7 +204,7 @@ static DIGITALTWIN_CLIENT_RESULT DigitalTwinSampleDeviceInfo_ReportProcessorManu
     return result;
 }
 
-// Sends a reported property for Total Storage of this device (a long, in kilobytes)
+// Sends a reported property for Total Storage of this device (a double, in kilobytes)
 static const char digitaltwinSample_TotalStorageProperty[] = "totalStorage";
 
 static DIGITALTWIN_CLIENT_RESULT DigitalTwinSampleDeviceInfo_ReportTotalStorageAsync(DIGITALTWIN_INTERFACE_CLIENT_HANDLE interfaceHandle)
@@ -226,7 +226,7 @@ static DIGITALTWIN_CLIENT_RESULT DigitalTwinSampleDeviceInfo_ReportTotalStorageA
     return result;
 }
 
-// Sends a reported property for Total Memory of this device (a long, in kilobytes)
+// Sends a reported property for Total Memory of this device (a double, in kilobytes)
 static const char digitaltwinSample_TotalMemoryProperty[] = "totalMemory";
 
 static DIGITALTWIN_CLIENT_RESULT DigitalTwinSampleDeviceInfo_ReportTotalMemoryAsync(DIGITALTWIN_INTERFACE_CLIENT_HANDLE interfaceHandle)


### PR DESCRIPTION
We're discouraging (if not outright removing) the use of longs from DTDL.  The issue is that Node cannot easily handle numbers > 2^52, whereas a long implies 2^64.  This will cause interop problems for customers using Node.

We're changing the DeviceInfo DTDL to use doubles instead of long.  While it may seem over-precise to specify a KB as a double instead of just as an int, our options of long we don't like and just moving it to a 32bit int would limit the maximum storage reportable on a device to 2TB which clearly isn't enough.

There's not really protocol changes in what the SDK is sending to support this.  Our comments should be correct, though.