### PR TITLE
Update release tag formats

### DIFF
--- a/doc/devbox_setup.md
+++ b/doc/devbox_setup.md
@@ -175,12 +175,12 @@ This section describes how to set up a development environment for the C SDK on 
   > To upgrade see "Upgrade CURL on Mac OS" steps below.
   
 - Locate the tag name for the [latest release][latest-release] of the SDK.
-  > Our release tag names are date values in `yyyy-mm-dd` format.
+  > Our release tag names are date values in `lts_mm_yyyy` format.
 
 - Clone the latest release of SDK to your local machine using the tag name you found:
 
   ```Shell
-  git clone -b <yyyy-mm-dd> https://github.com/Azure/azure-iot-sdk-c.git
+  git clone -b <lts_mm_yyyy> https://github.com/Azure/azure-iot-sdk-c.git
   cd azure-iot-sdk-c
   git submodule update --init
   ```
@@ -248,12 +248,12 @@ We've tested the device SDK for C on macOS High Sierra, with XCode version 9.2.
   > To upgrade see "Upgrade CURL on Mac OS" steps below.
   
 - Locate the tag name for the [latest release][latest-release] of the SDK.
-  > Our release tag names are date values in `yyyy-mm-dd` format.
+  > Our release tag names are date values in `lts_mm_yyyy` format.
 
 - Clone the latest release of SDK to your local machine using the tag name you found:
 
   ```Shell
-  git clone -b <yyyy-mm-dd> https://github.com/Azure/azure-iot-sdk-c.git
+  git clone -b <lts_mm_yyyy> https://github.com/Azure/azure-iot-sdk-c.git
   cd azure-iot-sdk-c
   git submodule update --init
   ```


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [X] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [X] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
The .md file for setting up your devbox with the SDK had one instance of the release tag format fixed (the first one at the top of the file) but two lower down still reflected the old tag format. 

# Description of the solution
Documentation issue, fixed by updating the documentation