### PR TITLE
SDK Reference fixes

### DIFF
--- a/iothub_client/inc/iothub_client.h
+++ b/iothub_client/inc/iothub_client.h
@@ -240,7 +240,7 @@ extern "C"
     *                  the parameter is <em>total request time</em>. When the HTTP protocol uses
     *                  winhttp, the meaning is the same as the @c dwSendTimeout and
     *                  @c dwReceiveTimeout parameters of the
-    *                  <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa384116(v=vs.85).aspx">
+    *                  <a href="https://msdn.microsoft.com/library/windows/desktop/aa384116(v=vs.85).aspx">
     *                  WinHttpSetTimeouts</a> API.
     *                - @b CURLOPT_LOW_SPEED_LIMIT - only available for HTTP protocol and only
     *                  when CURL is used. It has the same meaning as CURL's option with the same

--- a/iothub_client/inc/iothub_client_ll.h
+++ b/iothub_client/inc/iothub_client_ll.h
@@ -254,7 +254,7 @@ typedef struct IOTHUB_CLIENT_CORE_LL_HANDLE_DATA_TAG* IOTHUB_CLIENT_LL_HANDLE;
     *                  the parameter is <em>total request time</em>. When the HTTP protocol uses
     *                  winhttp, the meaning is the same as the @c dwSendTimeout and
     *                  @c dwReceiveTimeout parameters of the
-    *                  <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa384116(v=vs.85).aspx">
+    *                  <a href="https://msdn.microsoft.com/library/windows/desktop/aa384116(v=vs.85).aspx">
     *                  WinHttpSetTimeouts</a> API.
     *                - @b CURLOPT_LOW_SPEED_LIMIT - only available for HTTP protocol and only
     *                  when CURL is used. It has the same meaning as CURL's option with the same

--- a/iothub_client/inc/iothub_device_client.h
+++ b/iothub_client/inc/iothub_device_client.h
@@ -239,7 +239,7 @@ extern "C"
     *                  the parameter is <em>total request time</em>. When the HTTP protocol uses
     *                  winhttp, the meaning is the same as the @c dwSendTimeout and
     *                  @c dwReceiveTimeout parameters of the
-    *                  <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa384116(v=vs.85).aspx">
+    *                  <a href="https://msdn.microsoft.com/library/windows/desktop/aa384116(v=vs.85).aspx">
     *                  WinHttpSetTimeouts</a> API.
     *                - @b CURLOPT_LOW_SPEED_LIMIT - only available for HTTP protocol and only
     *                  when CURL is used. It has the same meaning as CURL's option with the same

--- a/iothub_client/inc/iothub_device_client_ll.h
+++ b/iothub_client/inc/iothub_device_client_ll.h
@@ -258,7 +258,7 @@ typedef struct IOTHUB_CLIENT_CORE_LL_HANDLE_DATA_TAG* IOTHUB_DEVICE_CLIENT_LL_HA
     *                  the parameter is <em>total request time</em>. When the HTTP protocol uses
     *                  winhttp, the meaning is the same as the @c dwSendTimeout and
     *                  @c dwReceiveTimeout parameters of the
-    *                  <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa384116(v=vs.85).aspx">
+    *                  <a href="https://msdn.microsoft.com/library/windows/desktop/aa384116(v=vs.85).aspx">
     *                  WinHttpSetTimeouts</a> API.
     *                - @b CURLOPT_LOW_SPEED_LIMIT - only available for HTTP protocol and only
     *                  when CURL is used. It has the same meaning as CURL's option with the same

--- a/iothub_client/inc/iothub_message.h
+++ b/iothub_client/inc/iothub_message.h
@@ -191,9 +191,12 @@ MOCKABLE_FUNCTION(, MAP_HANDLE, IoTHubMessage_Properties, IOTHUB_MESSAGE_HANDLE,
 *
 * @param   iotHubMessageHandle Handle to the message.
 *
-* @param   key name of the property to set.  Note that when sending messages via the HTTP transport, this value must not contain spaces.
+* @param   key name of the property to set. Note that when sending messages via the HTTP transport, this value must not contain spaces.
 *
-* @param   value of the property to set.
+* @param   value of the property to set. Note that when sending messages via the HTTP transport, this value must not contain spaces.
+*
+*            @b NOTE: Property names and values must not contain spaces and can only contain ASCII alphanumeric characters, 
+*            plus {'!', '#', '$', '%, '&', ''', '*', '+', '-', '.', '^', '_', '`', '|', '~'}.
 *
 * @return  An @c IOTHUB_MESSAGE_RESULT value indicating the result of setting the property.
 */

--- a/iothub_client/inc/iothub_module_client.h
+++ b/iothub_client/inc/iothub_module_client.h
@@ -197,7 +197,7 @@ extern "C"
     *                  the parameter is <em>total request time</em>. When the HTTP protocol uses
     *                  winhttp, the meaning is the same as the @c dwSendTimeout and
     *                  @c dwReceiveTimeout parameters of the
-    *                  <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa384116(v=vs.85).aspx">
+    *                  <a href="https://msdn.microsoft.com/library/windows/desktop/aa384116(v=vs.85).aspx">
     *                  WinHttpSetTimeouts</a> API.
     *                - @b CURLOPT_LOW_SPEED_LIMIT - only available for HTTP protocol and only
     *                  when CURL is used. It has the same meaning as CURL's option with the same

--- a/iothub_client/inc/iothub_module_client_ll.h
+++ b/iothub_client/inc/iothub_module_client_ll.h
@@ -223,7 +223,7 @@ extern "C"
     *                  the parameter is <em>total request time</em>. When the HTTP protocol uses
     *                  winhttp, the meaning is the same as the @c dwSendTimeout and
     *                  @c dwReceiveTimeout parameters of the
-    *                  <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa384116(v=vs.85).aspx">
+    *                  <a href="https://msdn.microsoft.com/library/windows/desktop/aa384116(v=vs.85).aspx">
     *                  WinHttpSetTimeouts</a> API.
     *                - @b CURLOPT_LOW_SPEED_LIMIT - only available for HTTP protocol and only
     *                  when CURL is used. It has the same meaning as CURL's option with the same


### PR DESCRIPTION
This change only affects reference docs generated from the header files of the IoT C SDK.

Remove hardcoded EN lang links which causes build issues with docs.microsoft.com. Also added a fix for [Github issue 1290](https://github.com/Azure/azure-iot-sdk-c/issues/1290)

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [X] This pull-request is submitted against the `master` branch. 
  - [X] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [X] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

[https://github.com/Azure/azure-iot-sdk-c/issues/1290](https://github.com/Azure/azure-iot-sdk-c/issues/1290)

# Description of the problem

These changes support the latest refresh of the reference docs located at [https://docs.microsoft.com/en-us/azure/iot-hub/iot-c-sdk-ref/](https://docs.microsoft.com/en-us/azure/iot-hub/iot-c-sdk-ref/)

* Remove hardcoded english language in HTML links.  These causes issues with docs.microsoft.com build and validation checking.  By using non-locale specific links we retain the option to localize reference content/
* Added comments for doc coverage of [IoTHubMessage_SetProperty()](https://docs.microsoft.com/azure/iot-hub/iot-c-sdk-ref/iothub-message-h/iothubmessage-setproperty) to inform customers of the valid characters for the property key and value.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 