### PR TITLE
Remove asychronous commands

### DIFF
--- a/digitaltwin_client/doc/data_format.md
+++ b/digitaltwin_client/doc/data_format.md
@@ -5,7 +5,6 @@ All Digital Twin data payloads are currently based on JSON.  In particular, this
 * Telemetry messages
 * Reporting property values
 * Setting a response message when processing a command
-* Setting a payload when sending an asynchronous command update
 
 **Not sending valid JSON or JSON that does not match the model defined will result in potentially very hard to diagnose problems for server backend developers.  Your application may not be notified it has sent bad content in most cases.**  Issues will only be apparent during service application / system integration.
 
@@ -28,4 +27,3 @@ What happens if you do not specify legal JSON depends on which scenario you're u
 * **Telemetry messages** with bad JSON will be successfully ingested by the server.  This means the device application's callback will **NOT** receive an error on sending invalid telemetry.  The JSON is not parsed for validity on ingestion to optimize server, as the amount of traffic it ingests such parsing would be create scaling problems.
 * **Reporting property values** The server does parse the data for this scenario and the device application's callback will receive an error *only* if the JSON is not valid.  If the payload does not match the modeled schema but is legal JSON, then the server will successfully accept the request (which pushes the debugging problem to later).
 * **Setting a response message when processing a command** There is no mechanism for applications to be notified that a command response has been successfully or unsuccessfully processed.  Therefore sending bad JSON will silently fail.
-* **Setting a payload when sending an asynchronous command update** There is no mechanism for applications to be notified that an asynchronous command response has been successfully or unsuccessfully processed.  Therefore sending bad JSON will silently fail.

--- a/digitaltwin_client/doc/interfaces.md
+++ b/digitaltwin_client/doc/interfaces.md
@@ -13,7 +13,7 @@ This document will cover high-level concepts that are C SDK specific.  However i
   * The application may optionally specify a callback function to be invoked when the interface has registered, registration has failed, or its owning device handle has closed it.
 * The application optionally invokes `DigitalTwin_InterfaceClient_SetPropertiesUpdatedCallback` and/or `DigitalTwin_InterfaceClient_SetCommandsCallback`, depending on whether the model that the interface implements supports commands and/or properties.
   * These callback commands **MUST** be invoked prior to the interface handle being registered.  Attempts to set callbacks post-registration will fail.
-* The device application registers this interface by passing the `DIGITALTWIN_INTERFACE_CLIENT_HANDLE` into one of the appropriate [Digital Twin device RegisterInterfacesAsync](./connection_setup.md#Register_Interfaces) commands.
+* The device application registers this interface by passing the `DIGITALTWIN_INTERFACE_CLIENT_HANDLE` into one of the appropriate [Digital Twin device RegisterInterfacesAsync](./connection_setup.md#Register_Interfaces) functions.
 * Interface registration is a network operation which will take time and may fail.  The device application must not attempt any operations - e.g. sending telemetry or reporting properties - until the interface has been registered.  Attempts to do so will fail.
 
 ## Operations after registration
@@ -21,7 +21,7 @@ This document will cover high-level concepts that are C SDK specific.  However i
 * Once the interface registration has been ACK'd by the server, the Digital Twin Device SDK will automatically query for desired properties and invoke the interface's property update callback (if specified in `DigitalTwin_InterfaceClient_SetPropertiesUpdatedCallback`).
 * The Digital Twin SDK will  listen for property changes after the initial property query.  It will route any future property updates to the `DigitalTwin_InterfaceClient_SetPropertiesUpdatedCallback` specified callback.
 * The Digital Twin SDK will listed for incoming commands and invoke the callback specified in `DigitalTwin_InterfaceClient_SetCommandsCallback`, if one was set. 
-* The device application may periodically invoke `DigitalTwin_InterfaceClient_SendTelemetryAsync` and `DigitalTwin_InterfaceClient_ReportPropertyAsync` to report information to the server.  It may also invoke `DigitalTwin_InterfaceClient_UpdateAsyncCommandStatusAsync` to report the status of an asynchronous command.
+* The device application may periodically invoke `DigitalTwin_InterfaceClient_SendTelemetryAsync` and `DigitalTwin_InterfaceClient_ReportPropertyAsync` to report information to the server.
 * When the interface is ready to be shut down, `DigitalTwin_InterfaceClient_Destroy` frees its resources.  
 
 ## No \_LL\_ interface handles

--- a/digitaltwin_client/samples/readme.md
+++ b/digitaltwin_client/samples/readme.md
@@ -10,7 +10,7 @@ This directory contains samples demonstrating creating and using Digital Twin in
 
 ### Directories that build libraries
 * [digitaltwin\_sample\_device_info](./digitaltwin_sample_device_info) - This directory builds the sample device info library.  This is a Digital Twin interface that reports information about the device - such as OS version, amount of storage, etc.
-* [digitaltwin\_sample\_environmental_sensor](./digitaltwin_sample_environmental_sensor) - This directory builds the sample environmental sensor library.  This is a Digital Twin interface  that demonstrates all concepts of implementing a Digital Twin model: commands (synchronous and asynchronous), properties, and telemetry.
+* [digitaltwin\_sample\_environmental_sensor](./digitaltwin_sample_environmental_sensor) - This directory builds the sample environmental sensor library.  This is a Digital Twin interface that demonstrates all concepts of implementing a Digital Twin model: commands, properties, and telemetry.
 
 ## Getting started
 

--- a/digitaltwin_client/src/digitaltwin_client_dll.def
+++ b/digitaltwin_client/src/digitaltwin_client_dll.def
@@ -12,5 +12,4 @@ EXPORTS
     DigitalTwin_InterfaceClient_Create
     DigitalTwin_InterfaceClient_SendTelemetryAsync
     DigitalTwin_InterfaceClient_ReportPropertyAsync
-    DigitalTwin_InterfaceClient_UpdateAsyncCommandStatusAsync
     DigitalTwin_InterfaceClient_Destroy


### PR DESCRIPTION
Support for asynchronous commands is being removed as a top-level construct for PnP devices.  This change removes the functions from PnP to reflect this.