### PR TITLE
sendPendingGetTwinRequests only after the suback is received

### DIFF
--- a/iothub_client/src/iothubtransport_mqtt_common.c
+++ b/iothub_client/src/iothubtransport_mqtt_common.c
@@ -3220,7 +3220,10 @@ void IoTHubTransport_MQTT_Common_DoWork(TRANSPORT_LL_HANDLE handle)
                     currentListEntry = savedFromCurrentListEntry.Flink;
                 }
 
-                sendPendingGetTwinRequests(transport_data);
+                if (transport_data->twin_resp_sub_recv)
+                {
+                    sendPendingGetTwinRequests(transport_data);
+                }
             }
             /* Codes_SRS_IOTHUB_MQTT_TRANSPORT_07_030: [IoTHubTransport_MQTT_Common_DoWork shall call mqtt_client_dowork everytime it is called if it is connected.] */
             mqtt_client_dowork(transport_data->mqttClient);

--- a/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
+++ b/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
@@ -4009,7 +4009,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_send_get_twin_succeed)
 
     QOS_VALUE QosValue[] = { DELIVER_AT_LEAST_ONCE };
     SUBSCRIBE_ACK suback;
-    suback.packetId = 1234;
+    suback.packetId = 0;
     suback.qosCount = 1;
     suback.qosReturn = QosValue;
 


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 