### PR TITLE
Remove redundant helpers name from file and function names

### DIFF
--- a/iothub_client/samples/pnp/common/pnp_device_client.c
+++ b/iothub_client/samples/pnp/common/pnp_device_client.c
@@ -9,7 +9,7 @@
 #include "iothub_device_client.h"
 #include "iothub_client_options.h"
 #include "iothubtransportmqtt.h"
-#include "pnp_device_client_helpers.h"
+#include "pnp_device_client.h"
 #ifdef USE_PROV_MODULE_FULL
 // DPS functionality using symmetric keys is only available if the cmake 
 // flags <-Duse_prov_client=ON -Dhsm_type_symm_key=ON> are enabled when building the Azure IoT C SDK.
@@ -51,7 +51,7 @@ static IOTHUB_DEVICE_CLIENT_HANDLE AllocateDeviceClientHandle(const PNP_DEVICE_C
     return deviceHandle;
 }
 
-IOTHUB_DEVICE_CLIENT_HANDLE PnPHelper_CreateDeviceClientHandle(const PNP_DEVICE_CONFIGURATION* pnpDeviceConfiguration)
+IOTHUB_DEVICE_CLIENT_HANDLE PnP_CreateDeviceClientHandle(const PNP_DEVICE_CONFIGURATION* pnpDeviceConfiguration)
 {
     IOTHUB_DEVICE_CLIENT_HANDLE deviceHandle = NULL;
     IOTHUB_CLIENT_RESULT iothubResult;

--- a/iothub_client/samples/pnp/common/pnp_device_client.h
+++ b/iothub_client/samples/pnp/common/pnp_device_client.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#ifndef PNP_DEVICE_CLIENT_HELPERS_H
-#define PNP_DEVICE_CLIENT_HELPERS_H
+#ifndef PNP_DEVICE_CLIENT_H
+#define PNP_DEVICE_CLIENT_H
 
 #include "iothub_device_client.h"
 
@@ -28,7 +28,7 @@ typedef struct PNP_DPS_CONFIGURATION_TAG
 #endif /* USE_PROV_MODULE_FULL */
 
 //
-// PNP_HELPER_DEVICE_CONFIGURATION is used to setup the IOTHUB_DEVICE_CLIENT_HANDLE
+// PNP_DEVICE_CONFIGURATION is used to setup the IOTHUB_DEVICE_CLIENT_HANDLE
 //
 typedef struct PNP_DEVICE_CONFIGURATION_TAG
 {
@@ -54,13 +54,13 @@ typedef struct PNP_DEVICE_CONFIGURATION_TAG
 } PNP_DEVICE_CONFIGURATION;
 
 //
-// PnPHelper_CreateDeviceClientHandle creates an IOTHUB_DEVICE_CLIENT_HANDLE that will be ready to interact with PnP.
+// PnP_CreateDeviceClientHandle creates an IOTHUB_DEVICE_CLIENT_HANDLE that will be ready to interact with PnP.
 // Beyond basic handle creation, it also sets the handle to the appropriate ModelId, optionally sets up callback functions
 // for Device Method and Device Twin callbacks (to process PnP Commands and Properties, respectively)
 // as well as some other basic maintenence on the handle. 
 //
 // NOTE: When using DPS based authentication, this function can *block* until DPS responds to the request or timeout.
 //
-IOTHUB_DEVICE_CLIENT_HANDLE PnPHelper_CreateDeviceClientHandle(const PNP_DEVICE_CONFIGURATION* pnpDeviceConfiguration);
+IOTHUB_DEVICE_CLIENT_HANDLE PnP_CreateDeviceClientHandle(const PNP_DEVICE_CONFIGURATION* pnpDeviceConfiguration);
 
-#endif /* PNP_DEVICE_CLIENT_HELPERS_H */
+#endif /* PNP_DEVICE_CLIENT_H */

--- a/iothub_client/samples/pnp/common/pnp_dps.c
+++ b/iothub_client/samples/pnp/common/pnp_dps.c
@@ -11,7 +11,7 @@
 
 #include "iothub_device_client.h"
 #include "iothubtransportmqtt.h"
-#include "pnp_device_client_helpers.h"
+#include "pnp_device_client.h"
 
 #include "azure_c_shared_utility/strings.h"
 #include "azure_c_shared_utility/threadapi.h"

--- a/iothub_client/samples/pnp/common/pnp_dps.h
+++ b/iothub_client/samples/pnp/common/pnp_dps.h
@@ -14,7 +14,7 @@
 // PnP_CreateDeviceClientHandle_ViaDps is used to create a IOTHUB_DEVICE_CLIENT_HANDLE, invoking the DPS client
 // to retrieve the needed hub information.
 //
-// Applications should NOT invoke this function directly but instead should use PnPHelper_CreateDeviceClientHandle.
+// Applications should NOT invoke this function directly but instead should use PnP_CreateDeviceClientHandle.
 //
 IOTHUB_DEVICE_CLIENT_HANDLE PnP_CreateDeviceClientHandle_ViaDps(const PNP_DEVICE_CONFIGURATION* pnpDeviceConfiguration);
 

--- a/iothub_client/samples/pnp/common/pnp_protocol.c
+++ b/iothub_client/samples/pnp/common/pnp_protocol.c
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // Header associated with this .c file
-#include "pnp_protocol_helpers.h"
+#include "pnp_protocol.h"
 
 // JSON parsing library
 #include "parson.h"
@@ -36,7 +36,7 @@ static const char g_IoTHubTwinDesiredObjectName[] = "desired";
 // Telemetry message property used to indicate the message's component.
 static const char PnP_TelemetryComponentProperty[] = "$.sub";
 
-STRING_HANDLE PnPHelper_CreateReportedProperty(const char* componentName, const char* propertyName, const char* propertyValue)
+STRING_HANDLE PnP_CreateReportedProperty(const char* componentName, const char* propertyName, const char* propertyValue)
 {
     STRING_HANDLE jsonToSend;
 
@@ -57,7 +57,7 @@ STRING_HANDLE PnPHelper_CreateReportedProperty(const char* componentName, const 
     return jsonToSend;
 }
 
-STRING_HANDLE PnPHelper_CreateReportedPropertyWithStatus(const char* componentName, const char* propertyName, const char* propertyValue, int result, const char* description, int ackVersion)
+STRING_HANDLE PnP_CreateReportedPropertyWithStatus(const char* componentName, const char* propertyName, const char* propertyValue, int result, const char* description, int ackVersion)
 {
     STRING_HANDLE jsonToSend;
 
@@ -78,7 +78,7 @@ STRING_HANDLE PnPHelper_CreateReportedPropertyWithStatus(const char* componentNa
     return jsonToSend;    
 }
 
-void PnPHelper_ParseCommandName(const char* deviceMethodName, unsigned const char** componentName, size_t* componentNameSize, const char** pnpCommandName)
+void PnP_ParseCommandName(const char* deviceMethodName, unsigned const char** componentName, size_t* componentNameSize, const char** pnpCommandName)
 {
     const char* separator;
 
@@ -100,7 +100,7 @@ void PnPHelper_ParseCommandName(const char* deviceMethodName, unsigned const cha
     }
 }
 
-IOTHUB_MESSAGE_HANDLE PnPHelper_CreateTelemetryMessageHandle(const char* componentName, const char* telemetryData) 
+IOTHUB_MESSAGE_HANDLE PnP_CreateTelemetryMessageHandle(const char* componentName, const char* telemetryData) 
 {
     IOTHUB_MESSAGE_HANDLE messageHandle;
     IOTHUB_MESSAGE_RESULT iothubMessageResult;
@@ -135,7 +135,7 @@ IOTHUB_MESSAGE_HANDLE PnPHelper_CreateTelemetryMessageHandle(const char* compone
 // VisitComponentProperties visits each sub element of the the given objectName in the desired JSON.  Each of these sub elements corresponds to
 // a property of this component, which we'll invoke the application's pnpPropertyCallback to inform.
 // 
-static void VisitComponentProperties(const char* objectName, JSON_Value* value, int version, PnPHelperPropertyCallbackFunction pnpPropertyCallback, void* userContextCallback)
+static void VisitComponentProperties(const char* objectName, JSON_Value* value, int version, PnPPropertyCallbackFunction pnpPropertyCallback, void* userContextCallback)
 {
     JSON_Object* object = json_value_get_object(value);
     size_t numChildren = json_object_get_count(object);
@@ -188,7 +188,7 @@ static bool IsJsonObjectAComponentInModel(const char* objectName, const char** c
 //
 // VisitDesiredObject visits each child JSON element of the desired device twin.  As we parse each property out, we invoke the application's passed in pnpPropertyCallback.
 //
-static bool VisitDesiredObject(JSON_Object* desiredObject, const char** componentsInModel, size_t numComponentsInModel, PnPHelperPropertyCallbackFunction pnpPropertyCallback, void* userContextCallback)
+static bool VisitDesiredObject(JSON_Object* desiredObject, const char** componentsInModel, size_t numComponentsInModel, PnPPropertyCallbackFunction pnpPropertyCallback, void* userContextCallback)
 {
     JSON_Value* versionValue = NULL;
     size_t numChildren;
@@ -275,14 +275,14 @@ static JSON_Object* GetDesiredJson(DEVICE_TWIN_UPDATE_STATE updateState, JSON_Va
     return desiredObject;
 }
 
-bool PnPHelper_ProcessTwinData(DEVICE_TWIN_UPDATE_STATE updateState, const unsigned char* payload, size_t size, const char** componentsInModel, size_t numComponentsInModel, PnPHelperPropertyCallbackFunction pnpPropertyCallback, void* userContextCallback)
+bool PnP_ProcessTwinData(DEVICE_TWIN_UPDATE_STATE updateState, const unsigned char* payload, size_t size, const char** componentsInModel, size_t numComponentsInModel, PnPPropertyCallbackFunction pnpPropertyCallback, void* userContextCallback)
 {
     char* jsonStr = NULL;
     JSON_Value* rootValue = NULL;
     JSON_Object* desiredObject;
     bool result;
 
-    if ((jsonStr = PnPHelper_CopyPayloadToString(payload, size)) == NULL)
+    if ((jsonStr = PnP_CopyPayloadToString(payload, size)) == NULL)
     {
         LogError("Unable to allocate twin buffer");
         result = false;
@@ -309,7 +309,7 @@ bool PnPHelper_ProcessTwinData(DEVICE_TWIN_UPDATE_STATE updateState, const unsig
     return result;
 }
 
-char* PnPHelper_CopyPayloadToString(const unsigned char* payload, size_t size)
+char* PnP_CopyPayloadToString(const unsigned char* payload, size_t size)
 {
     char* jsonStr;
     size_t sizeToAllocate = size + 1;

--- a/iothub_client/samples/pnp/common/pnp_protocol.h
+++ b/iothub_client/samples/pnp/common/pnp_protocol.h
@@ -3,12 +3,12 @@
 
 //
 // PnP is a convention built on top of existing IoTHub device transport primitives.
-// This header implements helper functions to aide applications in serializing and deserializing PnP data.
+// This header implements functions to aide applications in serializing and deserializing PnP data.
 // Note that actually sending and receiving the data from the underlying IoTHub client is the application's responsibility.
 //
 
-#ifndef PNP_PROTOCOL_HELPERS_H
-#define PNP_PROTOCOL_HELPERS_H
+#ifndef PNP_PROTOCOL_H
+#define PNP_PROTOCOL_H
 
 #include "azure_c_shared_utility/strings.h"
 #include "iothub_client_core_common.h"
@@ -29,21 +29,21 @@
 #define PNP_MAXIMUM_COMPONENT_LENGTH 64
 
 //
-// PnPHelperPropertyCallbackFunction defines the function prototype the application implements to receive a callback for each PnP property in a given Device Twin.
+// PnPPropertyCallbackFunction defines the function prototype the application implements to receive a callback for each PnP property in a given Device Twin.
 // 
-typedef void (*PnPHelperPropertyCallbackFunction)(const char* componentName, const char* propertyName, JSON_Value* propertyValue, int version, void* userContextCallback);
+typedef void (*PnPPropertyCallbackFunction)(const char* componentName, const char* propertyName, JSON_Value* propertyValue, int version, void* userContextCallback);
 
 //
-// PnPHelper_CreateReportedProperty returns JSON to report a property's value from the device.  This does NOT contain any metadata such as 
+// PnP_CreateReportedProperty returns JSON to report a property's value from the device.  This does NOT contain any metadata such as 
 // a result code or version.  It is used when sending properties that are NOT marked as <"writable": true> in the DTDL defining
 // the given property.
 //
 // The application itself needs to send this to Device Twin, using a function such as IoTHubDeviceClient_SendReportedState.
 //
-STRING_HANDLE PnPHelper_CreateReportedProperty(const char* componentName, const char* propertyName, const char* propertyValue);
+STRING_HANDLE PnP_CreateReportedProperty(const char* componentName, const char* propertyName, const char* propertyValue);
 
 //
-// PnPHelper_CreateReportedProperty returns JSON to report a property's value from the device.  This contains metadata such as 
+// PnP_CreateReportedProperty returns JSON to report a property's value from the device.  This contains metadata such as 
 // a result code or version.  It is used when responding to a desired property change request from the server, and in particular
 // for properties marked with <"writable": true>.
 // For instance, after processing a thermostat's set point the application acknowledges that it has received the request and can indicate 
@@ -51,35 +51,35 @@ STRING_HANDLE PnPHelper_CreateReportedProperty(const char* componentName, const 
 //
 // The application itself needs to send this to Device Twin, using a function such as IoTHubDeviceClient_SendReportedState.
 //
-STRING_HANDLE PnPHelper_CreateReportedPropertyWithStatus(const char* componentName, const char* propertyName, const char* propertyValue, int result, const char* description, int ackVersion);
+STRING_HANDLE PnP_CreateReportedPropertyWithStatus(const char* componentName, const char* propertyName, const char* propertyValue, int result, const char* description, int ackVersion);
 
 // 
-// PnPHelper_ParseCommandName is invoked by the application when an incoming device method arrives.  This function
+// PnP_ParseCommandName is invoked by the application when an incoming device method arrives.  This function
 // parses the device method name into the targeted (optional) component and PnP specific command.  Note that 
 // because we don't want to allocate separate buffers for componentName and pnpCommandName and we can't modify deviceMethodName in place,
 // we return the componentName as a non-NULL terminated character array with its length in componentNameSize.
 //
-void PnPHelper_ParseCommandName(const char* deviceMethodName, unsigned const char** componentName, size_t* componentNameSize, const char** pnpCommandName);
+void PnP_ParseCommandName(const char* deviceMethodName, unsigned const char** componentName, size_t* componentNameSize, const char** pnpCommandName);
 
 //
-// PnPHelper_CreateTelemetryMessageHandle creates an IOTHUB_MESSAGE_HANDLE that contains tho contents of the telemetryData.
+// PnP_CreateTelemetryMessageHandle creates an IOTHUB_MESSAGE_HANDLE that contains tho contents of the telemetryData.
 // If the optional componentName parameter is specified, the created message will have this as a property.
 //
 // The application itself needs to send this to IoTHub, using a function such as IoTHubDeviceClient_SendEventAsync.
 //
-IOTHUB_MESSAGE_HANDLE PnPHelper_CreateTelemetryMessageHandle(const char* componentName, const char* telemetryData);
+IOTHUB_MESSAGE_HANDLE PnP_CreateTelemetryMessageHandle(const char* componentName, const char* telemetryData);
 
 //
-// PnPHelper_ProcessTwinData is invoked by the application when a device twin arrives to its device twin processing callback.
-// PnPHelper_ProcessTwinData will visit the children of the desired portion of the twin and invoke the device's pnpPropertyCallback
+// PnP_ProcessTwinData is invoked by the application when a device twin arrives to its device twin processing callback.
+// PnP_ProcessTwinData will visit the children of the desired portion of the twin and invoke the device's pnpPropertyCallback
 // function for each property that it visits.
 // 
-bool PnPHelper_ProcessTwinData(DEVICE_TWIN_UPDATE_STATE updateState, const unsigned char* payload, size_t size, const char** componentsInModel, size_t numComponentsInModel, PnPHelperPropertyCallbackFunction pnpPropertyCallback, void* userContextCallback);
+bool PnP_ProcessTwinData(DEVICE_TWIN_UPDATE_STATE updateState, const unsigned char* payload, size_t size, const char** componentsInModel, size_t numComponentsInModel, PnPPropertyCallbackFunction pnpPropertyCallback, void* userContextCallback);
 
 //
-// PnPHelper_CopyTwinPayloadToString takes the payload data, which arrives as a potentially non-NULL terminated string from the IoTHub SDK, and creates
+// PnP_CopyTwinPayloadToString takes the payload data, which arrives as a potentially non-NULL terminated string from the IoTHub SDK, and creates
 // a new copy of the data with a NULL terminator.  The JSON parser this sample uses, parson, only operates over NULL terminated strings.
 //
-char* PnPHelper_CopyPayloadToString(const unsigned char* payload, size_t size);
+char* PnP_CopyPayloadToString(const unsigned char* payload, size_t size);
 
-#endif /* PNP_PROTOCOL_HELPERS_H */
+#endif /* PNP_PROTOCOL_H */

--- a/iothub_client/samples/pnp/common/readme.md
+++ b/iothub_client/samples/pnp/common/readme.md
@@ -1,4 +1,4 @@
-# Common helper utilities for PnP Sample
+# Common utilities for PnP Sample
 
 This directory contains sample code that your application should be able to take with little or no modification to accelerate implementing a PnP device application.
 
@@ -6,12 +6,12 @@ Probably the easiest way to understand how they work is to review the [pnp_tempe
 
 For reference the files are:
 
-* `pnp_device_client_helpers` header and .c file implement a function to help create a `IOTHUB_DEVICE_CLIENT_HANDLE`.  The `IOTHUB_DEVICE_CLIENT_HANDLE` is an existing IoTHub Device SDK that can be used for device <=> IoTHub communication.  (There are many samples demonstrating its non-PnP uses in the [samples parent directory](../..).)
+* `pnp_device_client` header and .c file implement a function to help create a `IOTHUB_DEVICE_CLIENT_HANDLE`.  The `IOTHUB_DEVICE_CLIENT_HANDLE` is an existing IoTHub Device SDK that can be used for device <=> IoTHub communication.  (There are many samples demonstrating its non-PnP uses in the [samples parent directory](../..).)
 
     Creating a `IOTHUB_DEVICE_CLIENT_HANDLE` that works with PnP requires a few additional steps, most importantly defining the device's PnP ModelId, which this code does.
 
     The Azure IoTHub SDK defines additional types of handles - namely `IOTHUB_DEVICE_CLIENT_LL_HANDLE` (for a device using the \_LL\_ lower layer) and for modules the analogous `IOTHUB_MODULE_CLIENT_HANDLE` and `IOTHUB_MODULE_CLIENT_LL_HANDLE`.  The code in this file can easily be modified to use a different handle flavor for your code.
 
-* `pnp_protocol_helpers` header and .c file implement functions to help with serializing and de-serializing the PnP convention.  As an example of their usefulness, PnP properties are sent between the device and IoTHub using a specific JSON convention over the device twin.  Helpers in this function perform some of the tedious parsing and JSON string generation that your PnP application would need to do.
+* `pnp_protocol` header and .c file implement functions to help with serializing and de-serializing the PnP convention.  As an example of their usefulness, PnP properties are sent between the device and IoTHub using a specific JSON convention over the device twin.  Functions in this header perform some of the tedious parsing and JSON string generation that your PnP application would need to do.
 
-    The helpers are agnostic to the underlying transport handle used.  If you use `IOTHUB_DEVICE_CLIENT_LL_HANDLE`, `IOTHUB_MODULE_CLIENT_HANDLE` or `IOTHUB_MODULE_CLIENT_LL_HANDLE` instead of the sample's `IOTHUB_DEVICE_CLIENT_HANDLE`, the `pnp_protocol_helpers` logic does not need to change.
+    The functions are agnostic to the underlying transport handle used.  If you use `IOTHUB_DEVICE_CLIENT_LL_HANDLE`, `IOTHUB_MODULE_CLIENT_HANDLE` or `IOTHUB_MODULE_CLIENT_LL_HANDLE` instead of the sample's `IOTHUB_DEVICE_CLIENT_HANDLE`, the `pnp_protocol` logic does not need to change.

--- a/iothub_client/samples/pnp/pnp_temperature_controller/CMakeLists.txt
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/CMakeLists.txt
@@ -9,8 +9,8 @@ set(pnp_temperature_controller_c_files
     pnp_temperature_controller.c
     pnp_thermostat_component.c
     pnp_deviceinfo_component.c
-    ../common/pnp_device_client_helpers.c
-    ../common/pnp_protocol_helpers.c
+    ../common/pnp_device_client.c
+    ../common/pnp_protocol.c
 )
 
 IF(WIN32)

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_deviceinfo_component.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_deviceinfo_component.c
@@ -3,16 +3,16 @@
 
 // The DTDL for this interface is defined at https://repo.azureiotrepository.com/Models/dtmi:azure:DeviceManagement:DeviceInformation;1?api-version=2020-05-01-preview
 
-// PnP helper routines
+// PnP routines
 #include "pnp_deviceinfo_component.h"
-#include "pnp_protocol_helpers.h"
+#include "pnp_protocol.h"
 
 // Core IoT SDK utilities
 #include "azure_c_shared_utility/xlogging.h"
 
 // Property names along with their simulated values.  
 // NOTE: the property values must be legal JSON values.  Strings specifically must be enclosed with an extra set of quotes to be legal json string values.
-// The property names in this sample do not hard-code the extra quotes because the underlying PnP helper adds this to names automatically.
+// The property names in this sample do not hard-code the extra quotes because the underlying PnP sample adds this to names automatically.
 #define PNP_ENCODE_STRING_FOR_JSON(str) #str
 
 static const char PnPDeviceInfo_SoftwareVersionPropertyName[] = "swVersion";
@@ -48,7 +48,7 @@ static void SendReportedPropertyForDeviceInformation(IOTHUB_DEVICE_CLIENT_HANDLE
     IOTHUB_CLIENT_RESULT iothubClientResult;
     STRING_HANDLE jsonToSend = NULL;
 
-    if ((jsonToSend = PnPHelper_CreateReportedProperty(componentName, propertyName, propertyValue)) == NULL)
+    if ((jsonToSend = PnP_CreateReportedProperty(componentName, propertyName, propertyValue)) == NULL)
     {
         LogError("Unable to build reported property response for propertyName=%s, propertyValue=%s", propertyName, propertyValue);
     }
@@ -74,7 +74,7 @@ void PnP_DeviceInfoComponent_Report_All_Properties(const char* componentName, IO
 {
     // NOTE: It is possible to put multiple property updates into a single JSON and IoTHubDeviceClient_SendReportedState invocation.
     // This sample does not do so for clarity, though production devices should seriously consider such property update batching to
-    // save bandwidth.  The underlying PnP_Helper routines currently do not accept an array.
+    // save bandwidth.  PnP_CreateReportedProperty does not currently accept arrays.
     SendReportedPropertyForDeviceInformation(deviceClient, componentName, PnPDeviceInfo_SoftwareVersionPropertyName, PnPDeviceInfo_SoftwareVersionPropertyValue);
     SendReportedPropertyForDeviceInformation(deviceClient, componentName, PnPDeviceInfo_ManufacturerPropertyName, PnPDeviceInfo_ManufacturerPropertyValue);
     SendReportedPropertyForDeviceInformation(deviceClient, componentName, PnPDeviceInfo_ModelPropertyName, PnPDeviceInfo_ModelPropertyValue);

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.c
@@ -7,8 +7,8 @@
 #include <string.h>
 #include <time.h>
 
-// PnP helper routines
-#include "pnp_protocol_helpers.h"
+// PnP routines
+#include "pnp_protocol.h"
 #include "pnp_thermostat_component.h"
 
 // Core IoT SDK utilities
@@ -261,7 +261,7 @@ static void SendTargetTemperatureResponse(PNP_THERMOSTAT_COMPONENT* pnpThermosta
     {
         LogError("Unable to create target temperature string for reporting result");
     }
-    else if ((jsonToSend = PnPHelper_CreateReportedPropertyWithStatus(pnpThermostatComponent->componentName, g_targetTemperaturePropertyName, targetTemperatureAsString, 
+    else if ((jsonToSend = PnP_CreateReportedPropertyWithStatus(pnpThermostatComponent->componentName, g_targetTemperaturePropertyName, targetTemperatureAsString, 
                                                                       PNP_STATUS_SUCCESS, g_temperaturePropertyResponseDescription, version)) == NULL)
     {
         LogError("Unable to build reported property response");
@@ -295,7 +295,7 @@ void PnP_TempControlComponent_Report_MaxTempSinceLastReboot_Property(PNP_THERMOS
     {
         LogError("Unable to create max temp since last reboot string for reporting result");
     }
-    else if ((jsonToSend = PnPHelper_CreateReportedProperty(pnpThermostatComponent->componentName, g_maxTempSinceLastRebootPropertyName, maximumTemperatureAsString)) == NULL)
+    else if ((jsonToSend = PnP_CreateReportedProperty(pnpThermostatComponent->componentName, g_maxTempSinceLastRebootPropertyName, maximumTemperatureAsString)) == NULL)
     {
         LogError("Unable to build max temp since last reboot property");
     }
@@ -361,7 +361,7 @@ void PnP_ThermostatComponent_SendTelemetry(PNP_THERMOSTAT_COMPONENT_HANDLE pnpTh
     {
         LogError("snprintf of current temperature telemetry failed");
     }
-    else if ((messageHandle = PnPHelper_CreateTelemetryMessageHandle(pnpThermostatComponent->componentName, temperatureStringBuffer)) == NULL)
+    else if ((messageHandle = PnP_CreateTelemetryMessageHandle(pnpThermostatComponent->componentName, temperatureStringBuffer)) == NULL)
     {
         LogError("Unable to create telemetry message");
     }

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.h
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.h
@@ -8,7 +8,7 @@
 // thermostat2.  
 //
 // The code in this header/.c file is designed to be generic so that the calling application can call PnP_ThermostatComponent_CreateHandle
-// multiple times and then pass processing of a given component (thermostat1 or thermostat2) to the appropriate helper.
+// multiple times and then pass processing of a given component (thermostat1 or thermostat2) to the appropriate function.
 //
 
 #ifndef PNP_THERMOSTAT_CONTROLLER_H

--- a/iothub_client/samples/pnp/readme.md
+++ b/iothub_client/samples/pnp/readme.md
@@ -10,7 +10,7 @@ The directory contains the following samples:
 
 * [pnp_temperature_controller](./pnp_temperature_controller) A temperature controller that implements the model [dtmi:com:example:TemperatureController;1](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json).  This is considerably more complex than the [pnp_simple_thermostat](./pnp_simple_thermostat) and demonstrates the use of subcomponents.  **You should move onto this sample only after fully understanding pnp_simple_thermostat.**
 
-* [common](./common) This directory contains helpers for serializing and de-serializing data for PnP and for creating the `IOTHUB_DEVICE_CLIENT_HANDLE` that acts as the transport.  `pnp_temperature_controller` makes extensive use of these helpers and demonstrates their use.  **The files in [common](./common) are written generically such that your PnP device application can use them with little or no modification, speeding up your devolpment.**
+* [common](./common) This directory contains functions for serializing and de-serializing data for PnP and for creating the `IOTHUB_DEVICE_CLIENT_HANDLE` that acts as the transport.  `pnp_temperature_controller` makes extensive use of these functions and demonstrates their use.  **The files in [common](./common) are written generically such that your PnP device application should be able to use them with little or no modification, speeding up your devolpment.**
 
 ## Caveats
 

--- a/iothub_client/samples/pnp/readme.md
+++ b/iothub_client/samples/pnp/readme.md
@@ -10,7 +10,7 @@ The directory contains the following samples:
 
 * [pnp_temperature_controller](./pnp_temperature_controller) A temperature controller that implements the model [dtmi:com:example:TemperatureController;1](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json).  This is considerably more complex than the [pnp_simple_thermostat](./pnp_simple_thermostat) and demonstrates the use of subcomponents.  **You should move onto this sample only after fully understanding pnp_simple_thermostat.**
 
-* [common](./common) This directory contains functions for serializing and de-serializing data for PnP and for creating the `IOTHUB_DEVICE_CLIENT_HANDLE` that acts as the transport.  `pnp_temperature_controller` makes extensive use of these functions and demonstrates their use.  **The files in [common](./common) are written generically such that your PnP device application should be able to use them with little or no modification, speeding up your devolpment.**
+* [common](./common) This directory contains functions for serializing and de-serializing data for PnP and for creating the `IOTHUB_DEVICE_CLIENT_HANDLE` that acts as the transport.  `pnp_temperature_controller` makes extensive use of these functions and demonstrates their use.  **The files in [common](./common) are written generically such that your PnP device application should be able to use them with little or no modification, speeding up your development.**
 
 ## Caveats
 


### PR DESCRIPTION
Naming functions and file name with `helper` wasn't particularly helpful.  Cleaning up.