### PR TITLE
Fix measurement unit name in samples

### DIFF
--- a/iothub_client/samples/iothub_convenience_sample/iothub_convenience_sample.c
+++ b/iothub_client/samples/iothub_convenience_sample/iothub_convenience_sample.c
@@ -201,7 +201,7 @@ int main(void)
     IOTHUB_MESSAGE_HANDLE message_handle;
     float telemetry_temperature;
     float telemetry_humidity;
-    const char* telemetry_scale = "Celcius";
+    const char* telemetry_scale = "Celsius";
     char telemetry_msg_buffer[80];
 
     int messagecount = 0;

--- a/samples/dockerbuilds/myapp/iothub_cross_compile_simple_sample.c
+++ b/samples/dockerbuilds/myapp/iothub_cross_compile_simple_sample.c
@@ -50,7 +50,7 @@ int main(void)
     IOTHUB_MESSAGE_HANDLE message_handle;
     float telemetry_temperature;
     float telemetry_humidity;
-    const char* telemetry_scale = "Celcius";
+    const char* telemetry_scale = "Celsius";
     char telemetry_msg_buffer[80];
 
     int messagecount = 0;


### PR DESCRIPTION
Correct temperature scale name is "Celsius".

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [X] This pull-request is submitted against the `master` branch. 
  - [X] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [X] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
The temperature scale name is wrong, in two samples: Celcius.
# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Corrected the temperature scale name to Celsius.