### PR TITLE
Fix message printed in case of connection creation failure

### DIFF
--- a/iothub_client/samples/iotedge_downstream_device_sample/iotedge_downstream_device_sample.c
+++ b/iothub_client/samples/iotedge_downstream_device_sample/iotedge_downstream_device_sample.c
@@ -225,7 +225,7 @@ int main(void)
     device_handle = IoTHubDeviceClient_CreateFromConnectionString(connectionString, protocol);
     if (device_handle == NULL)
     {
-        (void)printf("Failure creating device client handle.  Hint: Check you connection string.\r\n");
+        (void)printf("Failure creating device client handle. Hint: Check your connection string.\r\n");
     }
     else
     {

--- a/iothub_client/samples/iothub_client_sample_upload_to_blob/iothub_client_sample_upload_to_blob.c
+++ b/iothub_client/samples/iothub_client_sample_upload_to_blob/iothub_client_sample_upload_to_blob.c
@@ -48,7 +48,7 @@ int main(void)
     device_ll_handle = IoTHubDeviceClient_LL_CreateFromConnectionString(connectionString, HTTP_Protocol);
     if (device_ll_handle == NULL)
     {
-        (void)printf("Failure createing Iothub device.  Hint: Check you connection string.\r\n");
+        (void)printf("Failure creating IotHub device. Hint: Check your connection string.\r\n");
     }
     else
     {

--- a/iothub_client/samples/iothub_client_sample_upload_to_blob_mb/iothub_client_sample_upload_to_blob_mb.c
+++ b/iothub_client/samples/iothub_client_sample_upload_to_blob_mb/iothub_client_sample_upload_to_blob_mb.c
@@ -90,7 +90,7 @@ int main(void)
     device_ll_handle = IoTHubDeviceClient_LL_CreateFromConnectionString(connectionString, HTTP_Protocol);
     if (device_ll_handle == NULL)
     {
-        (void)printf("Failure createing Iothub device.  Hint: Check you connection string.\r\n");
+        (void)printf("Failure creating IotHub device. Hint: Check your connection string.\r\n");
     }
     else
     {

--- a/iothub_client/samples/iothub_convenience_sample/iothub_convenience_sample.c
+++ b/iothub_client/samples/iothub_convenience_sample/iothub_convenience_sample.c
@@ -235,7 +235,7 @@ int main(void)
     device_handle = IoTHubDeviceClient_CreateFromConnectionString(connectionString, protocol);
     if (device_handle == NULL)
     {
-        (void)printf("Failure creating Iothub device.  Hint: Check you connection string.\r\n");
+        (void)printf("Failure creating IotHub device. Hint: Check your connection string.\r\n");
     }
     else
     {

--- a/iothub_client/samples/iothub_ll_c2d_sample/iothub_ll_c2d_sample.c
+++ b/iothub_client/samples/iothub_ll_c2d_sample/iothub_ll_c2d_sample.c
@@ -139,7 +139,7 @@ int main(void)
     device_ll_handle = IoTHubDeviceClient_LL_CreateFromConnectionString(connectionString, protocol);
     if (device_ll_handle == NULL)
     {
-        (void)printf("Failure createing Iothub device.  Hint: Check you connection string.\r\n");
+        (void)printf("Failure creating IotHub device. Hint: Check your connection string.\r\n");
     }
     else
     {

--- a/iothub_client/samples/iothub_ll_client_x509_sample/iothub_ll_client_x509_sample.c
+++ b/iothub_client/samples/iothub_ll_client_x509_sample/iothub_ll_client_x509_sample.c
@@ -127,7 +127,7 @@ int main(void)
     device_ll_handle = IoTHubDeviceClient_LL_CreateFromConnectionString(connectionString, protocol);
     if (device_ll_handle == NULL)
     {
-        (void)printf("Failure createing Iothub device.  Hint: Check you connection string.\r\n");
+        (void)printf("Failure creating IotHub device. Hint: Check your connection string.\r\n");
     }
     else
     {

--- a/iothub_client/samples/iothub_ll_telemetry_sample/iothub_ll_telemetry_sample.c
+++ b/iothub_client/samples/iothub_ll_telemetry_sample/iothub_ll_telemetry_sample.c
@@ -112,7 +112,7 @@ int main(void)
     device_ll_handle = IoTHubDeviceClient_LL_CreateFromConnectionString(connectionString, protocol);
     if (device_ll_handle == NULL)
     {
-        (void)printf("Failure createing Iothub device.  Hint: Check you connection string.\r\n");
+        (void)printf("Failure creating IotHub device. Hint: Check your connection string.\r\n");
     }
     else
     {

--- a/samples/dockerbuilds/myapp/iothub_cross_compile_simple_sample.c
+++ b/samples/dockerbuilds/myapp/iothub_cross_compile_simple_sample.c
@@ -67,7 +67,7 @@ int main(void)
     device_handle = IoTHubDeviceClient_CreateFromConnectionString(connectionString, protocol);
     if (device_handle == NULL)
     {
-        (void)printf("Failure creating Iothub device.  Hint: Check you connection string.\r\n");
+        (void)printf("Failure creating IotHub device. Hint: Check your connection string.\r\n");
     }
     else
     {

--- a/samples/solutions/remote_monitoring_client/remote_monitoring.c
+++ b/samples/solutions/remote_monitoring_client/remote_monitoring.c
@@ -371,7 +371,7 @@ int main(void)
 	device_handle = IoTHubDeviceClient_CreateFromConnectionString(connectionString, MQTT_Protocol);
 	if (device_handle == NULL)
 	{
-		(void)printf("Failure creating Iothub device.  Hint: Check you connection string.\r\n");
+		(void)printf("Failure creating IotHub device. Hint: Check your connection string.\r\n");
 	}
 	else
 	{


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [X] This pull-request is submitted against the `master` branch. 
  - [X] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [X] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
The message printed in case of connection failure has some typos and double spaces.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Corrected the message in various files.