### PR TITLE
Add DPS sample code to temperature controller and helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,8 @@ endif()
 # Set Provisioning Information.  This will also setup appropriate HSM
 if (${use_prov_client})
     set(use_prov_client_core ON)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_PROV_MODULE_FULL")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_PROV_MODULE_FULL")
     if ("${hsm_custom_lib}" STREQUAL "")
         if ((NOT ${hsm_type_x509}) AND (NOT ${hsm_type_sastoken}) AND (NOT ${hsm_type_symm_key}))
             # If the cmake option did not explicitly configure an hsm type, then enable them all.

--- a/iothub_client/samples/pnp/common/pnp_device_client_helpers.c
+++ b/iothub_client/samples/pnp/common/pnp_device_client_helpers.c
@@ -43,8 +43,8 @@ static IOTHUB_DEVICE_CLIENT_HANDLE AllocateDeviceClientHandle(const PNP_DEVICE_C
         }
     }
 #ifdef USE_PROV_MODULE
-    // DPS functionality is only available if the cmake flag -Duse_prov_client=ON was
-    // enabled when building the Azure IoT C SDK.
+    // DPS functionality using symmetric keys is only available if the cmake 
+    // flags <-Duse_prov_client=ON -Dhsm_type_symm_key=ON> are enabled when building the Azure IoT C SDK.
     else
     {
         if (iothub_security_init(IOTHUB_SECURITY_TYPE_SYMMETRIC_KEY) != 0)

--- a/iothub_client/samples/pnp/common/pnp_device_client_helpers.c
+++ b/iothub_client/samples/pnp/common/pnp_device_client_helpers.c
@@ -9,15 +9,59 @@
 #include "iothub_device_client.h"
 #include "iothub_client_options.h"
 #include "iothubtransportmqtt.h"
+#include "pnp_device_client_helpers.h"
 
 #include "azure_c_shared_utility/xlogging.h"
 
 #ifdef SET_TRUSTED_CERT_IN_SAMPLES
+// For devices that do not have (or want) an OS level trusted certificate store,
+// but instead bring in default trusted certificates from the Azure IoT C SDK.
 #include "azure_c_shared_utility/shared_util_options.h"
 #include "certs.h"
 #endif // SET_TRUSTED_CERT_IN_SAMPLES
 
-IOTHUB_DEVICE_CLIENT_HANDLE PnPHelper_CreateDeviceClientHandle(const char* connectionString, const char* modelId, bool enableTracing, IOTHUB_CLIENT_DEVICE_METHOD_CALLBACK_ASYNC deviceMethodCallback, IOTHUB_CLIENT_DEVICE_TWIN_CALLBACK deviceTwinCallback)
+#ifdef USE_PROV_MODULE
+// DPS related header files
+#include "azure_prov_client/iothub_security_factory.h"
+#include "azure_prov_client/prov_device_ll_client.h"
+#include "azure_prov_client/prov_transport_mqtt_client.h"
+#include "azure_prov_client/prov_security_factory.h"
+#endif // USE_PROV_MODULE
+
+//
+// AllocateDeviceClientHandle does the actual createHandle call, depending on the security type
+//
+static IOTHUB_DEVICE_CLIENT_HANDLE AllocateDeviceClientHandle(const PNP_DEVICE_CONFIGURATION* pnpDeviceConfiguration)
+{
+    IOTHUB_DEVICE_CLIENT_HANDLE deviceHandle = NULL;
+
+    if (pnpDeviceConfiguration->securityType == PNP_CONNECTION_SECURITY_TYPE_CONNECTION_STRING)
+    {
+        if ((deviceHandle = IoTHubDeviceClient_CreateFromConnectionString(pnpDeviceConfiguration->u.connectionString, MQTT_Protocol)) == NULL)
+        {
+            LogError("Failure creating IotHub client.  Hint: Check your connection string");
+        }
+    }
+#ifdef USE_PROV_MODULE
+    // DPS functionality is only available if the cmake flag -Duse_prov_client=ON was
+    // enabled when building the Azure IoT C SDK.
+    else
+    {
+        if (iothub_security_init(IOTHUB_SECURITY_TYPE_SYMMETRIC_KEY) != 0)
+        {
+            LogError("iothub_security_init failed");
+        }
+        else if ((deviceHandle = IoTHubDeviceClient_CreateFromDeviceAuth(pnpDeviceConfiguration->u.dpsConfiguration.iothubUri, pnpDeviceConfiguration->u.dpsConfiguration.deviceId, MQTT_Protocol)) == NULL)
+        {
+            LogError("IoTHubDeviceClient_CreateFromDeviceAuth failed");
+        }
+    }
+#endif /* USE_PROV_MODULE */
+
+    return deviceHandle;
+}
+
+IOTHUB_DEVICE_CLIENT_HANDLE PnPHelper_CreateDeviceClientHandle(const PNP_DEVICE_CONFIGURATION* pnpDeviceConfiguration)
 {
     IOTHUB_DEVICE_CLIENT_HANDLE deviceHandle = NULL;
     IOTHUB_CLIENT_RESULT iothubResult;
@@ -31,14 +75,14 @@ IOTHUB_DEVICE_CLIENT_HANDLE PnPHelper_CreateDeviceClientHandle(const char* conne
         LogError("Failure to initialize client, error=%d", iothubInitResult);
         result = false;
     }
-    // Create the deviceHandle itself.
-    else if ((deviceHandle = IoTHubDeviceClient_CreateFromConnectionString(connectionString, MQTT_Protocol)) == NULL)
+    else if ((deviceHandle = AllocateDeviceClientHandle(pnpDeviceConfiguration)) == NULL)
     {
-        LogError("Failure creating IotHub client.  Hint: Check your connection string");
+        LogError("Unable to allocate deviceHandle");
         result = false;
     }
+
     // Sets verbosity level
-    else if ((iothubResult = IoTHubDeviceClient_SetOption(deviceHandle, OPTION_LOG_TRACE, &enableTracing)) != IOTHUB_CLIENT_OK)
+    else if ((iothubResult = IoTHubDeviceClient_SetOption(deviceHandle, OPTION_LOG_TRACE, &pnpDeviceConfiguration->enableTracing)) != IOTHUB_CLIENT_OK)
     {
         LogError("Unable to set logging option, error=%d", iothubResult);
         result = false;
@@ -46,20 +90,20 @@ IOTHUB_DEVICE_CLIENT_HANDLE PnPHelper_CreateDeviceClientHandle(const char* conne
     // Sets the name of ModelId for this PnP device.
     // This *MUST* be set before the client is connected to IoTHub.  We do not automatically connect when the 
     // handle is created, but will implicitly connect to subscribe for device method and device twin callbacks below.
-    else if ((iothubResult = IoTHubDeviceClient_SetOption(deviceHandle, OPTION_MODEL_ID, modelId)) != IOTHUB_CLIENT_OK)
+    else if ((iothubResult = IoTHubDeviceClient_SetOption(deviceHandle, OPTION_MODEL_ID, pnpDeviceConfiguration->modelId)) != IOTHUB_CLIENT_OK)
     {
         LogError("Unable to set the ModelID, error=%d", iothubResult);
         result = false;
     }
     // Optionally, set the callback function that processes incoming device methods, which is the channel PnP Commands are transferred over
-    else if ((deviceMethodCallback != NULL) && (iothubResult = IoTHubDeviceClient_SetDeviceMethodCallback(deviceHandle, deviceMethodCallback, NULL)) != IOTHUB_CLIENT_OK)
+    else if ((pnpDeviceConfiguration->deviceMethodCallback != NULL) && (iothubResult = IoTHubDeviceClient_SetDeviceMethodCallback(deviceHandle, pnpDeviceConfiguration->deviceMethodCallback, NULL)) != IOTHUB_CLIENT_OK)
     {
         LogError("Unable to set device method callback, error=%d", iothubResult);
         result = false;
     }
     // Optionall, set the callback function that processes device twin changes from the IoTHub, which is the channel that PnP Properties are 
     // transferred over.  This will also automatically retrieve the full twin for the application on startup. 
-    else if ((deviceTwinCallback != NULL) && (iothubResult = IoTHubDeviceClient_SetDeviceTwinCallback(deviceHandle, deviceTwinCallback, (void*)deviceHandle)) != IOTHUB_CLIENT_OK)
+    else if ((pnpDeviceConfiguration->deviceTwinCallback != NULL) && (iothubResult = IoTHubDeviceClient_SetDeviceTwinCallback(deviceHandle, pnpDeviceConfiguration->deviceTwinCallback, (void*)deviceHandle)) != IOTHUB_CLIENT_OK)
     {
         LogError("Unable to set device twin callback, error=%d", iothubResult);
         result = false;

--- a/iothub_client/samples/pnp/common/pnp_device_client_helpers.c
+++ b/iothub_client/samples/pnp/common/pnp_device_client_helpers.c
@@ -42,12 +42,9 @@ static IOTHUB_DEVICE_CLIENT_HANDLE AllocateDeviceClientHandle(const PNP_DEVICE_C
         }
     }
 #ifdef USE_PROV_MODULE
-    else
+    else if ((deviceHandle = PnP_CreateDeviceClientHandle_ViaDps(pnpDeviceConfiguration)) == NULL)
     {
-        if ((deviceHandle = PnP_CreateDeviceClientHandle_ViaDps(pnpDeviceConfiguration)) == NULL)
-        {
-            LogError("Cannot retrieve IoT Hub connection information from DPS client");
-        }
+        LogError("Cannot retrieve IoT Hub connection information from DPS client");
     }
 #endif /* USE_PROV_MODULE */
 

--- a/iothub_client/samples/pnp/common/pnp_device_client_helpers.c
+++ b/iothub_client/samples/pnp/common/pnp_device_client_helpers.c
@@ -11,6 +11,8 @@
 #include "iothubtransportmqtt.h"
 #include "pnp_device_client_helpers.h"
 #ifdef USE_PROV_MODULE
+// DPS functionality using symmetric keys is only available if the cmake 
+// flags <-Duse_prov_client=ON -Dhsm_type_symm_key=ON> are enabled when building the Azure IoT C SDK.
 #include "pnp_dps.h"
 #endif
 
@@ -40,8 +42,6 @@ static IOTHUB_DEVICE_CLIENT_HANDLE AllocateDeviceClientHandle(const PNP_DEVICE_C
         }
     }
 #ifdef USE_PROV_MODULE
-    // DPS functionality using symmetric keys is only available if the cmake 
-    // flags <-Duse_prov_client=ON -Dhsm_type_symm_key=ON> are enabled when building the Azure IoT C SDK.
     else
     {
         if ((deviceHandle = PnP_CreateDeviceClientHandle_ViaDps(pnpDeviceConfiguration)) == NULL)
@@ -62,7 +62,7 @@ IOTHUB_DEVICE_CLIENT_HANDLE PnPHelper_CreateDeviceClientHandle(const PNP_DEVICE_
     int iothubInitResult;
     bool result;
 
-    // Before invoking ANY IoTHub Device SDK functionality, IoTHub_Init must be invoked.
+    // Before invoking ANY IoT Hub or DPS functionality, IoTHub_Init must be invoked.
     if ((iothubInitResult = IoTHub_Init()) != 0)
     {
         LogError("Failure to initialize client, error=%d", iothubInitResult);
@@ -73,7 +73,6 @@ IOTHUB_DEVICE_CLIENT_HANDLE PnPHelper_CreateDeviceClientHandle(const PNP_DEVICE_
         LogError("Unable to allocate deviceHandle");
         result = false;
     }
-
     // Sets verbosity level
     else if ((iothubResult = IoTHubDeviceClient_SetOption(deviceHandle, OPTION_LOG_TRACE, &pnpDeviceConfiguration->enableTracing)) != IOTHUB_CLIENT_OK)
     {

--- a/iothub_client/samples/pnp/common/pnp_device_client_helpers.c
+++ b/iothub_client/samples/pnp/common/pnp_device_client_helpers.c
@@ -10,14 +10,14 @@
 #include "iothub_client_options.h"
 #include "iothubtransportmqtt.h"
 #include "pnp_device_client_helpers.h"
-#ifdef USE_PROV_MODULE
+#ifdef USE_PROV_MODULE_FULL
 // DPS functionality using symmetric keys is only available if the cmake 
 // flags <-Duse_prov_client=ON -Dhsm_type_symm_key=ON> are enabled when building the Azure IoT C SDK.
 #include "pnp_dps.h"
 #endif
 
-#include "azure_c_shared_utility/threadapi.h"
 #include "azure_c_shared_utility/strings.h"
+#include "azure_c_shared_utility/threadapi.h"
 #include "azure_c_shared_utility/xlogging.h"
 
 #ifdef SET_TRUSTED_CERT_IN_SAMPLES
@@ -41,12 +41,12 @@ static IOTHUB_DEVICE_CLIENT_HANDLE AllocateDeviceClientHandle(const PNP_DEVICE_C
             LogError("Failure creating IotHub client.  Hint: Check your connection string");
         }
     }
-#ifdef USE_PROV_MODULE
+#ifdef USE_PROV_MODULE_FULL
     else if ((deviceHandle = PnP_CreateDeviceClientHandle_ViaDps(pnpDeviceConfiguration)) == NULL)
     {
         LogError("Cannot retrieve IoT Hub connection information from DPS client");
     }
-#endif /* USE_PROV_MODULE */
+#endif /* USE_PROV_MODULE_FULL */
 
     return deviceHandle;
 }

--- a/iothub_client/samples/pnp/common/pnp_device_client_helpers.h
+++ b/iothub_client/samples/pnp/common/pnp_device_client_helpers.h
@@ -17,29 +17,14 @@ typedef enum PNP_CONNECTION_SECURITY_TYPE_TAG
 
 #ifdef USE_PROV_MODULE
 //
-// DPS functionality using symmetric keys is only available if the cmake 
-// flags <-Duse_prov_client=ON -Dhsm_type_symm_key=ON> are enabled when building the Azure IoT C SDK.
+// PNP_DPS_CONFIGURATION is used to configure the DPS device client
 //
-// PNP_DPS_SYMMETRIC_KEY specifies the values the authentication material needed
-// to authenticate when using DPS symmetric keys.
-// 
-typedef struct PNP_DPS_SYMMETRIC_KEY_TAG
-{
-    char* idScope;
-    char* deviceId;
-    char* deviceKey;
-} PNP_DPS_SYMMETRIC_KEY;
-
-//
-// PNP_DPS_CONFIGURATION is the configuration for the IoTHub retrieved by the
-// DPS client at runtime (NOT pre-configured environmnent)
 typedef struct PNP_DPS_CONFIGURATION_TAG
 {
     char* idScope;
     char* deviceId;
     char* deviceKey;
 } PNP_DPS_CONFIGURATION;
-
 #endif /* USE_PROV_MODULE */
 
 //
@@ -58,11 +43,13 @@ typedef struct PNP_DEVICE_CONFIGURATION_TAG
     } u;
     // ModelId of this PnP device
     const char* modelId;
-    // Whether more verbose tracing is enabled at IoT Hub DeviceClient layer
+    // Whether more verbose tracing is enabled for the IoT Hub client
     bool enableTracing;
-    // Callback for IoT Hub device methods, which is the mechanism PnP commands use
+    // Callback for IoT Hub device methods, which is the mechanism PnP commands use.  If PnP commands
+    // are not used, this should be NULL to conserve memory and bandwidth.
     IOTHUB_CLIENT_DEVICE_METHOD_CALLBACK_ASYNC deviceMethodCallback;
-    // Callback for IoT Hub device twin notifications, which is the mechanism PnP properties from service use
+    // Callback for IoT Hub device twin notifications, which is the mechanism PnP properties from service use.
+    // If PnP properties are not configured by the server, this should be NULL to conserve memory and bandwidth.
     IOTHUB_CLIENT_DEVICE_TWIN_CALLBACK deviceTwinCallback;
 } PNP_DEVICE_CONFIGURATION;
 
@@ -72,13 +59,8 @@ typedef struct PNP_DEVICE_CONFIGURATION_TAG
 // for Device Method and Device Twin callbacks (to process PnP Commands and Properties, respectively)
 // as well as some other basic maintenence on the handle. 
 //
-// If the application's model does not implement PnP commands, the application should set deviceMethodCallback to NULL.
-// Analogously, if there are no desired PnP properties, deviceTwinCallback should be NULL.  Not subscribing for these
-// callbacks if they are not needed by the model will save bandwidth and RAM.
-//
-// NOTE: When using DPS based authentication, this function can *block* until DPS responds to the request or we timeout.
+// NOTE: When using DPS based authentication, this function can *block* until DPS responds to the request or timeout.
 //
 IOTHUB_DEVICE_CLIENT_HANDLE PnPHelper_CreateDeviceClientHandle(const PNP_DEVICE_CONFIGURATION* pnpDeviceConfiguration);
-//const char* connectionString, const char* modelId, bool enableTracing, IOTHUB_CLIENT_DEVICE_METHOD_CALLBACK_ASYNC deviceMethodCallback, IOTHUB_CLIENT_DEVICE_TWIN_CALLBACK deviceTwinCallback);
 
 #endif /* PNP_DEVICE_CLIENT_HELPERS_H */

--- a/iothub_client/samples/pnp/common/pnp_device_client_helpers.h
+++ b/iothub_client/samples/pnp/common/pnp_device_client_helpers.h
@@ -22,7 +22,7 @@ typedef enum PNP_CONNECTION_SECURITY_TYPE_TAG
 typedef struct PNP_DPS_CONFIGURATION_TAG
 {
     char* idScope;
-    char* deviceId;
+    char* registrationId;
     char* deviceKey;
 } PNP_DPS_CONFIGURATION;
 #endif /* USE_PROV_MODULE */

--- a/iothub_client/samples/pnp/common/pnp_device_client_helpers.h
+++ b/iothub_client/samples/pnp/common/pnp_device_client_helpers.h
@@ -35,8 +35,8 @@ typedef struct PNP_DPS_SYMMETRIC_KEY_TAG
 // DPS client at runtime (NOT pre-configured environmnent)
 typedef struct PNP_DPS_CONFIGURATION_TAG
 {
-    const char* iothubUri;
-    const char* deviceId;
+    char* iothubUri;
+    char* deviceId;
 } PNP_DPS_CONFIGURATION;
 
 #endif /* USE_PROV_MODULE */

--- a/iothub_client/samples/pnp/common/pnp_device_client_helpers.h
+++ b/iothub_client/samples/pnp/common/pnp_device_client_helpers.h
@@ -17,8 +17,8 @@ typedef enum PNP_CONNECTION_SECURITY_TYPE_TAG
 
 #ifdef USE_PROV_MODULE
 //
-// DPS functionality is only available if the cmake flag -Duse_prov_client=ON was
-// enabled when building the Azure IoT C SDK.
+// DPS functionality using symmetric keys is only available if the cmake 
+// flags <-Duse_prov_client=ON -Dhsm_type_symm_key=ON> are enabled when building the Azure IoT C SDK.
 //
 // PNP_DPS_SYMMETRIC_KEY specifies the values the authentication material needed
 // to authenticate when using DPS symmetric keys.

--- a/iothub_client/samples/pnp/common/pnp_device_client_helpers.h
+++ b/iothub_client/samples/pnp/common/pnp_device_client_helpers.h
@@ -15,17 +15,17 @@ typedef enum PNP_CONNECTION_SECURITY_TYPE_TAG
     PNP_CONNECTION_SECURITY_TYPE_DPS
 } PNP_CONNECTION_SECURITY_TYPE;
 
-#ifdef USE_PROV_MODULE
+#ifdef USE_PROV_MODULE_FULL
 //
-// PNP_DPS_CONFIGURATION is used to configure the DPS device client
+// PNP_DPS_CONNECTION_AUTH is used to configure the DPS device client
 //
 typedef struct PNP_DPS_CONFIGURATION_TAG
 {
     char* idScope;
-    char* registrationId;
+    char* deviceId;
     char* deviceKey;
-} PNP_DPS_CONFIGURATION;
-#endif /* USE_PROV_MODULE */
+} PNP_DPS_CONNECTION_AUTH;
+#endif /* USE_PROV_MODULE_FULL */
 
 //
 // PNP_HELPER_DEVICE_CONFIGURATION is used to setup the IOTHUB_DEVICE_CLIENT_HANDLE
@@ -37,8 +37,8 @@ typedef struct PNP_DEVICE_CONFIGURATION_TAG
     // The connection string or DPS security information
     union {
         char* connectionString;
-#ifdef USE_PROV_MODULE
-        PNP_DPS_CONFIGURATION dpsConfiguration;
+#ifdef USE_PROV_MODULE_FULL
+        PNP_DPS_CONNECTION_AUTH dpsConnectionAuth;
 #endif
     } u;
     // ModelId of this PnP device

--- a/iothub_client/samples/pnp/common/pnp_device_client_helpers.h
+++ b/iothub_client/samples/pnp/common/pnp_device_client_helpers.h
@@ -7,6 +7,65 @@
 #include "iothub_device_client.h"
 
 //
+// Whether we're using a connection string or DPS provisioning for device credentials
+//
+typedef enum PNP_CONNECTION_SECURITY_TYPE_TAG
+{
+    PNP_CONNECTION_SECURITY_TYPE_CONNECTION_STRING,
+    PNP_CONNECTION_SECURITY_TYPE_DPS
+} PNP_CONNECTION_SECURITY_TYPE;
+
+#ifdef USE_PROV_MODULE
+//
+// DPS functionality is only available if the cmake flag -Duse_prov_client=ON was
+// enabled when building the Azure IoT C SDK.
+//
+// PNP_DPS_SYMMETRIC_KEY specifies the values the authentication material needed
+// to authenticate when using DPS symmetric keys.
+// 
+typedef struct PNP_DPS_SYMMETRIC_KEY_TAG
+{
+    char* idScope;
+    char* deviceId;
+    char* deviceKey;
+} PNP_DPS_SYMMETRIC_KEY;
+
+//
+// PNP_DPS_CONFIGURATION is the configuration for the IoTHub retrieved by the
+// DPS client at runtime (NOT pre-configured environmnent)
+typedef struct PNP_DPS_CONFIGURATION_TAG
+{
+    const char* iothubUri;
+    const char* deviceId;
+} PNP_DPS_CONFIGURATION;
+
+#endif /* USE_PROV_MODULE */
+
+//
+// PNP_HELPER_DEVICE_CONFIGURATION is used to setup the IOTHUB_DEVICE_CLIENT_HANDLE
+//
+typedef struct PNP_DEVICE_CONFIGURATION_TAG
+{
+    // Whether we're using connection string or DPS
+    PNP_CONNECTION_SECURITY_TYPE securityType;
+    // The connection string or DPS security information
+    union {
+        char* connectionString;
+#ifdef USE_PROV_MODULE
+        PNP_DPS_CONFIGURATION dpsConfiguration;
+#endif
+    } u;
+    // ModelId of this PnP device
+    const char* modelId;
+    // Whether more verbose tracing is enabled at IoT Hub DeviceClient layer
+    bool enableTracing;
+    // Callback for IoT Hub device methods, which is the mechanism PnP commands use
+    IOTHUB_CLIENT_DEVICE_METHOD_CALLBACK_ASYNC deviceMethodCallback;
+    // Callback for IoT Hub device twin notifications, which is the mechanism PnP properties from service use
+    IOTHUB_CLIENT_DEVICE_TWIN_CALLBACK deviceTwinCallback;
+} PNP_DEVICE_CONFIGURATION;
+
+//
 // PnPHelper_CreateDeviceClientHandle creates an IOTHUB_DEVICE_CLIENT_HANDLE that will be ready to interact with PnP.
 // Beyond basic handle creation, it also sets the handle to the appropriate ModelId, optionally sets up callback functions
 // for Device Method and Device Twin callbacks (to process PnP Commands and Properties, respectively)
@@ -16,6 +75,7 @@
 // Anologously, if there are no desired PnP properties, deviceTwinCallback should be NULL.  Not subscribing for these
 // callbacks if they are not needed by the model will save bandwidth and RAM.
 //
-IOTHUB_DEVICE_CLIENT_HANDLE PnPHelper_CreateDeviceClientHandle(const char* connectionString, const char* modelId, bool enableTracing, IOTHUB_CLIENT_DEVICE_METHOD_CALLBACK_ASYNC deviceMethodCallback, IOTHUB_CLIENT_DEVICE_TWIN_CALLBACK deviceTwinCallback);
+IOTHUB_DEVICE_CLIENT_HANDLE PnPHelper_CreateDeviceClientHandle(const PNP_DEVICE_CONFIGURATION* pnpDeviceConfiguration);
+//const char* connectionString, const char* modelId, bool enableTracing, IOTHUB_CLIENT_DEVICE_METHOD_CALLBACK_ASYNC deviceMethodCallback, IOTHUB_CLIENT_DEVICE_TWIN_CALLBACK deviceTwinCallback);
 
 #endif /* PNP_DEVICE_CLIENT_HELPERS_H */

--- a/iothub_client/samples/pnp/common/pnp_device_client_helpers.h
+++ b/iothub_client/samples/pnp/common/pnp_device_client_helpers.h
@@ -35,8 +35,9 @@ typedef struct PNP_DPS_SYMMETRIC_KEY_TAG
 // DPS client at runtime (NOT pre-configured environmnent)
 typedef struct PNP_DPS_CONFIGURATION_TAG
 {
-    char* iothubUri;
+    char* idScope;
     char* deviceId;
+    char* deviceKey;
 } PNP_DPS_CONFIGURATION;
 
 #endif /* USE_PROV_MODULE */
@@ -72,8 +73,10 @@ typedef struct PNP_DEVICE_CONFIGURATION_TAG
 // as well as some other basic maintenence on the handle. 
 //
 // If the application's model does not implement PnP commands, the application should set deviceMethodCallback to NULL.
-// Anologously, if there are no desired PnP properties, deviceTwinCallback should be NULL.  Not subscribing for these
+// Analogously, if there are no desired PnP properties, deviceTwinCallback should be NULL.  Not subscribing for these
 // callbacks if they are not needed by the model will save bandwidth and RAM.
+//
+// NOTE: When using DPS based authentication, this function can *block* until DPS responds to the request or we timeout.
 //
 IOTHUB_DEVICE_CLIENT_HANDLE PnPHelper_CreateDeviceClientHandle(const PNP_DEVICE_CONFIGURATION* pnpDeviceConfiguration);
 //const char* connectionString, const char* modelId, bool enableTracing, IOTHUB_CLIENT_DEVICE_METHOD_CALLBACK_ASYNC deviceMethodCallback, IOTHUB_CLIENT_DEVICE_TWIN_CALLBACK deviceTwinCallback);

--- a/iothub_client/samples/pnp/common/pnp_dps.c
+++ b/iothub_client/samples/pnp/common/pnp_dps.c
@@ -1,0 +1,184 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef USE_PROV_MODULE
+#error "Missing cmake flag for DPS"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "iothub_device_client.h"
+#include "iothubtransportmqtt.h"
+#include "pnp_device_client_helpers.h"
+
+#include "azure_c_shared_utility/threadapi.h"
+#include "azure_c_shared_utility/strings.h"
+#include "azure_c_shared_utility/xlogging.h"
+
+// DPS related header files
+#include "azure_prov_client/iothub_security_factory.h"
+#include "azure_prov_client/prov_device_client.h"
+#include "azure_prov_client/prov_transport_mqtt_client.h"
+#include "azure_prov_client/prov_security_factory.h"
+
+//
+// DPS specific configuration, only brought in if DPS is included as part of the SDK at cmake time
+//
+
+// Global provisioning endpoint for DPS
+static const char* g_dps_GlobalProvUri = "global.azure-devices-provisioning.net";
+static const char g_dps_PayloadFormatForModelId[] = "{\"modelId\":\"%s\"}";
+
+// State of DPS registration process.  We cannot proceed with PnP until we get into the state PNP_DPS_REGISTRATION_SUCCEEDED.
+typedef enum PNP_DPS_REGISTRATION_STATUS_TAG
+{
+    PNP_DPS_REGISTRATION_PENDING,
+    PNP_DPS_REGISTRATION_SUCCEEDED,
+    PNP_DPS_REGISTRATION_FAILED
+} PNP_DPS_REGISTRATION_STATUS;
+
+PNP_DPS_REGISTRATION_STATUS g_pnpDpsRegistrationStatus = PNP_DPS_REGISTRATION_PENDING;
+
+// Maximum amount of times we'll poll for DPS registration being ready.  Note that even though DPS works off of callbacks,
+// the main() loop itself blocks 
+static const int g_dpsRegistrationMaxPolls = 60;
+// Amount to sleep between querying state from DPS registration loop
+static const int g_dpsRegistrationPollSleep = 1000;
+
+// IoT Hub for this device as determined by the DPS client runtime
+static char* g_dpsIothubUri;
+// DeviceId for this device as determined by the DPS client runtime
+static char* g_dpsDeviceId;
+
+//
+// provisioningRegisterCallback is called back by the DPS client when the DPS server has either succeeded or failed our request.
+//
+static void provisioningRegisterCallback(PROV_DEVICE_RESULT registerResult, const char* iothubUri, const char* deviceId, void* userContext)
+{
+    PNP_DPS_REGISTRATION_STATUS* pnpDpsRegistrationStatus = (PNP_DPS_REGISTRATION_STATUS*)userContext;
+
+    if (registerResult != PROV_DEVICE_RESULT_OK)
+    {
+        LogError("DPS Provisioning callback called with error state %d", registerResult);
+        *pnpDpsRegistrationStatus = PNP_DPS_REGISTRATION_FAILED;
+    }
+    else
+    {
+        if ((mallocAndStrcpy_s(&g_dpsIothubUri, iothubUri) != 0) ||
+            (mallocAndStrcpy_s(&g_dpsDeviceId, deviceId) != 0))
+        {
+            LogError("Unable to copy provisioning information");
+            *pnpDpsRegistrationStatus = PNP_DPS_REGISTRATION_FAILED;
+        }
+        else
+        {
+            LogInfo("Provisioning callback indicates success.  iothubUri=%s, deviceId=%s", iothubUri, deviceId);
+            *pnpDpsRegistrationStatus = PNP_DPS_REGISTRATION_SUCCEEDED;
+        }
+    }
+}
+
+IOTHUB_DEVICE_CLIENT_HANDLE PnP_CreateDeviceClientHandle_ViaDps(const PNP_DEVICE_CONFIGURATION* pnpDeviceConfiguration)
+{
+    IOTHUB_DEVICE_CLIENT_HANDLE deviceHandle = NULL;
+    bool result;
+
+    PROV_DEVICE_RESULT provDeviceResult;
+    PROV_DEVICE_HANDLE provDeviceHandle = NULL;
+    STRING_HANDLE modelIdPayload = NULL;
+
+    LogInfo("Initiating DPS client to retrieve IoT Hub connection information");
+
+    if ((modelIdPayload = STRING_construct_sprintf(g_dps_PayloadFormatForModelId, pnpDeviceConfiguration->modelId)) == NULL)
+    {
+        LogError("Cannot allocate DPS payload for modelId.");
+        result = false;
+    }
+    else if ((prov_dev_set_symmetric_key_info(pnpDeviceConfiguration->u.dpsConfiguration.deviceId, pnpDeviceConfiguration->u.dpsConfiguration.deviceKey) != 0))
+    {
+        LogError("prov_dev_set_symmetric_key_info failed.");
+        result = false;
+    }
+    else if (prov_dev_security_init(SECURE_DEVICE_TYPE_SYMMETRIC_KEY) != 0)
+    {
+        LogError("prov_dev_security_init failed");
+        result = false;
+    }
+    else if ((provDeviceHandle = Prov_Device_Create(g_dps_GlobalProvUri, pnpDeviceConfiguration->u.dpsConfiguration.idScope, Prov_Device_MQTT_Protocol)) == NULL)
+    {
+        LogError("failed calling Prov_Device_Create");
+        result = false;
+    }
+    else if ((provDeviceResult = Prov_Device_SetOption(provDeviceHandle, PROV_OPTION_LOG_TRACE, &pnpDeviceConfiguration->enableTracing)) != PROV_DEVICE_RESULT_OK)
+    {
+        LogError("Setting provisioning tracing on failed, error=%d", provDeviceResult);
+        result = false;
+    }
+    // This step indicates the ModelId of the device to DPS.  This allows the service to (optionally) perform custom operations,
+    // such as allocating a different IoT Hub to devices based on their ModelId.
+    else if ((provDeviceResult = Prov_Device_Set_Provisioning_Payload(provDeviceHandle, STRING_c_str(modelIdPayload))) != PROV_DEVICE_RESULT_OK)
+    {
+        LogError("Failed setting provisioning data, error=%d", provDeviceResult);
+        result = false;
+    }
+    else if ((provDeviceResult = Prov_Device_Register_Device(provDeviceHandle, provisioningRegisterCallback, &g_pnpDpsRegistrationStatus, NULL, NULL)) != PROV_DEVICE_RESULT_OK)
+    {
+        LogError("Prov_Device_Register_Device failed, error=%d", provDeviceResult);
+        result = false;
+    }
+    else
+    {
+        for (int i = 0; (i < g_dpsRegistrationMaxPolls) && (g_pnpDpsRegistrationStatus == PNP_DPS_REGISTRATION_PENDING); i++)
+        {
+            ThreadAPI_Sleep(g_dpsRegistrationPollSleep);
+        }
+
+        if (g_pnpDpsRegistrationStatus == PNP_DPS_REGISTRATION_SUCCEEDED)
+        {
+            LogInfo("DPS successfully registered.  Continuing on to creation of IoTHub device client handle.");
+            result = true;
+        }
+        else if (g_pnpDpsRegistrationStatus == PNP_DPS_REGISTRATION_PENDING)
+        {
+            LogError("Timed out attempting to register DPS device");
+            result = false;
+        }
+        else
+        {
+            LogError("Error registering device for DPS");
+            result = false;
+        }
+    }
+
+    // Destroy the provisioning handle here, instead of the typical convention of doing so at the end of the function.
+    // We do so because this handle is no longer required and because on devices with limited amounts of memory
+    // cannot keep this open and have a device handle (via IoTHubDeviceClient_CreateFromDeviceAuth below) at the same time.
+    if (provDeviceHandle != NULL)
+    {
+        Prov_Device_Destroy(provDeviceHandle);
+    }
+
+
+    if (result == true)
+    {
+        if (iothub_security_init(IOTHUB_SECURITY_TYPE_SYMMETRIC_KEY) != 0)
+        {
+            LogError("iothub_security_init failed");
+            result = false;
+        }
+        else if ((deviceHandle = IoTHubDeviceClient_CreateFromDeviceAuth(g_dpsIothubUri, g_dpsDeviceId, MQTT_Protocol)) == NULL)
+        {
+            LogError("IoTHubDeviceClient_CreateFromDeviceAuth failed");
+            result = true;
+        }
+    }
+
+    free(g_dpsIothubUri);
+    free(g_dpsDeviceId);
+    STRING_delete(modelIdPayload);
+
+    return deviceHandle;
+}
+

--- a/iothub_client/samples/pnp/common/pnp_dps.c
+++ b/iothub_client/samples/pnp/common/pnp_dps.c
@@ -23,10 +23,6 @@
 #include "azure_prov_client/prov_transport_mqtt_client.h"
 #include "azure_prov_client/prov_security_factory.h"
 
-//
-// DPS specific configuration, only brought in if DPS is included as part of the SDK at cmake time
-//
-
 // Global provisioning endpoint for DPS
 static const char* g_dps_GlobalProvUri = "global.azure-devices-provisioning.net";
 static const char g_dps_PayloadFormatForModelId[] = "{\"modelId\":\"%s\"}";
@@ -160,7 +156,6 @@ IOTHUB_DEVICE_CLIENT_HANDLE PnP_CreateDeviceClientHandle_ViaDps(const PNP_DEVICE
         Prov_Device_Destroy(provDeviceHandle);
     }
 
-
     if (result == true)
     {
         if (iothub_security_init(IOTHUB_SECURITY_TYPE_SYMMETRIC_KEY) != 0)
@@ -181,4 +176,3 @@ IOTHUB_DEVICE_CLIENT_HANDLE PnP_CreateDeviceClientHandle_ViaDps(const PNP_DEVICE
 
     return deviceHandle;
 }
-

--- a/iothub_client/samples/pnp/common/pnp_dps.h
+++ b/iothub_client/samples/pnp/common/pnp_dps.h
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef PNP_DPS_H
+#define PNP_DPS_H
+
+#include "iothub_device_client.h"
+
+#ifndef USE_PROV_MODULE
+#error "Missing cmake flag for DPS"
+#endif
+
+//
+// _PnPHelper_CreateDeviceClientHandle_ViaDps is used to create a IOTHUB_DEVICE_CLIENT_HANDLE, invoking the DPS client
+// to retrieve the needed hub information.
+//
+// Applications should NOT invoke this function directly but instead should use PnPHelper_CreateDeviceClientHandle.
+IOTHUB_DEVICE_CLIENT_HANDLE PnP_CreateDeviceClientHandle_ViaDps(const PNP_DEVICE_CONFIGURATION* pnpDeviceConfiguration);
+
+#endif /* PNP_DPS_H */

--- a/iothub_client/samples/pnp/common/pnp_dps.h
+++ b/iothub_client/samples/pnp/common/pnp_dps.h
@@ -11,10 +11,11 @@
 #endif
 
 //
-// _PnPHelper_CreateDeviceClientHandle_ViaDps is used to create a IOTHUB_DEVICE_CLIENT_HANDLE, invoking the DPS client
+// PnP_CreateDeviceClientHandle_ViaDps is used to create a IOTHUB_DEVICE_CLIENT_HANDLE, invoking the DPS client
 // to retrieve the needed hub information.
 //
 // Applications should NOT invoke this function directly but instead should use PnPHelper_CreateDeviceClientHandle.
+//
 IOTHUB_DEVICE_CLIENT_HANDLE PnP_CreateDeviceClientHandle_ViaDps(const PNP_DEVICE_CONFIGURATION* pnpDeviceConfiguration);
 
 #endif /* PNP_DPS_H */

--- a/iothub_client/samples/pnp/common/pnp_dps.h
+++ b/iothub_client/samples/pnp/common/pnp_dps.h
@@ -6,7 +6,7 @@
 
 #include "iothub_device_client.h"
 
-#ifndef USE_PROV_MODULE
+#ifndef USE_PROV_MODULE_FULL
 #error "Missing cmake flag for DPS"
 #endif
 

--- a/iothub_client/samples/pnp/pnp_simple_thermostat/pnp_simple_thermostat.c
+++ b/iothub_client/samples/pnp/pnp_simple_thermostat/pnp_simple_thermostat.c
@@ -91,7 +91,7 @@ static const char g_temperaturePropertyResponseDescription[] = "success";
 // Size of buffer to store ISO 8601 time.
 #define TIME_BUFFER_SIZE 128
 // Format string to create an ISO 8601 time.  This corresponds to the DTDL datetime schema item.
-static const char g_ISO8601Format[] = "%04d-%02d-%02dT%02d:%02d:%02dZ";
+static const char g_ISO8601Format[] = "%Y-%m-%dT%H:%M:%SZ";
 // Start time of the program, stored in ISO 8601 format string for UTC.
 char g_ProgramStartTime[TIME_BUFFER_SIZE];
 

--- a/iothub_client/samples/pnp/pnp_temperature_controller/CMakeLists.txt
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/CMakeLists.txt
@@ -25,6 +25,7 @@ if(${use_sample_trusted_cert})
     set(pnp_temperature_controller_c_files ${pnp_temperature_controller_c_files} ${PROJECT_SOURCE_DIR}/certs/certs.c)
 endif()
 
+
 include_directories(. ../common ${PROJECT_SOURCE_DIR}/deps/parson)
 
 add_executable(pnp_temperature_controller ${pnp_temperature_controller_c_files})
@@ -34,3 +35,8 @@ linkMqttLibrary(pnp_temperature_controller)
 add_definitions(-DUSE_MQTT)
 
 target_link_libraries(pnp_temperature_controller iothub_client)
+
+if(${use_prov_client})
+    target_link_libraries(pnp_temperature_controller prov_device_client prov_mqtt_transport)
+endif()
+

--- a/iothub_client/samples/pnp/pnp_temperature_controller/CMakeLists.txt
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/CMakeLists.txt
@@ -18,13 +18,16 @@ IF(WIN32)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 ENDIF(WIN32)
 
+if(${use_prov_client})
+    set(pnp_temperature_controller_c_files ${pnp_temperature_controller_c_files} ../common/pnp_dps.c)
+endif()
+
 #Conditionally use the SDK trusted certs in the samples
 if(${use_sample_trusted_cert})
     add_definitions(-DSET_TRUSTED_CERT_IN_SAMPLES)
     include_directories(${PROJECT_SOURCE_DIR}/certs)
     set(pnp_temperature_controller_c_files ${pnp_temperature_controller_c_files} ${PROJECT_SOURCE_DIR}/certs/certs.c)
 endif()
-
 
 include_directories(. ../common ${PROJECT_SOURCE_DIR}/deps/parson)
 

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_temperature_controller.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_temperature_controller.c
@@ -25,14 +25,6 @@
 #include "pnp_device_client_helpers.h"
 #include "pnp_protocol_helpers.h"
 
-#ifdef USE_PROV_MODULE
-// DPS related header files
-#include "azure_prov_client/iothub_security_factory.h"
-#include "azure_prov_client/prov_device_client.h"
-#include "azure_prov_client/prov_transport_mqtt_client.h"
-#include "azure_prov_client/prov_security_factory.h"
-#endif // USE_PROV_MODULE
-
 // Headers that provide implementation for subcomponents (the two thermostat components and DeviceInfo)
 #include "pnp_thermostat_component.h"
 #include "pnp_deviceinfo_component.h"
@@ -49,14 +41,13 @@ static const char g_connectionStringEnvironmentVariable[] = "IOTHUB_DEVICE_CONNE
 static const char g_dpsIdScopeEnvironmentVariable[] = "IOTHUB_DEVICE_DPS_ID_SCOPE";
 
 // Environment variable used to specify this application's DPS device id
-static const char g_dpsDeviceIdEnvironmentVariable[] = "IOTHUB_DEVICE_DPS_DEVICE_ID";
+static const char g_dpsRegistrationIdEnvironmentVariable[] = "IOTHUB_DEVICE_DPS_REGISTRATION_ID";
 
 // Environment variable used to specify this application's DPS device key
 static const char g_dpsDeviceKeyEnvironmentVariable[] = "IOTHUB_DEVICE_DPS_DEVICE_KEY";
 
 // Values of connection / security settings read from environment variables and/or DPS runtime
 PNP_DEVICE_CONFIGURATION g_pnpDeviceConfiguration;
-char* g_connectionString;
 
 // Amount of time to sleep between sending telemetry to IotHub, in milliseconds.  Set to 1 minute.
 static unsigned int g_sleepBetweenTelemetrySends = 60 * 1000;
@@ -356,9 +347,9 @@ static bool GetDpsFromEnvironment()
         LogError("Cannot read environment variable=%s", g_dpsIdScopeEnvironmentVariable);
         result = false;
     }
-    else if ((g_pnpDeviceConfiguration.u.dpsConfiguration.deviceId = getenv(g_dpsDeviceIdEnvironmentVariable)) == NULL)
+    else if ((g_pnpDeviceConfiguration.u.dpsConfiguration.registrationId = getenv(g_dpsRegistrationIdEnvironmentVariable)) == NULL)
     {
-        LogError("Cannot read environment variable=%s", g_dpsDeviceIdEnvironmentVariable);
+        LogError("Cannot read environment variable=%s", g_dpsRegistrationIdEnvironmentVariable);
         result = false;
     }
     else if ((g_pnpDeviceConfiguration.u.dpsConfiguration.deviceKey = getenv(g_dpsDeviceKeyEnvironmentVariable)) == NULL)

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_temperature_controller.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_temperature_controller.c
@@ -65,7 +65,7 @@ static unsigned int g_sleepBetweenTelemetrySends = 60 * 1000;
 static bool g_hubClientTraceEnabled = true;
 
 // DTMI indicating this device's ModelId.
-#define TEMPERATURE_CONTROLLER_MODEL_ID "dtmi:com:example:TemperatureController;1"
+static const char g_temperatureControllerModelId[] = "dtmi:com:example:TemperatureController;1";
 
 // PNP_THERMOSTAT_COMPONENT_HANDLE represent the thermostat components that are sub-components of the temperature controller.
 // Note that we do NOT have an analogous DeviceInfo component handle because there is only DeviceInfo subcomponent and its
@@ -423,7 +423,7 @@ static IOTHUB_DEVICE_CLIENT_HANDLE CreateDeviceClientAndAllocateComponents(void)
     g_pnpDeviceConfiguration.deviceMethodCallback = PnP_TempControlComponent_DeviceMethodCallback;
     g_pnpDeviceConfiguration.deviceTwinCallback = PnP_TempControlComponent_DeviceTwinCallback;
     g_pnpDeviceConfiguration.enableTracing = g_hubClientTraceEnabled;
-    g_pnpDeviceConfiguration.modelId = TEMPERATURE_CONTROLLER_MODEL_ID;
+    g_pnpDeviceConfiguration.modelId = g_temperatureControllerModelId;
 
     if (GetConnectionSettingsFromEnvironment() == false)
     {

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_temperature_controller.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_temperature_controller.c
@@ -17,8 +17,8 @@
 #include "iothub_device_client.h"
 #include "iothub_client_options.h"
 #include "iothub_message.h"
-#include "azure_c_shared_utility/threadapi.h"
 #include "azure_c_shared_utility/strings.h"
+#include "azure_c_shared_utility/threadapi.h"
 #include "azure_c_shared_utility/xlogging.h"
 
 // PnP helper utilities.
@@ -41,7 +41,7 @@ static const char g_connectionStringEnvironmentVariable[] = "IOTHUB_DEVICE_CONNE
 static const char g_dpsIdScopeEnvironmentVariable[] = "IOTHUB_DEVICE_DPS_ID_SCOPE";
 
 // Environment variable used to specify this application's DPS device id
-static const char g_dpsRegistrationIdEnvironmentVariable[] = "IOTHUB_DEVICE_DPS_REGISTRATION_ID";
+static const char g_dpsDeviceIdEnvironmentVariable[] = "IOTHUB_DEVICE_DPS_DEVICE_ID";
 
 // Environment variable used to specify this application's DPS device key
 static const char g_dpsDeviceKeyEnvironmentVariable[] = "IOTHUB_DEVICE_DPS_DEVICE_KEY";
@@ -332,7 +332,7 @@ static bool GetConnectionStringFromEnvironment()
 //
 static bool GetDpsFromEnvironment()
 {
-#ifndef USE_PROV_MODULE
+#ifndef USE_PROV_MODULE_FULL
     // Explain to user misconfiguration.  The "run_e2e_tests" must be set to OFF because otherwise
     // the e2e's test HSM layer and symmetric key logic will conflict.
     LogError("DPS based authentication was requested via environment variables, but DPS is not enabled.");
@@ -342,17 +342,17 @@ static bool GetDpsFromEnvironment()
 #else
     bool result;
 
-    if ((g_pnpDeviceConfiguration.u.dpsConfiguration.idScope = getenv(g_dpsIdScopeEnvironmentVariable)) == NULL)
+    if ((g_pnpDeviceConfiguration.u.dpsConnectionAuth.idScope = getenv(g_dpsIdScopeEnvironmentVariable)) == NULL)
     {
         LogError("Cannot read environment variable=%s", g_dpsIdScopeEnvironmentVariable);
         result = false;
     }
-    else if ((g_pnpDeviceConfiguration.u.dpsConfiguration.registrationId = getenv(g_dpsRegistrationIdEnvironmentVariable)) == NULL)
+    else if ((g_pnpDeviceConfiguration.u.dpsConnectionAuth.deviceId = getenv(g_dpsDeviceIdEnvironmentVariable)) == NULL)
     {
-        LogError("Cannot read environment variable=%s", g_dpsRegistrationIdEnvironmentVariable);
+        LogError("Cannot read environment variable=%s", g_dpsDeviceIdEnvironmentVariable);
         result = false;
     }
-    else if ((g_pnpDeviceConfiguration.u.dpsConfiguration.deviceKey = getenv(g_dpsDeviceKeyEnvironmentVariable)) == NULL)
+    else if ((g_pnpDeviceConfiguration.u.dpsConnectionAuth.deviceKey = getenv(g_dpsDeviceKeyEnvironmentVariable)) == NULL)
     {
         LogError("Cannot read environment variable=%s", g_dpsDeviceKeyEnvironmentVariable);
         result = false;
@@ -363,7 +363,7 @@ static bool GetDpsFromEnvironment()
     }
 
     return result;
-#endif
+#endif // USE_PROV_MODULE_FULL
 }
 
 

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_temperature_controller.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_temperature_controller.c
@@ -54,39 +54,6 @@ static const char g_dpsDeviceIdEnvironmentVariable[] = "IOTHUB_DEVICE_DPS_DEVICE
 // Environment variable used to specify this application's DPS device key
 static const char g_dpsDeviceKeyEnvironmentVariable[] = "IOTHUB_DEVICE_DPS_DEVICE_KEY";
 
-#ifdef USE_PROV_MODULE
-//
-// DPS specific configuration, only brought in if DPS is included as part of the SDK at cmake time
-//
-
-// Global provisioning endpoint for DPS
-static const char* g_dps_GlobalProvUri = "global.azure-devices-provisioning.net";
-
-// g_dps_ModelId_Payload is sent as a custom payload during DPS registration
-static const char* g_dps_ModelId_Payload = "{"
-                                             //"\"ModelId\":\"" TEMPERATURE_CONTROLLER_MODEL_ID "\""
-                                           "}";
-
-// Values of pre-configured DPS settings, read from environment
-PNP_DPS_SYMMETRIC_KEY g_dpsSymmetricKey;
-
-// State of DPS registration process.  We cannot proceed with PnP until we get into the state PNP_DPS_REGISTRATION_SUCCEEDED.
-typedef enum PNP_DPS_REGISTRATION_STATUS_TAG
-{
-    PNP_DPS_REGISTRATION_PENDING,
-    PNP_DPS_REGISTRATION_SUCCEEDED,
-    PNP_DPS_REGISTRATION_FAILED
-} PNP_DPS_REGISTRATION_STATUS;
-
-PNP_DPS_REGISTRATION_STATUS g_pnpDpsRegistrationStatus = PNP_DPS_REGISTRATION_PENDING;
-
-// Maximum amount of times we'll poll for DPS registration being ready.  Note that even though DPS works off of callbacks,
-// the main() loop itself blocks 
-static const int g_dpsRegistrationMaxPolls = 60;
-// Amount to sleep between querying state from DPS registration loop
-static const int g_dpsRegistrationPollSleep = 1000;
-#endif
-
 // Values of connection / security settings read from environment variables and/or DPS runtime
 PNP_DEVICE_CONFIGURATION g_pnpDeviceConfiguration;
 char* g_connectionString;
@@ -384,17 +351,17 @@ static bool GetDpsFromEnvironment()
 #else
     bool result;
 
-    if ((g_dpsSymmetricKey.idScope = getenv(g_dpsIdScopeEnvironmentVariable)) == NULL)
+    if ((g_pnpDeviceConfiguration.u.dpsConfiguration.idScope = getenv(g_dpsIdScopeEnvironmentVariable)) == NULL)
     {
         LogError("Cannot read environment variable=%s", g_dpsIdScopeEnvironmentVariable);
         result = false;
     }
-    else if ((g_dpsSymmetricKey.deviceId = getenv(g_dpsDeviceIdEnvironmentVariable)) == NULL)
+    else if ((g_pnpDeviceConfiguration.u.dpsConfiguration.deviceId = getenv(g_dpsDeviceIdEnvironmentVariable)) == NULL)
     {
         LogError("Cannot read environment variable=%s", g_dpsDeviceIdEnvironmentVariable);
         result = false;
     }
-    else if ((g_dpsSymmetricKey.deviceKey = getenv(g_dpsDeviceKeyEnvironmentVariable)) == NULL)
+    else if ((g_pnpDeviceConfiguration.u.dpsConfiguration.deviceKey = getenv(g_dpsDeviceKeyEnvironmentVariable)) == NULL)
     {
         LogError("Cannot read environment variable=%s", g_dpsDeviceKeyEnvironmentVariable);
         result = false;
@@ -446,131 +413,6 @@ static bool GetConnectionSettingsFromEnvironment()
 }
 
 //
-// FreeDpsConfiguration cleans up resources we needed to configure the IoT Hub connection if we got to it via DPS.
-//
-static void FreeDpsConfiguration(void)
-{
-    free(g_pnpDeviceConfiguration.u.dpsConfiguration.iothubUri);
-    free(g_pnpDeviceConfiguration.u.dpsConfiguration.deviceId);
-}
-
-#ifdef USE_PROV_MODULE
-
-//
-// provisioningRegisterCallback is called back by the DPS client when the DPS server has either succeeded or failed our request.
-//
-static void provisioningRegisterCallback(PROV_DEVICE_RESULT registerResult, const char* iothubUri, const char* deviceId, void* userContext)
-{
-    PNP_DPS_REGISTRATION_STATUS* pnpDpsRegistrationStatus = (PNP_DPS_REGISTRATION_STATUS*)userContext;
-
-    if (registerResult != PROV_DEVICE_RESULT_OK)
-    {
-        LogError("DPS Provisioning callback called with error state %d", registerResult);
-        *pnpDpsRegistrationStatus = PNP_DPS_REGISTRATION_FAILED;
-    }
-    else
-    {
-        if ((mallocAndStrcpy_s(&g_pnpDeviceConfiguration.u.dpsConfiguration.iothubUri, iothubUri) != 0) ||
-            (mallocAndStrcpy_s(&g_pnpDeviceConfiguration.u.dpsConfiguration.deviceId, deviceId) != 0))
-        {
-            LogError("Unable to copy provisioning information");
-            *pnpDpsRegistrationStatus = PNP_DPS_REGISTRATION_FAILED;
-        }
-        else
-        {
-            LogInfo("Provisioning callback indicates success.  iothubUri=%s, deviceId=%s", iothubUri, deviceId);
-            *pnpDpsRegistrationStatus = PNP_DPS_REGISTRATION_SUCCEEDED;
-        }
-    }
-}
-
-//
-// GetIoTHubFromDPS is a BLOCKING call that retrieves the IoT Hub connection information for this device
-// by first invoking the Device Provisioning Service (DPS) client.  The call will block until 
-// the DPS accepts or fails the request or until the timeout is reached.
-// 
-static bool GetIoTHubFromDPS()
-{
-    bool result;
-
-    PROV_DEVICE_RESULT provDeviceResult;
-    PROV_DEVICE_HANDLE provDeviceHandle = NULL;
-
-    LogInfo("Initiating DPS client to retrieve IoT Hub connection information");
-
-    if (IoTHub_Init() != 0) // TODO: Need to remove extra call to this from helper or else just move this whole thing there.
-    {
-        LogError("IoTHub_Init failed");
-        result = false;
-    }
-    else if ((prov_dev_set_symmetric_key_info(g_dpsSymmetricKey.deviceId, g_dpsSymmetricKey.deviceKey) != 0))
-    {
-        LogError("prov_dev_set_symmetric_key_info failed.");
-        result = false;
-    }
-    else if (prov_dev_security_init(SECURE_DEVICE_TYPE_SYMMETRIC_KEY) != 0)
-    {
-        LogError("prov_dev_security_init failed");
-        result = false;
-    }
-    else if ((provDeviceHandle = Prov_Device_Create(g_dps_GlobalProvUri, g_dpsSymmetricKey.idScope, Prov_Device_MQTT_Protocol)) == NULL)
-    {
-        LogError("failed calling Prov_Device_Create");
-        result = false;
-    }
-    else if ((provDeviceResult = Prov_Device_SetOption(provDeviceHandle, PROV_OPTION_LOG_TRACE, &g_pnpDeviceConfiguration.enableTracing)) != PROV_DEVICE_RESULT_OK)
-    {
-        LogError("Setting provisioning tracing on failed, error=%d", provDeviceResult);
-        result = false;
-    }
-    // This step indicates the ModelId of the device to DPS.  This allows the service to (optionally) perform custom operations,
-    // such as allocating a different IoT Hub to devices based on their ModelId.
-    else if ((provDeviceResult = Prov_Device_Set_Provisioning_Payload(provDeviceHandle, g_dps_ModelId_Payload)) != PROV_DEVICE_RESULT_OK)
-    {
-        LogError("Failed setting provisioning data, error=%d", provDeviceResult);
-        result = false;
-    }
-    else if ((provDeviceResult = Prov_Device_Register_Device(provDeviceHandle, provisioningRegisterCallback, &g_pnpDpsRegistrationStatus, NULL, NULL)) != PROV_DEVICE_RESULT_OK)
-    {
-        LogError("Prov_Device_Register_Device failed, error=%d", provDeviceResult);
-        result = false;
-    }
-    else
-    {
-        for (int i = 0; (i < g_dpsRegistrationMaxPolls) && (g_pnpDpsRegistrationStatus == PNP_DPS_REGISTRATION_PENDING); i++)
-        {
-            ThreadAPI_Sleep(g_dpsRegistrationPollSleep);
-        }
-
-        if (g_pnpDpsRegistrationStatus == PNP_DPS_REGISTRATION_SUCCEEDED)
-        {
-            LogInfo("DPS successfully registered.  Continuing on to creation of IoTHub device client handle.");
-            result = true;
-        }
-        else if (g_pnpDpsRegistrationStatus == PNP_DPS_REGISTRATION_PENDING)
-        {
-            LogError("Timed out attempting to register DPS device");
-            result = false;
-        }
-        else
-        {
-            LogError("Error registering device for DPS");
-            result = false;
-        }
-    }
-
-    // We do not need to leave this handle active, even if we are going on to register with IoT Hub.  So
-    // destroy it to free up resources.
-    if (provDeviceHandle != NULL)
-    {
-        Prov_Device_Destroy(provDeviceHandle);
-    }
-
-    return result;
-}
-#endif
-
-//
 // CreateDeviceClientAndAllocateComponents allocates the IOTHUB_DEVICE_CLIENT_HANDLE the application will use along with thermostat components
 // 
 static IOTHUB_DEVICE_CLIENT_HANDLE CreateDeviceClientAndAllocateComponents(void)
@@ -588,13 +430,6 @@ static IOTHUB_DEVICE_CLIENT_HANDLE CreateDeviceClientAndAllocateComponents(void)
         LogError("Cannot read required environment variable(s)");
         result = false;
     }
-#ifdef USE_PROV_MODULE
-    else if ((g_pnpDeviceConfiguration.securityType == PNP_CONNECTION_SECURITY_TYPE_DPS) && (GetIoTHubFromDPS() == false))
-    {
-        LogError("Cannot retrieve IoT Hub connection information from DPS client");
-        result = false;
-    }
-#endif
     else if ((deviceClient = PnPHelper_CreateDeviceClientHandle(&g_pnpDeviceConfiguration)) == NULL)
     {
         LogError("Failure creating IotHub device client");
@@ -662,10 +497,6 @@ int main(void)
         // Free the memory allocated to track simulated thermostat.
         PnP_ThermostatComponent_Destroy(g_thermostatHandle2);
         PnP_ThermostatComponent_Destroy(g_thermostatHandle1);
-
-#ifndef USE_PROV_MODULE
-        FreeDpsConfiguration();
-#endif
 
         // Clean up the iothub sdk handle
         IoTHubDeviceClient_Destroy(deviceClient);


### PR DESCRIPTION
Adds DPS support to PnP temperature controller sample.

Note that we are not addressing other known issues like `helper` or transitioning from convenience layer to LL in this PR to minimize # of changes for reviewers.  Other changes will be forthcoming.