### PR TITLE
Fix for Issue 1290

### DIFF
--- a/iothub_client/inc/iothub_message.h
+++ b/iothub_client/inc/iothub_message.h
@@ -193,7 +193,7 @@ MOCKABLE_FUNCTION(, MAP_HANDLE, IoTHubMessage_Properties, IOTHUB_MESSAGE_HANDLE,
 *
 * @param   key name of the property to set using ASCII.  Note that when sending messages via the HTTP transport, this value must not contain spaces.
 *
-* @param   value of the property to set using ASCII
+* @param   value of the property to set using ASCII.
 *
 * @return  An @c IOTHUB_MESSAGE_RESULT value indicating the result of setting the property.
 */

--- a/iothub_client/inc/iothub_message.h
+++ b/iothub_client/inc/iothub_message.h
@@ -191,9 +191,9 @@ MOCKABLE_FUNCTION(, MAP_HANDLE, IoTHubMessage_Properties, IOTHUB_MESSAGE_HANDLE,
 *
 * @param   iotHubMessageHandle Handle to the message.
 *
-* @param   key name of the property to set.  Note that when sending messages via the HTTP transport, this value must not contain spaces.
+* @param   key name of the property to set using ASCII.  Note that when sending messages via the HTTP transport, this value must not contain spaces.
 *
-* @param   value of the property to set.
+* @param   value of the property to set using ASCII
 *
 * @return  An @c IOTHUB_MESSAGE_RESULT value indicating the result of setting the property.
 */
@@ -356,7 +356,7 @@ MOCKABLE_FUNCTION(, IOTHUB_MESSAGE_RESULT, IoTHubMessage_SetConnectionModuleId, 
 MOCKABLE_FUNCTION(, const char*, IoTHubMessage_GetConnectionDeviceId, IOTHUB_MESSAGE_HANDLE, iotHubMessageHandle);
 
 /**
-* @brief   Sets the message creation time in UTC. 
+* @brief   Sets the message creation time in UTC.
 *
 * @param   iotHubMessageHandle Handle to the message.
 * @param   messageCreationTimeUtc Pointer to the message creation time as null-terminated string

--- a/iothub_client/src/iothub_message.c
+++ b/iothub_client/src/iothub_message.c
@@ -572,12 +572,13 @@ IOTHUB_MESSAGE_RESULT IoTHubMessage_SetProperty(IOTHUB_MESSAGE_HANDLE msg_handle
     }
     else
     {
-        if (Map_AddOrUpdate(msg_handle->properties, key, value) == MAP_FILTER_REJECT)
+        MAP_RESULT map_result = Map_AddOrUpdate(msg_handle->properties, key, value);
+        if (map_result == MAP_FILTER_REJECT)
         {
             LogError("Failure validating property as ASCII");
             result = IOTHUB_MESSAGE_INVALID_TYPE;
         }
-        else if (Map_AddOrUpdate(msg_handle->properties, key, value) != MAP_OK)
+        else if (map_result != MAP_OK)
         {
             LogError("Failure adding property to internal map");
             result = IOTHUB_MESSAGE_ERROR;

--- a/iothub_client/src/iothub_message.c
+++ b/iothub_client/src/iothub_message.c
@@ -572,7 +572,12 @@ IOTHUB_MESSAGE_RESULT IoTHubMessage_SetProperty(IOTHUB_MESSAGE_HANDLE msg_handle
     }
     else
     {
-        if (Map_AddOrUpdate(msg_handle->properties, key, value) != MAP_OK)
+        if (Map_AddOrUpdate(msg_handle->properties, key, value) == MAP_FILTER_REJECT)
+        {
+            LogError("Failure validating property as ASCII");
+            result = IOTHUB_MESSAGE_INVALID_TYPE;
+        }
+        else if (Map_AddOrUpdate(msg_handle->properties, key, value) != MAP_OK)
         {
             LogError("Failure adding property to internal map");
             result = IOTHUB_MESSAGE_ERROR;

--- a/iothub_client/tests/iothubmessage_ut/iothubmessage_ut.c
+++ b/iothub_client/tests/iothubmessage_ut/iothubmessage_ut.c
@@ -82,8 +82,8 @@ static const char* TEST_CONNECTION_MODULE_ID = "connectionmoduleid";
 static const char* TEST_CONNECTION_MODULE_ID2 = "connectionmoduleid2";
 static const char* TEST_PROPERTY_KEY = "property_key";
 static const char* TEST_PROPERTY_VALUE = "property_value";
-static const char* TEST_NON_ASCII_PROPERTY_KEY = "\x01property_key"
-static const char* TEST_NON_ASCII_PROPERTY_VALUE = "\x01property_value"
+static const char* TEST_NON_ASCII_PROPERTY_KEY = "\x01property_key";
+static const char* TEST_NON_ASCII_PROPERTY_VALUE = "\x01property_value";
 
 static const char* TEST_MESSAGE_CREATION_TIME_UTC = "2020-07-01T01:00:00.000Z";
 static const char* TEST_MESSAGE_USER_ID = "2d4e2570-e7c2-4651-b190-4607986e3b9f";

--- a/iothub_client/tests/iothubmessage_ut/iothubmessage_ut.c
+++ b/iothub_client/tests/iothubmessage_ut/iothubmessage_ut.c
@@ -1776,7 +1776,7 @@ TEST_FUNCTION(IoTHubMessage_SetProperty_value_NULL_Fail)
     IoTHubMessage_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubMessage_SetProperty_Key_Non_Ascii_Fail)
+TEST_FUNCTION(IoTHubMessage_SetProperty_key_Non_Ascii_Fail)
 {
     //arrange
     IOTHUB_MESSAGE_HANDLE h = IoTHubMessage_CreateFromByteArray(c, 1);
@@ -1785,7 +1785,7 @@ TEST_FUNCTION(IoTHubMessage_SetProperty_Key_Non_Ascii_Fail)
     STRICT_EXPECTED_CALL(Map_AddOrUpdate(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG)).SetReturn(MAP_FILTER_REJECT);
 
     //act
-    IOTHUB_MESSAGE_RESULT result = IoTHubMessage_SetProperty(h, TEST_PROPERTY_KEY, TEST_PROPERTY_VALUE);
+    IOTHUB_MESSAGE_RESULT result = IoTHubMessage_SetProperty(h, TEST_NON_ASCII_PROPERTY_KEY, TEST_PROPERTY_VALUE);
 
     //assert
     ASSERT_ARE_NOT_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_OK, result);
@@ -1795,7 +1795,7 @@ TEST_FUNCTION(IoTHubMessage_SetProperty_Key_Non_Ascii_Fail)
     IoTHubMessage_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubMessage_SetProperty_Value_Non_Ascii_Fail)
+TEST_FUNCTION(IoTHubMessage_SetProperty_value_Non_Ascii_Fail)
 {
     //arrange
     IOTHUB_MESSAGE_HANDLE h = IoTHubMessage_CreateFromByteArray(c, 1);
@@ -1804,7 +1804,7 @@ TEST_FUNCTION(IoTHubMessage_SetProperty_Value_Non_Ascii_Fail)
     STRICT_EXPECTED_CALL(Map_AddOrUpdate(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG)).SetReturn(MAP_FILTER_REJECT);
 
     //act
-    IOTHUB_MESSAGE_RESULT result = IoTHubMessage_SetProperty(h, TEST_PROPERTY_KEY, TEST_PROPERTY_VALUE);
+    IOTHUB_MESSAGE_RESULT result = IoTHubMessage_SetProperty(h, TEST_PROPERTY_KEY, TEST_NON_ASCII_PROPERTY_VALUE);
 
     //assert
     ASSERT_ARE_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_INVALID_TYPE, result);

--- a/iothub_client/tests/iothubmessage_ut/iothubmessage_ut.c
+++ b/iothub_client/tests/iothubmessage_ut/iothubmessage_ut.c
@@ -1788,7 +1788,7 @@ TEST_FUNCTION(IoTHubMessage_SetProperty_key_Non_Ascii_Fail)
     IOTHUB_MESSAGE_RESULT result = IoTHubMessage_SetProperty(h, TEST_NON_ASCII_PROPERTY_KEY, TEST_PROPERTY_VALUE);
 
     //assert
-    ASSERT_ARE_NOT_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_INVALID_TYPE, result);
+    ASSERT_ARE_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_INVALID_TYPE, result);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     //cleanup

--- a/iothub_client/tests/iothubmessage_ut/iothubmessage_ut.c
+++ b/iothub_client/tests/iothubmessage_ut/iothubmessage_ut.c
@@ -82,6 +82,8 @@ static const char* TEST_CONNECTION_MODULE_ID = "connectionmoduleid";
 static const char* TEST_CONNECTION_MODULE_ID2 = "connectionmoduleid2";
 static const char* TEST_PROPERTY_KEY = "property_key";
 static const char* TEST_PROPERTY_VALUE = "property_value";
+static const char* TEST_NON_ASCII_PROPERTY_KEY = "\x01property_key"
+static const char* TEST_NON_ASCII_PROPERTY_VALUE = "\x01property_value"
 
 static const char* TEST_MESSAGE_CREATION_TIME_UTC = "2020-07-01T01:00:00.000Z";
 static const char* TEST_MESSAGE_USER_ID = "2d4e2570-e7c2-4651-b190-4607986e3b9f";
@@ -1774,6 +1776,44 @@ TEST_FUNCTION(IoTHubMessage_SetProperty_value_NULL_Fail)
     IoTHubMessage_Destroy(h);
 }
 
+TEST_FUNCTION(IoTHubMessage_SetProperty_Key_Non_Ascii_Fail)
+{
+    //arrange
+    IOTHUB_MESSAGE_HANDLE h = IoTHubMessage_CreateFromByteArray(c, 1);
+    umock_c_reset_all_calls();
+
+    STRICT_EXPECTED_CALL(Map_AddOrUpdate(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG)).SetReturn(MAP_FILTER_REJECT);
+
+    //act
+    IOTHUB_MESSAGE_RESULT result = IoTHubMessage_SetProperty(h, TEST_PROPERTY_KEY, TEST_PROPERTY_VALUE);
+
+    //assert
+    ASSERT_ARE_NOT_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_OK, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    //cleanup
+    IoTHubMessage_Destroy(h);
+}
+
+TEST_FUNCTION(IoTHubMessage_SetProperty_Value_Non_Ascii_Fail)
+{
+    //arrange
+    IOTHUB_MESSAGE_HANDLE h = IoTHubMessage_CreateFromByteArray(c, 1);
+    umock_c_reset_all_calls();
+
+    STRICT_EXPECTED_CALL(Map_AddOrUpdate(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG)).SetReturn(MAP_FILTER_REJECT);
+
+    //act
+    IOTHUB_MESSAGE_RESULT result = IoTHubMessage_SetProperty(h, TEST_PROPERTY_KEY, TEST_PROPERTY_VALUE);
+
+    //assert
+    ASSERT_ARE_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_INVALID_TYPE, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    //cleanup
+    IoTHubMessage_Destroy(h);
+}
+
 TEST_FUNCTION(IoTHubMessage_SetProperty_Fail)
 {
     //arrange
@@ -1786,7 +1826,7 @@ TEST_FUNCTION(IoTHubMessage_SetProperty_Fail)
     IOTHUB_MESSAGE_RESULT result = IoTHubMessage_SetProperty(h, TEST_PROPERTY_KEY, TEST_PROPERTY_VALUE);
 
     //assert
-    ASSERT_ARE_NOT_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_OK, result);
+    ASSERT_ARE_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_INVALID_TYPE, result);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     //cleanup
@@ -2216,5 +2256,3 @@ TEST_FUNCTION(IoTHubMessage_GetUserIdSystemProperty_SUCCEED)
 }
 
 END_TEST_SUITE(iothubmessage_ut)
-
-

--- a/iothub_client/tests/iothubmessage_ut/iothubmessage_ut.c
+++ b/iothub_client/tests/iothubmessage_ut/iothubmessage_ut.c
@@ -1736,7 +1736,7 @@ TEST_FUNCTION(IoTHubMessage_SetProperty_handle_NULL_Fail)
     IOTHUB_MESSAGE_RESULT result = IoTHubMessage_SetProperty(NULL, TEST_PROPERTY_KEY, TEST_PROPERTY_VALUE);
 
     //assert
-    ASSERT_ARE_NOT_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_OK, result);
+    ASSERT_ARE_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_INVALID_ARG, result);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     //cleanup
@@ -1752,7 +1752,7 @@ TEST_FUNCTION(IoTHubMessage_SetProperty_key_NULL_Fail)
     IOTHUB_MESSAGE_RESULT result = IoTHubMessage_SetProperty(h, NULL, TEST_PROPERTY_VALUE);
 
     //assert
-    ASSERT_ARE_NOT_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_OK, result);
+    ASSERT_ARE_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_INVALID_ARG, result);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     //cleanup
@@ -1769,7 +1769,7 @@ TEST_FUNCTION(IoTHubMessage_SetProperty_value_NULL_Fail)
     IOTHUB_MESSAGE_RESULT result = IoTHubMessage_SetProperty(h, TEST_PROPERTY_KEY, NULL);
 
     //assert
-    ASSERT_ARE_NOT_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_OK, result);
+    ASSERT_ARE_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_INVALID_ARG, result);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     //cleanup
@@ -1788,7 +1788,7 @@ TEST_FUNCTION(IoTHubMessage_SetProperty_key_Non_Ascii_Fail)
     IOTHUB_MESSAGE_RESULT result = IoTHubMessage_SetProperty(h, TEST_NON_ASCII_PROPERTY_KEY, TEST_PROPERTY_VALUE);
 
     //assert
-    ASSERT_ARE_NOT_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_OK, result);
+    ASSERT_ARE_NOT_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_INVALID_TYPE, result);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     //cleanup
@@ -1826,7 +1826,7 @@ TEST_FUNCTION(IoTHubMessage_SetProperty_Fail)
     IOTHUB_MESSAGE_RESULT result = IoTHubMessage_SetProperty(h, TEST_PROPERTY_KEY, TEST_PROPERTY_VALUE);
 
     //assert
-    ASSERT_ARE_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_INVALID_TYPE, result);
+    ASSERT_ARE_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_ERROR, result);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     //cleanup


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-c/issues/1290
# Description of the problem
Addresses Issue 1290

# Description of the solution
Uses the unused error `IOTHUB_MESSAGE_INVALID_TYPE` to differentiate when the ascii check fails in calling `IoTHubMessage_SetProperty.`
Adds 2 unit tests accordingly.