### PR TITLE
Add ModelID parameter to IoTHub Client (MQTT only)

### DIFF
--- a/iothub_client/inc/internal/iothub_internal_consts.h
+++ b/iothub_client/inc/internal/iothub_internal_consts.h
@@ -10,6 +10,9 @@ extern "C"
 #endif
 
     static const char* IOTHUB_API_VERSION = "2017-11-08-preview";
+    // TODO: https://github.com/Azure/azure-iot-sdk-c/issues/1547 tracks removing this preview 
+    // variable once the underlying logic is enabled on all IoTHubs.
+    static const char* IOTHUB_API_PREVIEW_VERSION = "2020-05-31-preview";
 
     static const char* SECURITY_INTERFACE_INTERNAL_ID = "iothub-interface-internal-id";
     static const char* SECURITY_INTERFACE_INTERNAL_ID_VALUE = "security*azureiot*com^SecurityAgent^1*0*0";

--- a/iothub_client/inc/internal/iothub_transport_ll_private.h
+++ b/iothub_client/inc/internal/iothub_transport_ll_private.h
@@ -38,7 +38,7 @@ extern "C"
     typedef void (*pfTransport_Twin_ReportedStateComplete_Callback)(uint32_t item_id, int status_code, void* ctx);
     typedef void (*pfTransport_Twin_RetrievePropertyComplete_Callback)(DEVICE_TWIN_UPDATE_STATE update_state, const unsigned char* payLoad, size_t size, void* ctx);
     typedef int (*pfTransport_DeviceMethod_Complete_Callback)(const char* method_name, const unsigned char* payLoad, size_t size, METHOD_HANDLE response_id, void* ctx);
-    typedef const char* (*pfTransport_GetOption_DT_MODEL_ID_Callback)(void* ctx);
+    typedef const char* (*pfTransport_GetOption_MODEL_ID_Callback)(void* ctx);
 
     /** @brief    This struct captures device configuration. */
     typedef struct IOTHUB_DEVICE_CONFIG_TAG
@@ -68,7 +68,7 @@ extern "C"
         pfTransport_Twin_ReportedStateComplete_Callback twin_rpt_state_complete_cb;
         pfTransport_Twin_RetrievePropertyComplete_Callback twin_retrieve_prop_complete_cb;
         pfTransport_DeviceMethod_Complete_Callback method_complete_cb;
-        pfTransport_GetOption_DT_MODEL_ID_Callback dt_get_model_id_cb;
+        pfTransport_GetOption_MODEL_ID_Callback get_model_id_cb;
     } TRANSPORT_CALLBACKS_INFO;
 
     typedef STRING_HANDLE (*pfIoTHubTransport_GetHostname)(TRANSPORT_LL_HANDLE handle);

--- a/iothub_client/inc/internal/iothub_transport_ll_private.h
+++ b/iothub_client/inc/internal/iothub_transport_ll_private.h
@@ -38,7 +38,7 @@ extern "C"
     typedef void (*pfTransport_Twin_ReportedStateComplete_Callback)(uint32_t item_id, int status_code, void* ctx);
     typedef void (*pfTransport_Twin_RetrievePropertyComplete_Callback)(DEVICE_TWIN_UPDATE_STATE update_state, const unsigned char* payLoad, size_t size, void* ctx);
     typedef int (*pfTransport_DeviceMethod_Complete_Callback)(const char* method_name, const unsigned char* payLoad, size_t size, METHOD_HANDLE response_id, void* ctx);
-    typedef const char* (*pfTransport_GetOption_MODEL_ID_Callback)(void* ctx);
+    typedef const char* (*pfTransport_GetOption_Model_Id_Callback)(void* ctx);
 
     /** @brief    This struct captures device configuration. */
     typedef struct IOTHUB_DEVICE_CONFIG_TAG
@@ -68,7 +68,7 @@ extern "C"
         pfTransport_Twin_ReportedStateComplete_Callback twin_rpt_state_complete_cb;
         pfTransport_Twin_RetrievePropertyComplete_Callback twin_retrieve_prop_complete_cb;
         pfTransport_DeviceMethod_Complete_Callback method_complete_cb;
-        pfTransport_GetOption_MODEL_ID_Callback get_model_id_cb;
+        pfTransport_GetOption_Model_Id_Callback get_model_id_cb;
     } TRANSPORT_CALLBACKS_INFO;
 
     typedef STRING_HANDLE (*pfIoTHubTransport_GetHostname)(TRANSPORT_LL_HANDLE handle);

--- a/iothub_client/inc/internal/iothub_transport_ll_private.h
+++ b/iothub_client/inc/internal/iothub_transport_ll_private.h
@@ -38,6 +38,7 @@ extern "C"
     typedef void (*pfTransport_Twin_ReportedStateComplete_Callback)(uint32_t item_id, int status_code, void* ctx);
     typedef void (*pfTransport_Twin_RetrievePropertyComplete_Callback)(DEVICE_TWIN_UPDATE_STATE update_state, const unsigned char* payLoad, size_t size, void* ctx);
     typedef int (*pfTransport_DeviceMethod_Complete_Callback)(const char* method_name, const unsigned char* payLoad, size_t size, METHOD_HANDLE response_id, void* ctx);
+    typedef const char* (*pfTransport_GetOption_DT_MODEL_ID_Callback)(void* ctx);
 
     /** @brief    This struct captures device configuration. */
     typedef struct IOTHUB_DEVICE_CONFIG_TAG
@@ -67,6 +68,7 @@ extern "C"
         pfTransport_Twin_ReportedStateComplete_Callback twin_rpt_state_complete_cb;
         pfTransport_Twin_RetrievePropertyComplete_Callback twin_retrieve_prop_complete_cb;
         pfTransport_DeviceMethod_Complete_Callback method_complete_cb;
+        pfTransport_GetOption_DT_MODEL_ID_Callback dt_get_model_id_cb;
     } TRANSPORT_CALLBACKS_INFO;
 
     typedef STRING_HANDLE (*pfIoTHubTransport_GetHostname)(TRANSPORT_LL_HANDLE handle);

--- a/iothub_client/inc/iothub_client_options.h
+++ b/iothub_client/inc/iothub_client_options.h
@@ -42,6 +42,7 @@ extern "C"
     static STATIC_VAR_UNUSED const char* OPTION_MESSAGE_TIMEOUT = "messageTimeout";
     static STATIC_VAR_UNUSED const char* OPTION_BLOB_UPLOAD_TIMEOUT_SECS = "blob_upload_timeout_secs";
     static STATIC_VAR_UNUSED const char* OPTION_PRODUCT_INFO = "product_info";
+    static STATIC_VAR_UNUSED const char* OPTION_DT_MODEL_ID = "dt_model_id";
 
     /*
     * @brief    Turns on automatic URL encoding of message properties + system properties. Only valid for use with MQTT Transport

--- a/iothub_client/inc/iothub_client_options.h
+++ b/iothub_client/inc/iothub_client_options.h
@@ -42,7 +42,11 @@ extern "C"
     static STATIC_VAR_UNUSED const char* OPTION_MESSAGE_TIMEOUT = "messageTimeout";
     static STATIC_VAR_UNUSED const char* OPTION_BLOB_UPLOAD_TIMEOUT_SECS = "blob_upload_timeout_secs";
     static STATIC_VAR_UNUSED const char* OPTION_PRODUCT_INFO = "product_info";
-    static STATIC_VAR_UNUSED const char* OPTION_DT_MODEL_ID = "dt_model_id";
+
+    /*
+    * @brief    Specifies the Digital Twin Model Id of the connection. Only valid for use with MQTT Transport
+    */
+    static STATIC_VAR_UNUSED const char* OPTION_MODEL_ID = "model_id";
 
     /*
     * @brief    Turns on automatic URL encoding of message properties + system properties. Only valid for use with MQTT Transport

--- a/iothub_client/src/iothub_client_core_ll.c
+++ b/iothub_client/src/iothub_client_core_ll.c
@@ -128,7 +128,7 @@ typedef struct IOTHUB_CLIENT_CORE_LL_HANDLE_DATA_TAG
     STRING_HANDLE product_info;
     IOTHUB_DIAGNOSTIC_SETTING_DATA diagnostic_setting;
     SINGLYLINKEDLIST_HANDLE event_callbacks;  // List of IOTHUB_EVENT_CALLBACK's
-    STRING_HANDLE dt_model_id;
+    STRING_HANDLE model_id;
 }IOTHUB_CLIENT_CORE_LL_HANDLE_DATA;
 
 static const char HOSTNAME_TOKEN[] = "HostName";
@@ -626,7 +626,7 @@ static const char* IoTHubClientCore_LL_GetModelID(void* ctx)
     else
     {
         IOTHUB_CLIENT_CORE_LL_HANDLE_DATA* iothub_data = (IOTHUB_CLIENT_CORE_LL_HANDLE_DATA*)ctx;
-        result = STRING_c_str(iothub_data->dt_model_id);
+        result = STRING_c_str(iothub_data->model_id);
     }
     return result;
 }
@@ -844,7 +844,7 @@ static IOTHUB_CLIENT_CORE_LL_HANDLE_DATA* initialize_iothub_client(const IOTHUB_
             transport_cb.msg_input_cb = IoTHubClientCore_LL_MessageCallbackFromInput;
             transport_cb.msg_cb = IoTHubClientCore_LL_MessageCallback;
             transport_cb.method_complete_cb = IoTHubClientCore_LL_DeviceMethodComplete;
-            transport_cb.dt_get_model_id_cb = IoTHubClientCore_LL_GetModelID;
+            transport_cb.get_model_id_cb = IoTHubClientCore_LL_GetModelID;
 
             if (client_config != NULL)
             {
@@ -1764,7 +1764,7 @@ void IoTHubClientCore_LL_Destroy(IOTHUB_CLIENT_CORE_LL_HANDLE iotHubClientHandle
         IoTHubClient_EdgeHandle_Destroy(handleData->methodHandle);
 #endif
         STRING_delete(handleData->product_info);
-        STRING_delete(handleData->dt_model_id);
+        STRING_delete(handleData->model_id);
         free(handleData);
     }
 }
@@ -2337,14 +2337,14 @@ IOTHUB_CLIENT_RESULT IoTHubClientCore_LL_SetOption(IOTHUB_CLIENT_CORE_LL_HANDLE 
                 result = IOTHUB_CLIENT_OK;
             }
         }
-        else if (strcmp(optionName, OPTION_DT_MODEL_ID) == 0)
+        else if (strcmp(optionName, OPTION_MODEL_ID) == 0)
         {
-            if (handleData->dt_model_id != NULL)
+            if (handleData->model_id != NULL)
             {
                 LogError("DT ModelId already specified.");
                 result = IOTHUB_CLIENT_ERROR;
             } 
-            else if ((handleData->dt_model_id = STRING_construct((const char*)value)) == NULL)
+            else if ((handleData->model_id = STRING_construct((const char*)value)) == NULL)
             {
                 LogError("STRING_c_str failed");
                 result = IOTHUB_CLIENT_ERROR;
@@ -3009,7 +3009,7 @@ int IoTHubClientCore_LL_GetTransportCallbacks(TRANSPORT_CALLBACKS_INFO* transpor
         transport_cb->msg_input_cb = IoTHubClientCore_LL_MessageCallbackFromInput;
         transport_cb->msg_cb = IoTHubClientCore_LL_MessageCallback;
         transport_cb->method_complete_cb = IoTHubClientCore_LL_DeviceMethodComplete;
-        transport_cb->dt_get_model_id_cb = IoTHubClientCore_LL_GetModelID;
+        transport_cb->get_model_id_cb = IoTHubClientCore_LL_GetModelID;
         result = 0;
     }
     return result;

--- a/iothub_client/src/iothub_client_core_ll.c
+++ b/iothub_client/src/iothub_client_core_ll.c
@@ -615,7 +615,7 @@ static const char* IoTHubClientCore_LL_GetProductInfo(void* ctx)
     return result;
 }
 
-static const char* IoTHubClientCore_LL_GetModelID(void* ctx)
+static const char* IoTHubClientCore_LL_GetModelId(void* ctx)
 {
     const char* result;
     if (ctx == NULL)
@@ -844,7 +844,7 @@ static IOTHUB_CLIENT_CORE_LL_HANDLE_DATA* initialize_iothub_client(const IOTHUB_
             transport_cb.msg_input_cb = IoTHubClientCore_LL_MessageCallbackFromInput;
             transport_cb.msg_cb = IoTHubClientCore_LL_MessageCallback;
             transport_cb.method_complete_cb = IoTHubClientCore_LL_DeviceMethodComplete;
-            transport_cb.get_model_id_cb = IoTHubClientCore_LL_GetModelID;
+            transport_cb.get_model_id_cb = IoTHubClientCore_LL_GetModelId;
 
             if (client_config != NULL)
             {
@@ -3009,7 +3009,7 @@ int IoTHubClientCore_LL_GetTransportCallbacks(TRANSPORT_CALLBACKS_INFO* transpor
         transport_cb->msg_input_cb = IoTHubClientCore_LL_MessageCallbackFromInput;
         transport_cb->msg_cb = IoTHubClientCore_LL_MessageCallback;
         transport_cb->method_complete_cb = IoTHubClientCore_LL_DeviceMethodComplete;
-        transport_cb->get_model_id_cb = IoTHubClientCore_LL_GetModelID;
+        transport_cb->get_model_id_cb = IoTHubClientCore_LL_GetModelId;
         result = 0;
     }
     return result;

--- a/iothub_client/src/iothub_client_core_ll.c
+++ b/iothub_client/src/iothub_client_core_ll.c
@@ -2346,7 +2346,7 @@ IOTHUB_CLIENT_RESULT IoTHubClientCore_LL_SetOption(IOTHUB_CLIENT_CORE_LL_HANDLE 
             } 
             else if ((handleData->model_id = STRING_construct((const char*)value)) == NULL)
             {
-                LogError("STRING_c_str failed");
+                LogError("STRING_construct failed");
                 result = IOTHUB_CLIENT_ERROR;
             }
             else

--- a/iothub_client/src/iothubtransport_mqtt_common.c
+++ b/iothub_client/src/iothubtransport_mqtt_common.c
@@ -2479,7 +2479,8 @@ static int InitializeConnection(PMQTTTRANSPORT_HANDLE_DATA transport_data)
 }
 
 // At handle creation time, we don't have all the fields required for building up the user name (e.g. productID)
-// Build what we can (instead of making separate copies of the passed fields) for now.
+// We build up as much of the string as we can at this point because we do not store upperConfig after initialization.
+// In buildConfigForUsernameStep2IfNeeded, only immediately before we do CONNECT itself, do we complete building up this string.
 static STRING_HANDLE buildConfigForUsernameStep1(const IOTHUB_CLIENT_CONFIG* upperConfig, const char* moduleId)
 {
     if (moduleId == NULL)

--- a/iothub_client/src/iothubtransport_mqtt_common.c
+++ b/iothub_client/src/iothubtransport_mqtt_common.c
@@ -91,6 +91,10 @@ static const char* CONNECTION_MODULE_ID_PROPERTY = "cmid";
 
 static const char* DIAGNOSTIC_CONTEXT_CREATION_TIME_UTC_PROPERTY = "creationtimeutc";
 
+static const char DT_MODEL_ID_TOKEN[] = "digital-twin-model-id";
+
+static const char DEFAULT_IOTHUB_PRODUCT_IDENTIFIER[] = CLIENT_DEVICE_TYPE_PREFIX "/" IOTHUB_SDK_VERSION;
+
 #define TOLOWER(c) (((c>='A') && (c<='Z'))?c-'A'+'a':c)
 
 #define UNSUBSCRIBE_FROM_TOPIC                  0x0000
@@ -236,7 +240,7 @@ typedef struct MQTTTRANSPORT_HANDLE_DATA_TAG
     int http_proxy_port;
     char* http_proxy_username;
     char* http_proxy_password;
-    bool isProductInfoSet;
+    bool isConnectParamaterSet;
     int disconnect_recv_flag;
 } MQTTTRANSPORT_HANDLE_DATA, *PMQTTTRANSPORT_HANDLE_DATA;
 
@@ -418,6 +422,7 @@ static const char* retrieve_mqtt_return_codes(CONNECT_RETURN_CODE rtn_code)
 static int retrieve_device_method_rid_info(const char* resp_topic, STRING_HANDLE method_name, STRING_HANDLE request_id)
 {
     int result;
+
     STRING_TOKENIZER_HANDLE token_handle = STRING_TOKENIZER_create_from_char(resp_topic);
     if (token_handle == NULL)
     {
@@ -474,6 +479,7 @@ static int retrieve_device_method_rid_info(const char* resp_topic, STRING_HANDLE
         }
         STRING_TOKENIZER_destroy(token_handle);
     }
+
     return result;
 }
 
@@ -2172,6 +2178,80 @@ static STRING_HANDLE buildClientId(const char* device_id, const char* module_id)
     }
 }
 
+static int appendConnectParameters(PMQTTTRANSPORT_HANDLE_DATA transport_data)
+{
+    int result;
+
+    if (!transport_data->isConnectParamaterSet)
+    {
+        STRING_HANDLE versionAndClientType = NULL;
+        STRING_HANDLE modelIdParameter = NULL;
+        STRING_HANDLE urlEncodedModelId = NULL;
+        const char* dtModelId = transport_data->transport_callbacks.dt_get_model_id_cb(transport_data->transport_ctx);
+        // TODO: The preview API version in SDK is only scoped to scenarios that require the modelId to be set.
+        // https://github.com/Azure/azure-iot-sdk-c/issues/1547 tracks removing this once non-preview API versions support modelId.
+        const char* apiVersion = (dtModelId != NULL) ? IOTHUB_API_PREVIEW_VERSION : IOTHUB_API_VERSION;
+        const char* appSpecifiedProductInfo = transport_data->transport_callbacks.prod_info_cb(transport_data->transport_ctx);
+        STRING_HANDLE productInfoEncoded = NULL; 
+
+        if ((productInfoEncoded = URL_EncodeString((appSpecifiedProductInfo != NULL) ? appSpecifiedProductInfo : DEFAULT_IOTHUB_PRODUCT_IDENTIFIER)) == NULL)
+        {
+            LogError("Unable to UrlEncode productInfo");
+            result = MU_FAILURE;
+        }
+        else if ((versionAndClientType = STRING_construct_sprintf("?api-version=%s&DeviceClientType=%s", apiVersion, STRING_c_str(productInfoEncoded))) == NULL)
+        {
+            LogError("Failed constructing string");
+            result = 0;
+        }
+        else if (STRING_concat_with_STRING(transport_data->configPassedThroughUsername, versionAndClientType) != 0)
+        {
+            LogError("Failed concatenating the product info");
+            result = 0;
+        }           
+        else if (dtModelId != NULL)
+        {
+            if ((urlEncodedModelId = URL_EncodeString(dtModelId)) == NULL)
+            {
+                LogError("Failed to URL encode the modelID string");
+                result = MU_FAILURE;
+            }
+            else if ((modelIdParameter = STRING_construct_sprintf("&%s=%s", DT_MODEL_ID_TOKEN, STRING_c_str(urlEncodedModelId))) == NULL)
+            {
+                LogError("Cannot build modelID string");
+                result = MU_FAILURE;
+            }
+            else if (STRING_concat_with_STRING(transport_data->configPassedThroughUsername, modelIdParameter) != 0)
+            {
+                LogError("Failed to set modelID parameter in connect");
+                result = MU_FAILURE;
+            }
+            else
+            {
+                result = 0;
+            }
+        }
+        else
+        {
+            result = 0;
+        }
+
+        // setting optional connect parameter is only allowed once in the lifetime of the device client.
+        transport_data->isConnectParamaterSet = true;
+
+        STRING_delete(versionAndClientType);
+        STRING_delete(modelIdParameter);
+        STRING_delete(urlEncodedModelId);
+        STRING_delete(productInfoEncoded);
+    }
+    else
+    {
+        result = 0;
+    }
+
+    return result;
+}
+
 static int SendMqttConnectMsg(PMQTTTRANSPORT_HANDLE_DATA transport_data)
 {
     int result;
@@ -2215,47 +2295,13 @@ static int SendMqttConnectMsg(PMQTTTRANSPORT_HANDLE_DATA transport_data)
 
     if (result == 0)
     {
-        if (!transport_data->isProductInfoSet)
-        {
-            // This requires the iothubClientHandle, which sadly the MQTT transport only gets on DoWork, so this code still needs to remain here.
-            // The correct place for this would be in the Create method, but we don't get the client handle there.
-            // Also, when device multiplexing is used, the customer creates the transport directly and explicitly, when the client is still not created.
-            // This will be a major hurdle when we add device multiplexing to MQTT transport.
-
-            STRING_HANDLE clone;
-            const char* product_info = transport_data->transport_callbacks.prod_info_cb(transport_data->transport_ctx);
-            if (product_info == NULL)
-            {
-                clone = STRING_construct_sprintf("%s%%2F%s", CLIENT_DEVICE_TYPE_PREFIX, IOTHUB_SDK_VERSION);
-            }
-            else
-            {
-                clone = URL_EncodeString(product_info);
-            }
-
-            if (clone == NULL)
-            {
-                LogError("Failed obtaining the product info");
-            }
-            else
-            {
-                if (STRING_concat_with_STRING(transport_data->configPassedThroughUsername, clone) != 0)
-                {
-                    LogError("Failed concatenating the product info");
-                }
-                else
-                {
-                    transport_data->isProductInfoSet = true;
-                }
-
-                STRING_delete(clone);
-            }
-        }
-
         STRING_HANDLE clientId;
-
-        clientId = buildClientId(STRING_c_str(transport_data->device_id), STRING_c_str(transport_data->module_id));
-        if (NULL == clientId)
+        if (appendConnectParameters(transport_data) != 0)
+        {
+            LogError("Failed to add optional connect parameters.");
+            result = MU_FAILURE;
+        }
+        else if ((clientId = buildClientId(STRING_c_str(transport_data->device_id), STRING_c_str(transport_data->module_id))) == NULL)
         {
             LogError("Unable to allocate clientId");
             result = MU_FAILURE;
@@ -2301,7 +2347,6 @@ static int SendMqttConnectMsg(PMQTTTRANSPORT_HANDLE_DATA transport_data)
             }
             STRING_delete(clientId);
         }
-
     }
     return result;
 }
@@ -2436,11 +2481,11 @@ static STRING_HANDLE buildConfigForUsername(const IOTHUB_CLIENT_CONFIG* upperCon
 {
     if (moduleId == NULL)
     {
-        return STRING_construct_sprintf("%s.%s/%s/?api-version=%s&DeviceClientType=", upperConfig->iotHubName, upperConfig->iotHubSuffix, upperConfig->deviceId, IOTHUB_API_VERSION);
+        return STRING_construct_sprintf("%s.%s/%s/", upperConfig->iotHubName, upperConfig->iotHubSuffix, upperConfig->deviceId);
     }
     else
     {
-        return STRING_construct_sprintf("%s.%s/%s/%s/?api-version=%s&DeviceClientType=", upperConfig->iotHubName, upperConfig->iotHubSuffix, upperConfig->deviceId, moduleId, IOTHUB_API_VERSION);
+        return STRING_construct_sprintf("%s.%s/%s/%s/", upperConfig->iotHubName, upperConfig->iotHubSuffix, upperConfig->deviceId, moduleId);
     }
 }
 
@@ -2528,7 +2573,7 @@ static PMQTTTRANSPORT_HANDLE_DATA InitializeTransportHandleData(const IOTHUB_CLI
                 }
                 else
                 {
-                    /* Codes_SRS_IOTHUB_MQTT_TRANSPORT_07_008: [If the upperConfig contains a valid protocolGatewayHostName value the this shall be used for the hostname, otherwise the hostname shall be constructed using the iothubname and iothubSuffix.] */
+                    /* Codes_SRS_IOTHUB_MQTT_TRANSPORT_07_008: [If the upperConfig contains a valid protocolGatewayHostName value this shall be used for the hostname, otherwise the hostname shall be constructed using the iothubname and iothubSuffix.] */
                     if (upperConfig->protocolGatewayHostName == NULL)
                     {
                         state->hostAddress = STRING_construct_sprintf("%s.%s", upperConfig->iotHubName, upperConfig->iotHubSuffix);
@@ -2580,7 +2625,7 @@ static PMQTTTRANSPORT_HANDLE_DATA InitializeTransportHandleData(const IOTHUB_CLI
                         state->topic_DeviceMethods = NULL;
                         state->topic_InputQueue = NULL;
                         state->log_trace = state->raw_trace = false;
-                        state->isProductInfoSet = false;
+                        state->isConnectParamaterSet = false;
                         state->auto_url_encode_decode = false;
                         state->conn_attempted = false;
                     }

--- a/iothub_client/src/iothubtransport_mqtt_common.c
+++ b/iothub_client/src/iothubtransport_mqtt_common.c
@@ -2187,10 +2187,10 @@ static int appendConnectParameters(PMQTTTRANSPORT_HANDLE_DATA transport_data)
         STRING_HANDLE versionAndClientType = NULL;
         STRING_HANDLE modelIdParameter = NULL;
         STRING_HANDLE urlEncodedModelId = NULL;
-        const char* dtModelId = transport_data->transport_callbacks.dt_get_model_id_cb(transport_data->transport_ctx);
+        const char* modelId = transport_data->transport_callbacks.get_model_id_cb(transport_data->transport_ctx);
         // TODO: The preview API version in SDK is only scoped to scenarios that require the modelId to be set.
         // https://github.com/Azure/azure-iot-sdk-c/issues/1547 tracks removing this once non-preview API versions support modelId.
-        const char* apiVersion = (dtModelId != NULL) ? IOTHUB_API_PREVIEW_VERSION : IOTHUB_API_VERSION;
+        const char* apiVersion = (modelId != NULL) ? IOTHUB_API_PREVIEW_VERSION : IOTHUB_API_VERSION;
         const char* appSpecifiedProductInfo = transport_data->transport_callbacks.prod_info_cb(transport_data->transport_ctx);
         STRING_HANDLE productInfoEncoded = NULL; 
 
@@ -2209,9 +2209,9 @@ static int appendConnectParameters(PMQTTTRANSPORT_HANDLE_DATA transport_data)
             LogError("Failed concatenating the product info");
             result = 0;
         }           
-        else if (dtModelId != NULL)
+        else if (modelId != NULL)
         {
-            if ((urlEncodedModelId = URL_EncodeString(dtModelId)) == NULL)
+            if ((urlEncodedModelId = URL_EncodeString(modelId)) == NULL)
             {
                 LogError("Failed to URL encode the modelID string");
                 result = MU_FAILURE;

--- a/iothub_client/tests/iothubclientcore_ll_ut/iothub_client_core_ll_ut.c
+++ b/iothub_client/tests/iothubclientcore_ll_ut/iothub_client_core_ll_ut.c
@@ -5544,7 +5544,7 @@ TEST_FUNCTION(IoTHubClientCore_LL_SetOption_model_id_succeeds)
     STRICT_EXPECTED_CALL(STRING_construct(IGNORED_PTR_ARG));
 
     //act
-    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_MODEL_ID, "dtmi:YOUR_COMPANY_NAME_HERE:sample_device:1");
+    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_MODEL_ID, "dtmi:YOUR_COMPANY_NAME_HERE:sample_device;1");
 
     //assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);

--- a/iothub_client/tests/iothubclientcore_ll_ut/iothub_client_core_ll_ut.c
+++ b/iothub_client/tests/iothubclientcore_ll_ut/iothub_client_core_ll_ut.c
@@ -120,7 +120,7 @@ MOCKABLE_FUNCTION(, const char*, Transport_GetOption_Product_Info_Callback, void
 MOCKABLE_FUNCTION(, void, Transport_Twin_ReportedStateComplete_Callback, uint32_t, item_id, int, status_code, void*, ctx);
 MOCKABLE_FUNCTION(, void, Transport_Twin_RetrievePropertyComplete_Callback, DEVICE_TWIN_UPDATE_STATE, update_state, const unsigned char*, payLoad, size_t, size, void*, ctx);
 MOCKABLE_FUNCTION(, int, Transport_DeviceMethod_Complete_Callback, const char*, method_name, const unsigned char*, payLoad, size_t, size, METHOD_HANDLE, response_id, void*, ctx);
-MOCKABLE_FUNCTION(, const char*, Transport_GetOPTION_MODEL_ID_Callback, void*, ctx);
+MOCKABLE_FUNCTION(, const char*, Transport_GetOption_Model_Id_Callback, void*, ctx);
 
 static int bool_Compare(bool left, bool right)
 {
@@ -5536,7 +5536,7 @@ TEST_FUNCTION(IoTHubClientCore_LL_SetOption_product_info_fails_case1)
     IoTHubClientCore_LL_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClientCore_LL_SetOption_MODEL_ID_succeeds)
+TEST_FUNCTION(IoTHubClientCore_LL_SetOption_model_id_succeeds)
 {
     //arrange
     IOTHUB_CLIENT_CORE_LL_HANDLE h = IoTHubClientCore_LL_Create(&TEST_CONFIG);
@@ -5544,7 +5544,7 @@ TEST_FUNCTION(IoTHubClientCore_LL_SetOption_MODEL_ID_succeeds)
     STRICT_EXPECTED_CALL(STRING_construct(IGNORED_PTR_ARG));
 
     //act
-    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:1");
+    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_MODEL_ID, "dtmi:YOUR_COMPANY_NAME_HERE:sample_device:1");
 
     //assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -5554,7 +5554,7 @@ TEST_FUNCTION(IoTHubClientCore_LL_SetOption_MODEL_ID_succeeds)
     IoTHubClientCore_LL_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClientCore_LL_SetOption_MODEL_ID_string_construct_fails)
+TEST_FUNCTION(IoTHubClientCore_LL_SetOption_model_id_string_construct_fails)
 {
     //arrange
     IOTHUB_CLIENT_CORE_LL_HANDLE h = IoTHubClientCore_LL_Create(&TEST_CONFIG);
@@ -5563,7 +5563,7 @@ TEST_FUNCTION(IoTHubClientCore_LL_SetOption_MODEL_ID_string_construct_fails)
 
     //act
     g_fail_string_construct = true;
-    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:1");
+    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_MODEL_ID, "dtmi:YOUR_COMPANY_NAME_HERE:sample_device;1");
 
     //assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_ERROR, result);
@@ -5573,17 +5573,17 @@ TEST_FUNCTION(IoTHubClientCore_LL_SetOption_MODEL_ID_string_construct_fails)
     IoTHubClientCore_LL_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClientCore_LL_SetOption_MODEL_ID_twice_fails)
+TEST_FUNCTION(IoTHubClientCore_LL_SetOption_model_id_twice_fails)
 {
     //arrange
     IOTHUB_CLIENT_CORE_LL_HANDLE h = IoTHubClientCore_LL_Create(&TEST_CONFIG);
     umock_c_reset_all_calls();
     STRICT_EXPECTED_CALL(STRING_construct(IGNORED_PTR_ARG));
-    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:1");
+    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_MODEL_ID, "dtmi:YOUR_COMPANY_NAME_HERE:sample_device;1");
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
 
     //act
-    result = IoTHubClientCore_LL_SetOption(h, OPTION_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:2");
+    result = IoTHubClientCore_LL_SetOption(h, OPTION_MODEL_ID, "dtmi:YOUR_COMPANY_NAME_HERE:sample_device;2");
 
     //assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_ERROR, result);

--- a/iothub_client/tests/iothubclientcore_ll_ut/iothub_client_core_ll_ut.c
+++ b/iothub_client/tests/iothubclientcore_ll_ut/iothub_client_core_ll_ut.c
@@ -45,7 +45,7 @@ void* my_gballoc_realloc(void* ptr, size_t size)
 #include "azure_c_shared_utility/constbuffer.h"
 #include "azure_c_shared_utility/platform.h"
 #include "azure_c_shared_utility/envvariable.h"
-
+#include "azure_c_shared_utility/urlencode.h"
 
 #include "iothub_client_version.h"
 #include "iothub_message.h"
@@ -120,6 +120,7 @@ MOCKABLE_FUNCTION(, const char*, Transport_GetOption_Product_Info_Callback, void
 MOCKABLE_FUNCTION(, void, Transport_Twin_ReportedStateComplete_Callback, uint32_t, item_id, int, status_code, void*, ctx);
 MOCKABLE_FUNCTION(, void, Transport_Twin_RetrievePropertyComplete_Callback, DEVICE_TWIN_UPDATE_STATE, update_state, const unsigned char*, payLoad, size_t, size, void*, ctx);
 MOCKABLE_FUNCTION(, int, Transport_DeviceMethod_Complete_Callback, const char*, method_name, const unsigned char*, payLoad, size_t, size, METHOD_HANDLE, response_id, void*, ctx);
+MOCKABLE_FUNCTION(, const char*, Transport_GetOPTION_DT_MODEL_ID_Callback, void*, ctx);
 
 static int bool_Compare(bool left, bool right)
 {
@@ -178,6 +179,7 @@ static TEST_MUTEX_HANDLE test_serialize_mutex;
 bool g_fail_string_construct_sprintf;
 bool g_fail_platform_get_platform_info;
 bool g_fail_string_concat_with_string;
+bool g_fail_string_construct;
 
 static const char* TEST_STRING_VALUE = "Test string value";
 
@@ -361,7 +363,16 @@ static STRING_HANDLE my_STRING_new(void)
 static STRING_HANDLE my_STRING_construct(const char* psz)
 {
     (void)psz;
-    return (STRING_HANDLE)my_gballoc_malloc(1);
+    STRING_HANDLE result;
+    if (g_fail_string_construct)
+    {
+        result = (STRING_HANDLE)NULL;
+    }
+    else
+    {
+        result = (STRING_HANDLE)my_gballoc_malloc(1);
+    }
+    return result;
 }
 
 STRING_HANDLE STRING_construct_sprintf(const char* psz, ...)
@@ -958,6 +969,7 @@ TEST_FUNCTION_INITIALIZE(method_init)
     g_fail_string_construct_sprintf = false;
     g_fail_platform_get_platform_info = false;
     g_fail_string_concat_with_string = false;
+    g_fail_string_construct = false;
 
     g_transport_cb_ctx = NULL;
     memset(&g_transport_cb_info, 0, sizeof(TRANSPORT_CALLBACKS_INFO));
@@ -2121,6 +2133,7 @@ TEST_FUNCTION(IoTHubClientCore_LL_Destroys_the_underlying_transport_succeeds)
 #endif
 
     STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
     //act
@@ -2157,8 +2170,8 @@ TEST_FUNCTION(IoTHubClientCore_LL_Destroys_unregisters_but_does_not_destroy_tran
 #endif
 
     STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-
 
     //act
     IoTHubClientCore_LL_Destroy(handle);
@@ -2273,6 +2286,7 @@ TEST_FUNCTION(IoTHubClientCore_LL_Destroy_after_sendEvent_succeeds)
     STRICT_EXPECTED_CALL(IoTHubClient_EdgeHandle_Destroy(IGNORED_PTR_ARG));
 #endif
 
+    STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 
@@ -5513,6 +5527,63 @@ TEST_FUNCTION(IoTHubClientCore_LL_SetOption_product_info_fails_case1)
     //act
     g_fail_string_construct_sprintf = true;
     IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_PRODUCT_INFO, "Eight");
+
+    //assert
+    ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_ERROR, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    //cleanup
+    IoTHubClientCore_LL_Destroy(h);
+}
+
+TEST_FUNCTION(IoTHubClientCore_LL_SetOption_DT_MODEL_ID_succeeds)
+{
+    //arrange
+    IOTHUB_CLIENT_CORE_LL_HANDLE h = IoTHubClientCore_LL_Create(&TEST_CONFIG);
+    umock_c_reset_all_calls();
+    STRICT_EXPECTED_CALL(STRING_construct(IGNORED_PTR_ARG));
+
+    //act
+    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_DT_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:1");
+
+    //assert
+    ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    //cleanup
+    IoTHubClientCore_LL_Destroy(h);
+}
+
+TEST_FUNCTION(IoTHubClientCore_LL_SetOption_DT_MODEL_ID_string_construct_fails)
+{
+    //arrange
+    IOTHUB_CLIENT_CORE_LL_HANDLE h = IoTHubClientCore_LL_Create(&TEST_CONFIG);
+    umock_c_reset_all_calls();
+    STRICT_EXPECTED_CALL(STRING_construct(IGNORED_PTR_ARG));
+
+    //act
+    g_fail_string_construct = true;
+    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_DT_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:1");
+
+    //assert
+    ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_ERROR, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    //cleanup
+    IoTHubClientCore_LL_Destroy(h);
+}
+
+TEST_FUNCTION(IoTHubClientCore_LL_SetOption_DT_MODEL_ID_twice_fails)
+{
+    //arrange
+    IOTHUB_CLIENT_CORE_LL_HANDLE h = IoTHubClientCore_LL_Create(&TEST_CONFIG);
+    umock_c_reset_all_calls();
+    STRICT_EXPECTED_CALL(STRING_construct(IGNORED_PTR_ARG));
+    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_DT_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:1");
+    ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
+
+    //act
+    result = IoTHubClientCore_LL_SetOption(h, OPTION_DT_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:2");
 
     //assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_ERROR, result);

--- a/iothub_client/tests/iothubclientcore_ll_ut/iothub_client_core_ll_ut.c
+++ b/iothub_client/tests/iothubclientcore_ll_ut/iothub_client_core_ll_ut.c
@@ -120,7 +120,7 @@ MOCKABLE_FUNCTION(, const char*, Transport_GetOption_Product_Info_Callback, void
 MOCKABLE_FUNCTION(, void, Transport_Twin_ReportedStateComplete_Callback, uint32_t, item_id, int, status_code, void*, ctx);
 MOCKABLE_FUNCTION(, void, Transport_Twin_RetrievePropertyComplete_Callback, DEVICE_TWIN_UPDATE_STATE, update_state, const unsigned char*, payLoad, size_t, size, void*, ctx);
 MOCKABLE_FUNCTION(, int, Transport_DeviceMethod_Complete_Callback, const char*, method_name, const unsigned char*, payLoad, size_t, size, METHOD_HANDLE, response_id, void*, ctx);
-MOCKABLE_FUNCTION(, const char*, Transport_GetOPTION_DT_MODEL_ID_Callback, void*, ctx);
+MOCKABLE_FUNCTION(, const char*, Transport_GetOPTION_MODEL_ID_Callback, void*, ctx);
 
 static int bool_Compare(bool left, bool right)
 {
@@ -5536,7 +5536,7 @@ TEST_FUNCTION(IoTHubClientCore_LL_SetOption_product_info_fails_case1)
     IoTHubClientCore_LL_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClientCore_LL_SetOption_DT_MODEL_ID_succeeds)
+TEST_FUNCTION(IoTHubClientCore_LL_SetOption_MODEL_ID_succeeds)
 {
     //arrange
     IOTHUB_CLIENT_CORE_LL_HANDLE h = IoTHubClientCore_LL_Create(&TEST_CONFIG);
@@ -5544,7 +5544,7 @@ TEST_FUNCTION(IoTHubClientCore_LL_SetOption_DT_MODEL_ID_succeeds)
     STRICT_EXPECTED_CALL(STRING_construct(IGNORED_PTR_ARG));
 
     //act
-    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_DT_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:1");
+    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:1");
 
     //assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -5554,7 +5554,7 @@ TEST_FUNCTION(IoTHubClientCore_LL_SetOption_DT_MODEL_ID_succeeds)
     IoTHubClientCore_LL_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClientCore_LL_SetOption_DT_MODEL_ID_string_construct_fails)
+TEST_FUNCTION(IoTHubClientCore_LL_SetOption_MODEL_ID_string_construct_fails)
 {
     //arrange
     IOTHUB_CLIENT_CORE_LL_HANDLE h = IoTHubClientCore_LL_Create(&TEST_CONFIG);
@@ -5563,7 +5563,7 @@ TEST_FUNCTION(IoTHubClientCore_LL_SetOption_DT_MODEL_ID_string_construct_fails)
 
     //act
     g_fail_string_construct = true;
-    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_DT_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:1");
+    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:1");
 
     //assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_ERROR, result);
@@ -5573,17 +5573,17 @@ TEST_FUNCTION(IoTHubClientCore_LL_SetOption_DT_MODEL_ID_string_construct_fails)
     IoTHubClientCore_LL_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClientCore_LL_SetOption_DT_MODEL_ID_twice_fails)
+TEST_FUNCTION(IoTHubClientCore_LL_SetOption_MODEL_ID_twice_fails)
 {
     //arrange
     IOTHUB_CLIENT_CORE_LL_HANDLE h = IoTHubClientCore_LL_Create(&TEST_CONFIG);
     umock_c_reset_all_calls();
     STRICT_EXPECTED_CALL(STRING_construct(IGNORED_PTR_ARG));
-    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_DT_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:1");
+    IOTHUB_CLIENT_RESULT result = IoTHubClientCore_LL_SetOption(h, OPTION_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:1");
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
 
     //act
-    result = IoTHubClientCore_LL_SetOption(h, OPTION_DT_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:2");
+    result = IoTHubClientCore_LL_SetOption(h, OPTION_MODEL_ID, "urn:YOUR_COMPANY_NAME_HERE:sample_device:2");
 
     //assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_ERROR, result);

--- a/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
+++ b/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
@@ -76,7 +76,7 @@ MOCKABLE_FUNCTION(, const char*, Transport_GetOption_Product_Info_Callback, void
 MOCKABLE_FUNCTION(, void, Transport_Twin_ReportedStateComplete_Callback, uint32_t, item_id, int, status_code, void*, ctx);
 MOCKABLE_FUNCTION(, void, Transport_Twin_RetrievePropertyComplete_Callback, DEVICE_TWIN_UPDATE_STATE, update_state, const unsigned char*, payLoad, size_t, size, void*, ctx);
 MOCKABLE_FUNCTION(, int, Transport_DeviceMethod_Complete_Callback, const char*, method_name, const unsigned char*, payLoad, size_t, size, METHOD_HANDLE, response_id, void*, ctx);
-MOCKABLE_FUNCTION(, const char*, Transport_GetOption_MODEL_ID_Callback, void*, ctx);
+MOCKABLE_FUNCTION(, const char*, Transport_GetOption_Model_Id_Callback, void*, ctx);
 
 #undef ENABLE_MOCKS
 
@@ -151,7 +151,7 @@ static const char* my_Transport_GetOption_Product_Info_Callback(void* ctx)
     return "product_info";
 }
 
-static const char* my_Transport_GetOption_MODEL_ID_Callback(void* ctx)
+static const char* my_Transport_GetOption_Model_Id_Callback(void* ctx)
 {
     (void)ctx;
     return "dtmi:testDeviceCapabilityModel;1";
@@ -717,7 +717,7 @@ TEST_SUITE_INITIALIZE(suite_init)
     transport_cb_info.msg_input_cb = Transport_MessageCallbackFromInput;
     transport_cb_info.msg_cb = Transport_MessageCallback;
     transport_cb_info.method_complete_cb = Transport_DeviceMethod_Complete_Callback;
-    transport_cb_info.get_model_id_cb = Transport_GetOption_MODEL_ID_Callback;
+    transport_cb_info.get_model_id_cb = Transport_GetOption_Model_Id_Callback;
 
     g_cbuff.buffer = appMessage;
     g_cbuff.size = appMsgSize;
@@ -796,8 +796,8 @@ TEST_SUITE_INITIALIZE(suite_init)
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(URL_DecodeString, NULL);
     REGISTER_GLOBAL_MOCK_HOOK(Transport_GetOption_Product_Info_Callback, my_Transport_GetOption_Product_Info_Callback);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(Transport_GetOption_Product_Info_Callback, NULL);
-    REGISTER_GLOBAL_MOCK_HOOK(Transport_GetOption_MODEL_ID_Callback, my_Transport_GetOption_MODEL_ID_Callback);
-    REGISTER_GLOBAL_MOCK_FAIL_RETURN(Transport_GetOption_MODEL_ID_Callback, NULL);
+    REGISTER_GLOBAL_MOCK_HOOK(Transport_GetOption_Model_Id_Callback, my_Transport_GetOption_Model_Id_Callback);
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(Transport_GetOption_Model_Id_Callback, NULL);
 
     REGISTER_GLOBAL_MOCK_RETURN(IoTHub_Transport_ValidateCallbacks, 0);
     REGISTER_GLOBAL_MOCK_FAIL_RETURN(IoTHub_Transport_ValidateCallbacks, __LINE__);
@@ -1212,11 +1212,11 @@ static void setup_initialize_connection_mocks(bool useModelId)
     STRICT_EXPECTED_CALL(IoTHubClient_Auth_Get_Credential_Type(IGNORED_PTR_ARG));
     EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)).SetReturn(TEST_STRING_VALUE);
     STRICT_EXPECTED_CALL(IoTHubClient_Auth_Get_SasToken(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_NUM_ARG, IGNORED_PTR_ARG));
-    STRICT_EXPECTED_CALL(Transport_GetOption_MODEL_ID_Callback(IGNORED_PTR_ARG)).SetReturn(useModelId ? TEST_STRING_VALUE : NULL);
+    STRICT_EXPECTED_CALL(Transport_GetOption_Model_Id_Callback(IGNORED_PTR_ARG)).SetReturn(useModelId ? TEST_STRING_VALUE : NULL);
     STRICT_EXPECTED_CALL(Transport_GetOption_Product_Info_Callback(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(URL_EncodeString(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG));
-    STRICT_EXPECTED_CALL(STRING_concat_with_STRING(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG));
 
     if (useModelId)
     {
@@ -1224,7 +1224,8 @@ static void setup_initialize_connection_mocks(bool useModelId)
         EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)).SetReturn(TEST_STRING_VALUE);
         STRICT_EXPECTED_CALL(STRING_concat_with_STRING(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
     }
-    
+
+    STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG)).IgnoreArgument_handle();
     STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG)).IgnoreArgument_handle();
     STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG)).IgnoreArgument_handle();
     STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG)).IgnoreArgument_handle();


### PR DESCRIPTION
In order to support applications building PnP / DigitalTwin clients on the `master` IoTHub API, we need to let them specify their modelId for the MQTT CONNECT packet, which lives in the userName field.  

This is done via a `DeviceClient_SetOption(handle, OPTION_MODEL_ID, "dtmi:...");`.  It must be specified prior to the first CONNECT, since trying to add this or allow it to be changed later will considerably complicate the state management.  The only time a modelId will change on a given device/module identity in practice is during firmware updates in any case, which implies a new handle in any case.

The modelID parsing feature requires an API version which is still in preview and not deployed worldwide.  To account for this, we will use a preview API version if modelId has been specified and otherwise use the existing model ID.  This API version split is not long-term desirable; #1547 tracks fixing.

Note that this change is MQTT(_WS) only, per decision to only support C device SDK with PnP over MQTT(_WS).