### PR TITLE
Added support for fetch of SAS token via callback

### DIFF
--- a/iothub_client/inc/internal/iothub_client_authorization.h
+++ b/iothub_client/inc/internal/iothub_client_authorization.h
@@ -18,6 +18,8 @@ extern "C" {
 
 typedef struct IOTHUB_AUTHORIZATION_DATA_TAG* IOTHUB_AUTHORIZATION_HANDLE;
 
+typedef void (*IOTHUB_AUTHORIZATION_REQUEST_SAS_TOKEN_CALLBACK)(char** sas_token);
+
 #define IOTHUB_CREDENTIAL_TYPE_VALUES       \
     IOTHUB_CREDENTIAL_TYPE_UNKNOWN,         \
     IOTHUB_CREDENTIAL_TYPE_DEVICE_KEY,      \
@@ -36,7 +38,7 @@ MU_DEFINE_ENUM_WITHOUT_INVALID(IOTHUB_CREDENTIAL_TYPE, IOTHUB_CREDENTIAL_TYPE_VA
 
 MU_DEFINE_ENUM_WITHOUT_INVALID(SAS_TOKEN_STATUS, SAS_TOKEN_STATUS_VALUES);
 
-MOCKABLE_FUNCTION(, IOTHUB_AUTHORIZATION_HANDLE, IoTHubClient_Auth_Create, const char*, device_key, const char*, device_id, const char*, device_sas_token, const char *, module_id);
+MOCKABLE_FUNCTION(, IOTHUB_AUTHORIZATION_HANDLE, IoTHubClient_Auth_Create, const char*, device_key, const char*, device_id, const char*, device_sas_token, const char *, module_id, IOTHUB_AUTHORIZATION_REQUEST_SAS_TOKEN_CALLBACK, request_sas_token_callback);
 MOCKABLE_FUNCTION(, IOTHUB_AUTHORIZATION_HANDLE, IoTHubClient_Auth_CreateFromDeviceAuth, const char*, device_id, const char*, module_id);
 MOCKABLE_FUNCTION(, void, IoTHubClient_Auth_Destroy, IOTHUB_AUTHORIZATION_HANDLE, handle);
 MOCKABLE_FUNCTION(, IOTHUB_CREDENTIAL_TYPE, IoTHubClient_Auth_Set_x509_Type, IOTHUB_AUTHORIZATION_HANDLE, handle, bool, enable_x509);
@@ -47,6 +49,7 @@ MOCKABLE_FUNCTION(, const char*, IoTHubClient_Auth_Get_DeviceId, IOTHUB_AUTHORIZ
 MOCKABLE_FUNCTION(, const char*, IoTHubClient_Auth_Get_ModuleId, IOTHUB_AUTHORIZATION_HANDLE, handle);
 MOCKABLE_FUNCTION(, const char*, IoTHubClient_Auth_Get_DeviceKey, IOTHUB_AUTHORIZATION_HANDLE, handle);
 MOCKABLE_FUNCTION(, SAS_TOKEN_STATUS, IoTHubClient_Auth_Is_SasToken_Valid, IOTHUB_AUTHORIZATION_HANDLE, handle);
+MOCKABLE_FUNCTION(, bool, IoTHubClient_Auth_Is_SasToken_Update_Supported, IOTHUB_AUTHORIZATION_HANDLE, handle);
 MOCKABLE_FUNCTION(, int, IoTHubClient_Auth_Get_x509_info, IOTHUB_AUTHORIZATION_HANDLE, handle, char**, x509_cert, char**, x509_key);
 MOCKABLE_FUNCTION(, int, IoTHubClient_Auth_Set_SasToken_Expiry, IOTHUB_AUTHORIZATION_HANDLE, handle, size_t, expiry_time_seconds);
 MOCKABLE_FUNCTION(, size_t, IoTHubClient_Auth_Get_SasToken_Expiry, IOTHUB_AUTHORIZATION_HANDLE, handle);

--- a/iothub_client/inc/iothub_client_core_common.h
+++ b/iothub_client/inc/iothub_client_core_common.h
@@ -181,6 +181,12 @@ extern "C"
     typedef void(*IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_CALLBACK)(IOTHUB_CLIENT_FILE_UPLOAD_RESULT result, unsigned char const ** data, size_t* size, void* context);
     typedef IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_RESULT(*IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_CALLBACK_EX)(IOTHUB_CLIENT_FILE_UPLOAD_RESULT result, unsigned char const ** data, size_t* size, void* context);
 
+    /**
+    *  @brief           Callback invoked by IoTHubClient to fetch updated SAS token
+    *  @param sasToken  Pointer to string containing SAS token
+    */
+    typedef void (*IOTHUB_CLIENT_REQUEST_SAS_TOKEN_CALLBACK)(char** sasToken);
+
     /** @brief    This struct captures IoTHub client configuration. */
     typedef struct IOTHUB_CLIENT_CONFIG_TAG
     {
@@ -208,6 +214,9 @@ extern "C"
         const char* iotHubSuffix;
 
         const char* protocolGatewayHostName;
+
+        /** @brief    Callback to request new SAS Token, when SAS Token expires. */
+        IOTHUB_CLIENT_REQUEST_SAS_TOKEN_CALLBACK requestSasTokenCallback;
     } IOTHUB_CLIENT_CONFIG;
 
     /** @brief    This struct captures IoTHub client device configuration. */

--- a/iothub_client/src/iothub_client_core_ll.c
+++ b/iothub_client/src/iothub_client_core_ll.c
@@ -812,11 +812,13 @@ static IOTHUB_CLIENT_CORE_LL_HANDLE_DATA* initialize_iothub_client(const IOTHUB_
             const char* device_key;
             const char* device_id;
             const char* sas_token;
+            IOTHUB_AUTHORIZATION_REQUEST_SAS_TOKEN_CALLBACK requestSasTokenCallback = NULL;
             if (device_config == NULL)
             {
                 device_key = client_config->deviceKey;
                 device_id = client_config->deviceId;
                 sas_token = client_config->deviceSasToken;
+                requestSasTokenCallback = client_config->requestSasTokenCallback;
             }
             else
             {
@@ -826,7 +828,7 @@ static IOTHUB_CLIENT_CORE_LL_HANDLE_DATA* initialize_iothub_client(const IOTHUB_
             }
 
             /* Codes_SRS_IOTHUBCLIENT_LL_07_029: [ IoTHubClientCore_LL_Create shall create the Auth module with the device_key, device_id, and/or deviceSasToken values ] */
-            if ((result->authorization_module = IoTHubClient_Auth_Create(device_key, device_id, sas_token, module_id)) == NULL)
+            if ((result->authorization_module = IoTHubClient_Auth_Create(device_key, device_id, sas_token, module_id, requestSasTokenCallback)) == NULL)
             {
                 LogError("Failed create authorization module");
                 free(result);

--- a/iothub_client/src/iothubtransport_amqp_cbs_auth.c
+++ b/iothub_client/src/iothubtransport_amqp_cbs_auth.c
@@ -629,7 +629,9 @@ void authentication_do_work(AUTHENTICATION_HANDLE authentication_handle)
         {
             // Codes_SRS_IOTHUBTRANSPORT_AMQP_AUTH_09_040: [If `instance->state` is AUTHENTICATION_STATE_STARTED and user-provided SAS token was used, authentication_do_work() shall return]
             IOTHUB_CREDENTIAL_TYPE cred_type = IoTHubClient_Auth_Get_Credential_Type(instance->authorization_module);
-            if (cred_type == IOTHUB_CREDENTIAL_TYPE_DEVICE_KEY || cred_type == IOTHUB_CREDENTIAL_TYPE_DEVICE_AUTH)
+            if ( (cred_type == IOTHUB_CREDENTIAL_TYPE_DEVICE_KEY) ||
+                 (cred_type == IOTHUB_CREDENTIAL_TYPE_DEVICE_AUTH) ||
+                 ((cred_type == IOTHUB_CREDENTIAL_TYPE_SAS_TOKEN) && IoTHubClient_Auth_Is_SasToken_Update_Supported(instance->authorization_module)) )
             {
                 // Codes_SRS_IOTHUBTRANSPORT_AMQP_AUTH_09_039: [If `instance->state` is AUTHENTICATION_STATE_STARTED and device keys were used, authentication_do_work() shall only verify the SAS token refresh time]
                 // Codes_SRS_IOTHUBTRANSPORT_AMQP_AUTH_09_066: [If SAS token does not need to be refreshed, authentication_do_work() shall return]


### PR DESCRIPTION
#1625 

When using AMQP and SAS token authentication, it is not possible to inject updated SAS token in SDK without disconnecting.

Added possibility to assign a "request_sas_token_callback", which supplies Azure IoT SDK with an updated SAS token.
When a new SAS token is generated, or fetched from external source, the Azure IoT SDK is triggered to fetch the SAS token via the "IoTHubDeviceClient_LL_SetOption", "OPTION_SAS_TOKEN_LIFETIME". When the "request_sas_token_callback" callback is executed by the Azure IoT SDK, the "OPTION_SAS_TOKEN_LIFETIME" is set to the high value again. Next time a new SAS token is ready, the "OPTION_SAS_TOKEN_LIFETIME" is modified again.