### PR TITLE
Expand sendHttpRequestMethod in iothub_client_edge.c to succeed on any 2xx response

### DIFF
--- a/iothub_client/src/iothub_client_edge.c
+++ b/iothub_client/src/iothub_client_edge.c
@@ -440,7 +440,7 @@ static IOTHUB_CLIENT_RESULT sendHttpRequestMethod(IOTHUB_CLIENT_EDGE_HANDLE modu
         }
         else
         {
-            if (statusCode == 200)
+            if (statusCode >= 200 && statusCode < 300)
             {
                 result = IOTHUB_CLIENT_OK;
             }


### PR DESCRIPTION
This is a fix specifically for https://github.com/azure/azure-iot-sdk-c/issues/1231

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)
https://github.com/azure/azure-iot-sdk-c/issues/1231

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 