### PR TITLE
Fix #1698 and refactor multiblock upload code

### DIFF
--- a/iothub_client/samples/iothub_client_sample_upload_to_blob_mb/iothub_client_sample_upload_to_blob_mb.c
+++ b/iothub_client/samples/iothub_client_sample_upload_to_blob_mb/iothub_client_sample_upload_to_blob_mb.c
@@ -33,7 +33,8 @@ static const char* connectionString = "[device connection string]";
 /*Optional string with http proxy host and integer for http proxy port (Linux only)         */
 static const char* proxyHost = NULL;
 static int proxyPort = 0;
-static const char* data_to_upload = "Hello World from IoTHubClient_LL_UploadToBlob\n";
+static const char* data_to_upload_format = "Hello World from IoTHubClient_LL_UploadToBlob block: %d\n";
+static char data_to_upload[128];
 static int block_count = 0;
 
 static IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_RESULT getDataCallback(IOTHUB_CLIENT_FILE_UPLOAD_RESULT result, unsigned char const ** data, size_t* size, void* context)
@@ -44,9 +45,12 @@ static IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_RESULT getDataCallback(IOTHUB_CLIENT_F
         if (data != NULL && size != NULL)
         {
             // "block_count" is used to simulate reading chunks from a larger data content, like a large file.
+            // Note that the IoT SDK caller does NOT free(*data), as a typical use case the buffer returned 
+            // to the IoT layer may be part of a larger buffer that this callback is chunking up for network sends.
 
             if (block_count < 100)
             {
+                snprintf(data_to_upload, sizeof(data_to_upload), data_to_upload_format, block_count);
                 *data = (const unsigned char*)data_to_upload;
                 *size = strlen(data_to_upload);
                 block_count++;

--- a/iothub_client/src/blob.c
+++ b/iothub_client/src/blob.c
@@ -293,7 +293,6 @@ static BLOB_RESULT SendBlockIdList(HTTPAPIEX_HANDLE httpApiExHandle, const char*
     }
 
     return result;
-
 }
 
 

--- a/iothub_client/src/blob.c
+++ b/iothub_client/src/blob.c
@@ -13,6 +13,10 @@
 #include "azure_c_shared_utility/azure_base64.h"
 #include "azure_c_shared_utility/shared_util_options.h"
 
+static const char blockListXmlBegin[]  = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<BlockList>";
+static const char blockListXmlEnd[] = "</BlockList>";
+static const char blockListUriMarker[] = "&comp=blocklist";
+
 BLOB_RESULT Blob_UploadBlock(
         HTTPAPIEX_HANDLE httpApiExHandle,
         const char* relativePath,
@@ -131,257 +135,264 @@ BLOB_RESULT Blob_UploadBlock(
     return result;
 }
 
+
+// InvokeUserCallbackAndSendBlobs invokes the application's getDataCallbackEx as many time as callback requests and, for each call,
+// sends the blob contents to the server.
+static BLOB_RESULT InvokeUserCallbackAndSendBlobs(HTTPAPIEX_HANDLE httpApiExHandle, const char* relativePath, STRING_HANDLE blockIDList, IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_CALLBACK_EX getDataCallbackEx, void* context, unsigned int* httpStatus, BUFFER_HANDLE httpResponse)
+{
+    BLOB_RESULT result;
+
+    /*Codes_SRS_BLOB_02_021: [ For every block returned by `getDataCallbackEx` the following operations shall happen: ]*/
+    unsigned int blockID = 0; /* incremented for each new block */
+    unsigned int isError = 0; /* set to 1 if a block upload fails or if getDataCallbackEx returns incorrect blocks to upload */
+    unsigned int uploadOneMoreBlock = 1; /* set to 1 while getDataCallbackEx returns correct blocks to upload */
+    unsigned char const * source = NULL; /* data set by getDataCallbackEx */
+    size_t size = 0; /* source size set by getDataCallbackEx */
+    IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_RESULT getDataReturnValue;
+
+    do
+    {
+        getDataReturnValue = getDataCallbackEx(FILE_UPLOAD_OK, &source, &size, context);
+        if (getDataReturnValue == IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_ABORT)
+        {
+            /*Codes_SRS_BLOB_99_004: [ If `getDataCallbackEx` returns `IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_RESULT_ABORT`, then `Blob_UploadMultipleBlocksFromSasUri` shall exit the loop and return `BLOB_ABORTED`. ]*/
+            LogInfo("Upload to blob has been aborted by the user");
+            uploadOneMoreBlock = 0;
+            result = BLOB_ABORTED;
+        }
+        else if (source == NULL || size == 0)
+        {
+            /*Codes_SRS_BLOB_99_002: [ If the size of the block returned by `getDataCallbackEx` is 0 or if the data is NULL, then `Blob_UploadMultipleBlocksFromSasUri` shall exit the loop. ]*/
+            uploadOneMoreBlock = 0;
+            result = BLOB_OK;
+        }
+        else
+        {
+            if (size > BLOCK_SIZE)
+            {
+                /*Codes_SRS_BLOB_99_001: [ If the size of the block returned by `getDataCallbackEx` is bigger than 4MB, then `Blob_UploadMultipleBlocksFromSasUri` shall fail and return `BLOB_INVALID_ARG`. ]*/
+                LogError("tried to upload block of size %lu, max allowed size is %d", (unsigned long)size, BLOCK_SIZE);
+                result = BLOB_INVALID_ARG;
+                isError = 1;
+            }
+            else if (blockID >= MAX_BLOCK_COUNT)
+            {
+                /*Codes_SRS_BLOB_99_003: [ If `getDataCallbackEx` returns more than 50000 blocks, then `Blob_UploadMultipleBlocksFromSasUri` shall fail and return `BLOB_INVALID_ARG`. ]*/
+                LogError("unable to upload more than %lu blocks in one blob", (unsigned long)MAX_BLOCK_COUNT);
+                result = BLOB_INVALID_ARG;
+                isError = 1;
+            }
+            else
+            {
+                /*Codes_SRS_BLOB_02_023: [ Blob_UploadMultipleBlocksFromSasUri shall create a BUFFER_HANDLE from source and size parameters. ]*/
+                BUFFER_HANDLE requestContent = BUFFER_create(source, size);
+                if (requestContent == NULL)
+                {
+                    /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_ERROR ]*/
+                    LogError("unable to BUFFER_create");
+                    result = BLOB_ERROR;
+                    isError = 1;
+                }
+                else
+                {
+                    result = Blob_UploadBlock(
+                            httpApiExHandle,
+                            relativePath,
+                            requestContent,
+                            blockID,
+                            blockIDList,
+                            httpStatus,
+                            httpResponse);
+
+                    BUFFER_delete(requestContent);
+                }
+
+                /*Codes_SRS_BLOB_02_026: [ Otherwise, if HTTP response code is >=300 then Blob_UploadMultipleBlocksFromSasUri shall succeed and return BLOB_OK. ]*/
+                if (result != BLOB_OK || *httpStatus >= 300)
+                {
+                    LogError("unable to Blob_UploadBlock. Returned value=%d, httpStatus=%u", result, (unsigned int)*httpStatus);
+                    isError = 1;
+                }
+            }
+            blockID++;
+        }
+    }
+    while(uploadOneMoreBlock && !isError);
+
+    return result;
+}
+
+// SendBlockIdList to send an XML of uploaded blockIds to the server after the application's payload block(s) have been transfered.
+static BLOB_RESULT SendBlockIdList(HTTPAPIEX_HANDLE httpApiExHandle, const char* relativePath, STRING_HANDLE blockIDList, unsigned int* httpStatus, BUFFER_HANDLE httpResponse)
+{
+    BLOB_RESULT result;
+    
+    /*complete the XML*/
+    if (STRING_concat(blockIDList, blockListXmlEnd) != 0)
+    {
+        /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_ERROR ]*/
+        LogError("failed to STRING_concat");
+        result = BLOB_ERROR;
+    }
+    else
+    {
+        /*Codes_SRS_BLOB_02_029: [Blob_UploadMultipleBlocksFromSasUri shall construct a new relativePath from following string : base relativePath + "&comp=blocklist"]*/
+        STRING_HANDLE newRelativePath = STRING_construct(relativePath);
+        if (newRelativePath == NULL)
+        {
+            /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_ERROR ]*/
+            LogError("failed to STRING_construct");
+            result = BLOB_ERROR;
+        }
+        else
+        {
+            if (STRING_concat(newRelativePath, blockListUriMarker) != 0)
+            {
+                /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_ERROR ]*/
+                LogError("failed to STRING_concat");
+                result = BLOB_ERROR;
+            }
+            else
+            {
+                /*Codes_SRS_BLOB_02_030: [ Blob_UploadMultipleBlocksFromSasUri shall call HTTPAPIEX_ExecuteRequest with a PUT operation, passing the new relativePath, httpStatus and httpResponse and the XML string as content. ]*/
+                const char* s = STRING_c_str(blockIDList);
+                BUFFER_HANDLE blockIDListAsBuffer = BUFFER_create((const unsigned char*)s, strlen(s));
+                if (blockIDListAsBuffer == NULL)
+                {
+                    /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_ERROR ]*/
+                    LogError("failed to BUFFER_create");
+                    result = BLOB_ERROR;
+                }
+                else
+                {
+                    if (HTTPAPIEX_ExecuteRequest(
+                        httpApiExHandle,
+                        HTTPAPI_REQUEST_PUT,
+                        STRING_c_str(newRelativePath),
+                        NULL,
+                        blockIDListAsBuffer,
+                        httpStatus,
+                        NULL,
+                        httpResponse
+                    ) != HTTPAPIEX_OK)
+                    {
+                        /*Codes_SRS_BLOB_02_031: [ If HTTPAPIEX_ExecuteRequest fails then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_HTTP_ERROR. ]*/
+                        LogError("unable to HTTPAPIEX_ExecuteRequest");
+                        result = BLOB_HTTP_ERROR;
+                    }
+                    else
+                    {
+                        /*Codes_SRS_BLOB_02_032: [ Otherwise, Blob_UploadMultipleBlocksFromSasUri shall succeed and return BLOB_OK. ]*/
+                        result = BLOB_OK;
+                    }
+                    BUFFER_delete(blockIDListAsBuffer);
+                }
+            }
+            STRING_delete(newRelativePath);
+        }
+    }
+
+    return result;
+
+}
+
+
 BLOB_RESULT Blob_UploadMultipleBlocksFromSasUri(const char* SASURI, IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_CALLBACK_EX getDataCallbackEx, void* context, unsigned int* httpStatus, BUFFER_HANDLE httpResponse, const char* certificates, HTTP_PROXY_OPTIONS *proxyOptions)
 {
     BLOB_RESULT result;
+    const char* hostnameBegin;
+    STRING_HANDLE blockIDList = NULL;
+    HTTPAPIEX_HANDLE httpApiExHandle = NULL;
+    char* hostname = NULL;
+    
     /*Codes_SRS_BLOB_02_001: [ If SASURI is NULL then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_INVALID_ARG. ]*/
     if (SASURI == NULL)
     {
         LogError("parameter SASURI is NULL");
         result = BLOB_INVALID_ARG;
     }
+    /*Codes_SRS_BLOB_02_002: [ If getDataCallbackEx is NULL then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_INVALID_ARG. ]*/
+    else if (getDataCallbackEx == NULL)
+    {
+        LogError("IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_CALLBACK_EX getDataCallbackEx is NULL");
+        result = BLOB_INVALID_ARG;
+    }
+    /*Codes_SRS_BLOB_02_017: [ Blob_UploadMultipleBlocksFromSasUri shall copy from SASURI the hostname to a new const char* ]*/
+    /*to find the hostname, the following logic is applied:*/
+    /*the hostname starts at the first character after "://"*/
+    /*the hostname ends at the first character before the next "/" after "://"*/
+    else if ((hostnameBegin = strstr(SASURI, "://")) == NULL)
+    {
+        /*Codes_SRS_BLOB_02_005: [ If the hostname cannot be determined, then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_INVALID_ARG. ]*/
+        LogError("hostname cannot be determined");
+        result = BLOB_INVALID_ARG;
+    }
     else
     {
-        /*Codes_SRS_BLOB_02_002: [ If getDataCallbackEx is NULL then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_INVALID_ARG. ]*/
-        if (getDataCallbackEx == NULL)
+        hostnameBegin += 3; /*have to skip 3 characters which are "://"*/
+        const char* relativePath = strchr(hostnameBegin, '/');
+        if (relativePath == NULL)
         {
-            LogError("IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_CALLBACK_EX getDataCallbackEx is NULL");
+            /*Codes_SRS_BLOB_02_005: [ If the hostname cannot be determined, then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_INVALID_ARG. ]*/
+            LogError("hostname cannot be determined");
             result = BLOB_INVALID_ARG;
         }
-        /*the below define avoid a "condition always false" on some compilers*/
         else
         {
-            /*Codes_SRS_BLOB_02_017: [ Blob_UploadMultipleBlocksFromSasUri shall copy from SASURI the hostname to a new const char* ]*/
-            /*to find the hostname, the following logic is applied:*/
-            /*the hostname starts at the first character after "://"*/
-            /*the hostname ends at the first character before the next "/" after "://"*/
-            const char* hostnameBegin = strstr(SASURI, "://");
-            if (hostnameBegin == NULL)
+            size_t hostnameSize = relativePath - hostnameBegin;
+            if ((hostname = (char*)malloc(hostnameSize + 1)) == NULL)
             {
-                /*Codes_SRS_BLOB_02_005: [ If the hostname cannot be determined, then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_INVALID_ARG. ]*/
-                LogError("hostname cannot be determined");
-                result = BLOB_INVALID_ARG;
+                /*Codes_SRS_BLOB_02_016: [ If the hostname copy cannot be made then then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_ERROR ]*/
+                LogError("oom - out of memory");
+                result = BLOB_ERROR;
             }
             else
             {
-                hostnameBegin += 3; /*have to skip 3 characters which are "://"*/
-                const char* hostnameEnd = strchr(hostnameBegin, '/');
-                if (hostnameEnd == NULL)
+                (void)memcpy(hostname, hostnameBegin, hostnameSize);
+                hostname[hostnameSize] = '\0';
+
+                /*Codes_SRS_BLOB_02_018: [ Blob_UploadMultipleBlocksFromSasUri shall create a new HTTPAPI_EX_HANDLE by calling HTTPAPIEX_Create passing the hostname. ]*/
+                httpApiExHandle = HTTPAPIEX_Create(hostname);
+                if (httpApiExHandle == NULL)
                 {
-                    /*Codes_SRS_BLOB_02_005: [ If the hostname cannot be determined, then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_INVALID_ARG. ]*/
-                    LogError("hostname cannot be determined");
-                    result = BLOB_INVALID_ARG;
+                    /*Codes_SRS_BLOB_02_007: [ If HTTPAPIEX_Create fails then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_ERROR. ]*/
+                    LogError("unable to create a HTTPAPIEX_HANDLE");
+                    result = BLOB_ERROR;
                 }
-                else
+                else if ((certificates != NULL) && (HTTPAPIEX_SetOption(httpApiExHandle, "TrustedCerts", certificates) == HTTPAPIEX_ERROR))
                 {
-                    size_t hostnameSize = hostnameEnd - hostnameBegin;
-                    char* hostname = (char*)malloc(hostnameSize + 1); /*+1 because of '\0' at the end*/
-                    if (hostname == NULL)
-                    {
-                        /*Codes_SRS_BLOB_02_016: [ If the hostname copy cannot be made then then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_ERROR ]*/
-                        LogError("oom - out of memory");
-                        result = BLOB_ERROR;
-                    }
-                    else
-                    {
-                        HTTPAPIEX_HANDLE httpApiExHandle;
-                        (void)memcpy(hostname, hostnameBegin, hostnameSize);
-                        hostname[hostnameSize] = '\0';
-
-                        /*Codes_SRS_BLOB_02_018: [ Blob_UploadMultipleBlocksFromSasUri shall create a new HTTPAPI_EX_HANDLE by calling HTTPAPIEX_Create passing the hostname. ]*/
-                        httpApiExHandle = HTTPAPIEX_Create(hostname);
-                        if (httpApiExHandle == NULL)
-                        {
-                            /*Codes_SRS_BLOB_02_007: [ If HTTPAPIEX_Create fails then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_ERROR. ]*/
-                            LogError("unable to create a HTTPAPIEX_HANDLE");
-                            result = BLOB_ERROR;
-                        }
-                        else
-                        {
-                            if ((certificates != NULL)&& (HTTPAPIEX_SetOption(httpApiExHandle, "TrustedCerts", certificates) == HTTPAPIEX_ERROR))
-                            {
-                                LogError("failure in setting trusted certificates");
-                                result = BLOB_ERROR;
-                            }
-                            else if ((proxyOptions != NULL && proxyOptions->host_address != NULL) && HTTPAPIEX_SetOption(httpApiExHandle, OPTION_HTTP_PROXY, proxyOptions) == HTTPAPIEX_ERROR)
-                            {
-                                LogError("failure in setting proxy options");
-                                result = BLOB_ERROR;
-                            }
-                            else
-                            {
-                                /*Codes_SRS_BLOB_02_019: [ Blob_UploadMultipleBlocksFromSasUri shall compute the base relative path of the request from the SASURI parameter. ]*/
-                                const char* relativePath = hostnameEnd; /*this is where the relative path begins in the SasUri*/
-
-                                /*Codes_SRS_BLOB_02_028: [ Blob_UploadMultipleBlocksFromSasUri shall construct an XML string with the following content: ]*/
-                                STRING_HANDLE blockIDList = STRING_construct("<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<BlockList>"); /*the XML "build as we go"*/
-                                if (blockIDList == NULL)
-                                {
-                                    /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_ERROR ]*/
-                                    LogError("failed to STRING_construct");
-                                    result = BLOB_HTTP_ERROR;
-                                }
-                                else
-                                {
-                                    /*Codes_SRS_BLOB_02_021: [ For every block returned by `getDataCallbackEx` the following operations shall happen: ]*/
-                                    unsigned int blockID = 0; /* incremented for each new block */
-                                    unsigned int isError = 0; /* set to 1 if a block upload fails or if getDataCallbackEx returns incorrect blocks to upload */
-                                    unsigned int uploadOneMoreBlock = 1; /* set to 1 while getDataCallbackEx returns correct blocks to upload */
-                                    unsigned char const * source; /* data set by getDataCallbackEx */
-                                    size_t size; /* source size set by getDataCallbackEx */
-                                    IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_RESULT getDataReturnValue;
-
-                                    do
-                                    {
-                                        getDataReturnValue = getDataCallbackEx(FILE_UPLOAD_OK, &source, &size, context);
-                                        if (getDataReturnValue == IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_ABORT)
-                                        {
-                                            /*Codes_SRS_BLOB_99_004: [ If `getDataCallbackEx` returns `IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_RESULT_ABORT`, then `Blob_UploadMultipleBlocksFromSasUri` shall exit the loop and return `BLOB_ABORTED`. ]*/
-                                            LogInfo("Upload to blob has been aborted by the user");
-                                            uploadOneMoreBlock = 0;
-                                            result = BLOB_ABORTED;
-                                        }
-                                        else if (source == NULL || size == 0)
-                                        {
-                                            /*Codes_SRS_BLOB_99_002: [ If the size of the block returned by `getDataCallbackEx` is 0 or if the data is NULL, then `Blob_UploadMultipleBlocksFromSasUri` shall exit the loop. ]*/
-                                            uploadOneMoreBlock = 0;
-                                            result = BLOB_OK;
-                                        }
-                                        else
-                                        {
-                                            if (size > BLOCK_SIZE)
-                                            {
-                                                /*Codes_SRS_BLOB_99_001: [ If the size of the block returned by `getDataCallbackEx` is bigger than 4MB, then `Blob_UploadMultipleBlocksFromSasUri` shall fail and return `BLOB_INVALID_ARG`. ]*/
-                                                LogError("tried to upload block of size %lu, max allowed size is %d", (unsigned long)size, BLOCK_SIZE);
-                                                result = BLOB_INVALID_ARG;
-                                                isError = 1;
-                                            }
-                                            else if (blockID >= MAX_BLOCK_COUNT)
-                                            {
-                                                /*Codes_SRS_BLOB_99_003: [ If `getDataCallbackEx` returns more than 50000 blocks, then `Blob_UploadMultipleBlocksFromSasUri` shall fail and return `BLOB_INVALID_ARG`. ]*/
-                                                LogError("unable to upload more than %lu blocks in one blob", (unsigned long)MAX_BLOCK_COUNT);
-                                                result = BLOB_INVALID_ARG;
-                                                isError = 1;
-                                            }
-                                            else
-                                            {
-                                                /*Codes_SRS_BLOB_02_023: [ Blob_UploadMultipleBlocksFromSasUri shall create a BUFFER_HANDLE from source and size parameters. ]*/
-                                                BUFFER_HANDLE requestContent = BUFFER_create(source, size);
-                                                if (requestContent == NULL)
-                                                {
-                                                    /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_ERROR ]*/
-                                                    LogError("unable to BUFFER_create");
-                                                    result = BLOB_ERROR;
-                                                    isError = 1;
-                                                }
-                                                else
-                                                {
-                                                    result = Blob_UploadBlock(
-                                                            httpApiExHandle,
-                                                            relativePath,
-                                                            requestContent,
-                                                            blockID,
-                                                            blockIDList,
-                                                            httpStatus,
-                                                            httpResponse);
-
-                                                    BUFFER_delete(requestContent);
-                                                }
-
-                                                /*Codes_SRS_BLOB_02_026: [ Otherwise, if HTTP response code is >=300 then Blob_UploadMultipleBlocksFromSasUri shall succeed and return BLOB_OK. ]*/
-                                                if (result != BLOB_OK || *httpStatus >= 300)
-                                                {
-                                                    LogError("unable to Blob_UploadBlock. Returned value=%d, httpStatus=%u", result, (unsigned int)*httpStatus);
-                                                    isError = 1;
-                                                }
-                                            }
-                                            blockID++;
-                                        }
-                                    }
-                                    while(uploadOneMoreBlock && !isError);
-
-                                    if (isError || result != BLOB_OK)
-                                    {
-                                        /*do nothing, it will be reported "as is"*/
-                                    }
-                                    else
-                                    {
-                                        /*complete the XML*/
-                                        if (STRING_concat(blockIDList, "</BlockList>") != 0)
-                                        {
-                                            /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_ERROR ]*/
-                                            LogError("failed to STRING_concat");
-                                            result = BLOB_ERROR;
-                                        }
-                                        else
-                                        {
-                                            /*Codes_SRS_BLOB_02_029: [Blob_UploadMultipleBlocksFromSasUri shall construct a new relativePath from following string : base relativePath + "&comp=blocklist"]*/
-                                            STRING_HANDLE newRelativePath = STRING_construct(relativePath);
-                                            if (newRelativePath == NULL)
-                                            {
-                                                /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_ERROR ]*/
-                                                LogError("failed to STRING_construct");
-                                                result = BLOB_ERROR;
-                                            }
-                                            else
-                                            {
-                                                if (STRING_concat(newRelativePath, "&comp=blocklist") != 0)
-                                                {
-                                                    /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_ERROR ]*/
-                                                    LogError("failed to STRING_concat");
-                                                    result = BLOB_ERROR;
-                                                }
-                                                else
-                                                {
-                                                    /*Codes_SRS_BLOB_02_030: [ Blob_UploadMultipleBlocksFromSasUri shall call HTTPAPIEX_ExecuteRequest with a PUT operation, passing the new relativePath, httpStatus and httpResponse and the XML string as content. ]*/
-                                                    const char* s = STRING_c_str(blockIDList);
-                                                    BUFFER_HANDLE blockIDListAsBuffer = BUFFER_create((const unsigned char*)s, strlen(s));
-                                                    if (blockIDListAsBuffer == NULL)
-                                                    {
-                                                        /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_ERROR ]*/
-                                                        LogError("failed to BUFFER_create");
-                                                        result = BLOB_ERROR;
-                                                    }
-                                                    else
-                                                    {
-                                                        if (HTTPAPIEX_ExecuteRequest(
-                                                            httpApiExHandle,
-                                                            HTTPAPI_REQUEST_PUT,
-                                                            STRING_c_str(newRelativePath),
-                                                            NULL,
-                                                            blockIDListAsBuffer,
-                                                            httpStatus,
-                                                            NULL,
-                                                            httpResponse
-                                                        ) != HTTPAPIEX_OK)
-                                                        {
-                                                            /*Codes_SRS_BLOB_02_031: [ If HTTPAPIEX_ExecuteRequest fails then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_HTTP_ERROR. ]*/
-                                                            LogError("unable to HTTPAPIEX_ExecuteRequest");
-                                                            result = BLOB_HTTP_ERROR;
-                                                        }
-                                                        else
-                                                        {
-                                                            /*Codes_SRS_BLOB_02_032: [ Otherwise, Blob_UploadMultipleBlocksFromSasUri shall succeed and return BLOB_OK. ]*/
-                                                            result = BLOB_OK;
-                                                        }
-                                                        BUFFER_delete(blockIDListAsBuffer);
-                                                    }
-                                                }
-                                                STRING_delete(newRelativePath);
-                                            }
-                                        }
-                                    }
-                                    STRING_delete(blockIDList);
-                                }
-
-                            }
-                            HTTPAPIEX_Destroy(httpApiExHandle);
-                        }
-                        free(hostname);
-                    }
+                    LogError("failure in setting trusted certificates");
+                    result = BLOB_ERROR;
+                }
+                else if ((proxyOptions != NULL && proxyOptions->host_address != NULL) && HTTPAPIEX_SetOption(httpApiExHandle, OPTION_HTTP_PROXY, proxyOptions) == HTTPAPIEX_ERROR)
+                {
+                    LogError("failure in setting proxy options");
+                    result = BLOB_ERROR;
+                }
+                /*Codes_SRS_BLOB_02_028: [ Blob_UploadMultipleBlocksFromSasUri shall construct an XML string with the following content: ]*/
+                else if ((blockIDList = STRING_construct(blockListXmlBegin)) == NULL)
+                {
+                    /*Codes_SRS_BLOB_02_033: [ If any previous operation that doesn't have an explicit failure description fails then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_ERROR ]*/
+                    LogError("failed to STRING_construct");
+                    result = BLOB_HTTP_ERROR;
+                }
+                else if ((result = InvokeUserCallbackAndSendBlobs(httpApiExHandle, relativePath, blockIDList, getDataCallbackEx, context, httpStatus, httpResponse)) != BLOB_OK)
+                {
+                   ; 
+                }
+                else if (*httpStatus < 300)
+                {
+                    // Per SRS_BLOB_02_026, it possible for us to have a result=BLOB_OK AND a non-success HTTP status code.
+                    // In order to maintain back-compat with existing code, we will return the BLOB_OK to the caller but NOT invoke this final step.
+                    result = SendBlockIdList(httpApiExHandle, relativePath, blockIDList, httpStatus, httpResponse);
                 }
             }
         }
     }
+
+    HTTPAPIEX_Destroy(httpApiExHandle);
+    STRING_delete(blockIDList);
+    free(hostname);
+
     return result;
 }

--- a/iothub_client/src/blob.c
+++ b/iothub_client/src/blob.c
@@ -305,15 +305,10 @@ BLOB_RESULT Blob_UploadMultipleBlocksFromSasUri(const char* SASURI, IOTHUB_CLIEN
     char* hostname = NULL;
     
     /*Codes_SRS_BLOB_02_001: [ If SASURI is NULL then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_INVALID_ARG. ]*/
-    if (SASURI == NULL)
-    {
-        LogError("parameter SASURI is NULL");
-        result = BLOB_INVALID_ARG;
-    }
     /*Codes_SRS_BLOB_02_002: [ If getDataCallbackEx is NULL then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_INVALID_ARG. ]*/
-    else if (getDataCallbackEx == NULL)
+    if ((SASURI == NULL) || (getDataCallbackEx == NULL))
     {
-        LogError("IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_CALLBACK_EX getDataCallbackEx is NULL");
+        LogError("One or more required values is NULL, SASURI=%p, getDataCallbackEx=%p", SASURI, getDataCallbackEx);
         result = BLOB_INVALID_ARG;
     }
     /*Codes_SRS_BLOB_02_017: [ Blob_UploadMultipleBlocksFromSasUri shall copy from SASURI the hostname to a new const char* ]*/
@@ -377,7 +372,7 @@ BLOB_RESULT Blob_UploadMultipleBlocksFromSasUri(const char* SASURI, IOTHUB_CLIEN
                 }
                 else if ((result = InvokeUserCallbackAndSendBlobs(httpApiExHandle, relativePath, blockIDList, getDataCallbackEx, context, httpStatus, httpResponse)) != BLOB_OK)
                 {
-                   ; 
+                   LogError("Failed in invoking callback/sending blob step");
                 }
                 else if (*httpStatus < 300)
                 {

--- a/iothub_client/tests/blob_ut/blob_ut.c
+++ b/iothub_client/tests/blob_ut/blob_ut.c
@@ -301,6 +301,16 @@ static void reset_test_data()
     memset(&context, 0, sizeof(context));
 }
 
+static void set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup()
+{
+    STRICT_EXPECTED_CALL(HTTPAPIEX_Destroy(IGNORED_PTR_ARG)) /*this is the HTTPAPIEX handle*/
+        .IgnoreArgument_handle();
+    STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG))/*this is the XML string used for Put Block List operation*/
+        .IgnoreArgument_handle();
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG)) /*this is freeing the copy of hte hostname*/
+        .IgnoreArgument_ptr();
+}
+
 TEST_FUNCTION_INITIALIZE(Setup)
 {
     umock_c_reset_all_calls();
@@ -402,12 +412,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_succeeds_when_HTTP_status_code
             .IgnoreArgument_handle();
     }
 
-    STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG))/*this is the XML string used for Put Block List operation*/
-        .IgnoreArgument_handle();
-    STRICT_EXPECTED_CALL(HTTPAPIEX_Destroy(IGNORED_PTR_ARG)) /*this is the HTTPAPIEX handle*/
-        .IgnoreArgument_handle();
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG)) /*this is freeing the copy of hte hostname*/
-        .IgnoreArgument_ptr();
+    set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
 
     ///act
     BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri(TEST_VALID_SASURI_1, FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL);
@@ -480,12 +485,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_fails_when_HTTPAPIEX_ExecuteRe
             .IgnoreArgument_handle();
     }
 
-    STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG))/*this is the XML string used for Put Block List operation*/
-        .IgnoreArgument_handle();
-    STRICT_EXPECTED_CALL(HTTPAPIEX_Destroy(IGNORED_PTR_ARG)) /*this is the HTTPAPIEX handle*/
-        .IgnoreArgument_handle();
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG)) /*this is freeing the copy of hte hostname*/
-        .IgnoreArgument_ptr();
+    set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
 
     ///act
     BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri(TEST_VALID_SASURI_1, FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL);
@@ -516,14 +516,8 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_fails_when_BUFFER_create_fails
             STRICT_EXPECTED_CALL(BUFFER_create(&c, 1))
                 .SetReturn(NULL);
 
-            STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG))/*this is the XML string used for Put Block List operation*/
-                 .IgnoreArgument_handle();
-
-            STRICT_EXPECTED_CALL(HTTPAPIEX_Destroy(IGNORED_PTR_ARG))
-                .IgnoreArgument_handle();
         }
-        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))
-            .IgnoreArgument_ptr();
+        set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
     }
 
     ///act
@@ -550,9 +544,9 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_fails_when_HTTPAPIEX_Create_fa
         STRICT_EXPECTED_CALL(HTTPAPIEX_Create(TEST_HOSTNAME_1))
             .SetReturn(NULL)
             ;
-        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))
-            .IgnoreArgument_ptr();
     }
+
+    set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
 
     ///act
     BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri(TEST_VALID_SASURI_1, FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL);
@@ -577,6 +571,8 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_fails_when_malloc_fails)
         .SetReturn(NULL)
         ;
 
+    set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
+
     ///act
     BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri(TEST_VALID_SASURI_1, FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL);
 
@@ -596,6 +592,8 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_when_SasUri_is_wrong_fails_1)
     context.source = &c;
     context.toUpload = context.size;
 
+    set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
+
     ///act
     BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https:/h.h/doms", FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL); /*wrong format for protocol, notice it is actually http:\h.h\doms (missing a \ from http)*/
 
@@ -614,6 +612,8 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_when_SasUri_is_wrong_fails_2)
     context.size = 1;
     context.source = &c;
     context.toUpload = context.size;
+
+    set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
 
     ///act
     BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h", FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL); /*there's no relative path here*/
@@ -750,12 +750,7 @@ static void Blob_UploadMultipleBlocksFromSasUri_various_sizes_happy_path_Impl(HT
             .IgnoreArgument_handle();
         STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG)) /*this is destroying the relative path for Put Block List*/
             .IgnoreArgument_handle();
-        STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG))/*this is the XML string used for Put Block List operation*/
-            .IgnoreArgument_handle();
-        STRICT_EXPECTED_CALL(HTTPAPIEX_Destroy(IGNORED_PTR_ARG)) /*this is the HTTPAPIEX handle*/
-            .IgnoreArgument_handle();
-        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG)) /*this is freeing the copy of hte hostname*/
-            .IgnoreArgument_ptr();
+        set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
 
         ///act
         BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, proxyOptions);
@@ -932,12 +927,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_various_sizes_with_certificate
             .IgnoreArgument_handle();
         STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG)) /*this is destroying the relative path for Put Block List*/
             .IgnoreArgument_handle();
-        STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG))/*this is the XML string used for Put Block List operation*/
-            .IgnoreArgument_handle();
-        STRICT_EXPECTED_CALL(HTTPAPIEX_Destroy(IGNORED_PTR_ARG)) /*this is the HTTPAPIEX handle*/
-            .IgnoreArgument_handle();
-        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG)) /*this is freeing the copy of hte hostname*/
-            .IgnoreArgument_ptr();
+        set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
 
         ///act
         BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, "a", NULL);
@@ -955,86 +945,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_various_sizes_with_certificate
 TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_64MB_unhappy_paths)
 {
     size_t size = 64 * 1024 * 1024;
-
-    size_t calls_that_cannot_fail[] =
-    {
-        13   ,/*STRING_delete*/
-        26   ,/*STRING_delete*/
-        39   ,/*STRING_delete*/
-        52   ,/*STRING_delete*/
-        65   ,/*STRING_delete*/
-        78   ,/*STRING_delete*/
-        91   ,/*STRING_delete*/
-        104  ,/*STRING_delete*/
-        117  ,/*STRING_delete*/
-        130  ,/*STRING_delete*/
-        143  ,/*STRING_delete*/
-        156  ,/*STRING_delete*/
-        169  ,/*STRING_delete*/
-        182  ,/*STRING_delete*/
-        195  ,/*STRING_delete*/
-        208  ,/*STRING_delete*/
-        11   ,/*STRING_c_str*/
-        24   ,/*STRING_c_str*/
-        37   ,/*STRING_c_str*/
-        50   ,/*STRING_c_str*/
-        63   ,/*STRING_c_str*/
-        76   ,/*STRING_c_str*/
-        89   ,/*STRING_c_str*/
-        102  ,/*STRING_c_str*/
-        115  ,/*STRING_c_str*/
-        128  ,/*STRING_c_str*/
-        141  ,/*STRING_c_str*/
-        154  ,/*STRING_c_str*/
-        167  ,/*STRING_c_str*/
-        180  ,/*STRING_c_str*/
-        193  ,/*STRING_c_str*/
-        206  ,/*STRING_c_str*/
-        14   ,/*STRING_delete*/
-        27   ,/*STRING_delete*/
-        40   ,/*STRING_delete*/
-        53   ,/*STRING_delete*/
-        66   ,/*STRING_delete*/
-        79   ,/*STRING_delete*/
-        92   ,/*STRING_delete*/
-        105  ,/*STRING_delete*/
-        118  ,/*STRING_delete*/
-        131  ,/*STRING_delete*/
-        144  ,/*STRING_delete*/
-        157  ,/*STRING_delete*/
-        170  ,/*STRING_delete*/
-        183  ,/*STRING_delete*/
-        196  ,/*STRING_delete*/
-        209  ,/*STRING_delete*/
-        15   ,/*BUFFER_delete*/
-        28   ,/*BUFFER_delete*/
-        41   ,/*BUFFER_delete*/
-        54   ,/*BUFFER_delete*/
-        67   ,/*BUFFER_delete*/
-        80   ,/*BUFFER_delete*/
-        93   ,/*BUFFER_delete*/
-        106  ,/*BUFFER_delete*/
-        119  ,/*BUFFER_delete*/
-        132  ,/*BUFFER_delete*/
-        145  ,/*BUFFER_delete*/
-        158  ,/*BUFFER_delete*/
-        171  ,/*BUFFER_delete*/
-        184  ,/*BUFFER_delete*/
-        197  ,/*BUFFER_delete*/
-        210  ,/*BUFFER_delete*/
-
-
-        214, /*STRING_c_str*/
-        216, /*STRING_c_str*/
-        218, /*BUFFER_delete*/
-        219, /*STRING_delete*/
-        220, /*STRING_delete*/
-        221, /*HTTPAPIEX_Destroy*/
-        222, /*gballoc_free*/
-    };
-
     (void)umock_c_negative_tests_init();
-
 
     umock_c_reset_all_calls();
     ///arrange
@@ -1083,7 +994,8 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_64MB_unhappy_paths)
             .IgnoreArgument_s2();
 
         STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)) /*this is getting the relative path as const char* */ /*11, 24, 27...*/
-            .IgnoreArgument_handle();
+            .IgnoreArgument_handle()
+            .CallCannotFail();
 
         STRICT_EXPECTED_CALL(HTTPAPIEX_ExecuteRequest(IGNORED_PTR_ARG, HTTPAPI_REQUEST_PUT, IGNORED_PTR_ARG, NULL, IGNORED_PTR_ARG, &httpResponse, NULL, testValidBufferHandle))
             .IgnoreArgument_handle()
@@ -1109,13 +1021,15 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_64MB_unhappy_paths)
         .IgnoreArgument_handle();
 
     STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)) /*this is getting the XML as const char* so it can be passed to _ExecuteRequest*/
-        .IgnoreArgument_handle();
+        .IgnoreArgument_handle()
+        .CallCannotFail();
 
     STRICT_EXPECTED_CALL(BUFFER_create(IGNORED_PTR_ARG, IGNORED_NUM_ARG)) /*this is creating the XML body as BUFFER_HANDLE*/
         .IgnoreAllArguments();
 
     STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)) /*this is getting the relative path*/
-        .IgnoreArgument_handle();
+        .IgnoreArgument_handle()
+        .CallCannotFail();
 
     STRICT_EXPECTED_CALL(HTTPAPIEX_ExecuteRequest(
         IGNORED_PTR_ARG,
@@ -1137,27 +1051,15 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_64MB_unhappy_paths)
         .IgnoreArgument_handle();
     STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG)) /*this is destroying the relative path for Put Block List*/
         .IgnoreArgument_handle();
-    STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG))/*this is the XML string used for Put Block List operation*/
-        .IgnoreArgument_handle();
-    STRICT_EXPECTED_CALL(HTTPAPIEX_Destroy(IGNORED_PTR_ARG)) /*this is the HTTPAPIEX handle*/
-        .IgnoreArgument_handle();
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG)) /*this is freeing the copy of hte hostname*/
-        .IgnoreArgument_ptr();
+    set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
 
     umock_c_negative_tests_snapshot();
 
     for (size_t i = 0; i < umock_c_negative_tests_call_count(); i++)
     {
-        size_t j;
         umock_c_negative_tests_reset();
 
-        for (j = 0;j<sizeof(calls_that_cannot_fail) / sizeof(calls_that_cannot_fail[0]);j++) /*not running the tests that cannot fail*/
-        {
-            if (calls_that_cannot_fail[j] == i)
-                break;
-        }
-
-        if (j == sizeof(calls_that_cannot_fail) / sizeof(calls_that_cannot_fail[0]))
+        if (umock_c_negative_tests_can_call_fail(i))
         {
 
             umock_c_negative_tests_fail_call(i);
@@ -1184,83 +1086,6 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_64MB_unhappy_paths)
 TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_64MB_with_certificate_unhappy_paths)
 {
     size_t size = 64 * 1024 * 1024;
-
-    size_t calls_that_cannot_fail[] =
-    {
-        13  + 1 ,/*STRING_delete*/
-        26  + 1 ,/*STRING_delete*/
-        39  + 1 ,/*STRING_delete*/
-        52  + 1 ,/*STRING_delete*/
-        65  + 1 ,/*STRING_delete*/
-        78  + 1 ,/*STRING_delete*/
-        91  + 1 ,/*STRING_delete*/
-        104 + 1 ,/*STRING_delete*/
-        117 + 1 ,/*STRING_delete*/
-        130 + 1 ,/*STRING_delete*/
-        143 + 1 ,/*STRING_delete*/
-        156 + 1 ,/*STRING_delete*/
-        169 + 1 ,/*STRING_delete*/
-        182 + 1 ,/*STRING_delete*/
-        195 + 1 ,/*STRING_delete*/
-        208 + 1 ,/*STRING_delete*/
-        11  + 1 ,/*STRING_c_str*/
-        24  + 1 ,/*STRING_c_str*/
-        37  + 1 ,/*STRING_c_str*/
-        50  + 1 ,/*STRING_c_str*/
-        63  + 1 ,/*STRING_c_str*/
-        76  + 1 ,/*STRING_c_str*/
-        89  + 1 ,/*STRING_c_str*/
-        102 + 1 ,/*STRING_c_str*/
-        115 + 1 ,/*STRING_c_str*/
-        128 + 1 ,/*STRING_c_str*/
-        141 + 1 ,/*STRING_c_str*/
-        154 + 1 ,/*STRING_c_str*/
-        167 + 1 ,/*STRING_c_str*/
-        180 + 1 ,/*STRING_c_str*/
-        193 + 1 ,/*STRING_c_str*/
-        206 + 1 ,/*STRING_c_str*/
-        14  + 1 ,/*STRING_delete*/
-        27  + 1 ,/*STRING_delete*/
-        40  + 1 ,/*STRING_delete*/
-        53  + 1 ,/*STRING_delete*/
-        66  + 1 ,/*STRING_delete*/
-        79  + 1 ,/*STRING_delete*/
-        92  + 1 ,/*STRING_delete*/
-        105 + 1 ,/*STRING_delete*/
-        118 + 1 ,/*STRING_delete*/
-        131 + 1 ,/*STRING_delete*/
-        144 + 1 ,/*STRING_delete*/
-        157 + 1 ,/*STRING_delete*/
-        170 + 1 ,/*STRING_delete*/
-        183 + 1 ,/*STRING_delete*/
-        196 + 1 ,/*STRING_delete*/
-        209 + 1 ,/*STRING_delete*/
-        15  + 1 ,/*BUFFER_delete*/
-        28  + 1 ,/*BUFFER_delete*/
-        41  + 1 ,/*BUFFER_delete*/
-        54  + 1 ,/*BUFFER_delete*/
-        67  + 1 ,/*BUFFER_delete*/
-        80  + 1 ,/*BUFFER_delete*/
-        93  + 1 ,/*BUFFER_delete*/
-        106 + 1 ,/*BUFFER_delete*/
-        119 + 1 ,/*BUFFER_delete*/
-        132 + 1 ,/*BUFFER_delete*/
-        145 + 1 ,/*BUFFER_delete*/
-        158 + 1 ,/*BUFFER_delete*/
-        171 + 1 ,/*BUFFER_delete*/
-        184 + 1 ,/*BUFFER_delete*/
-        197 + 1 ,/*BUFFER_delete*/
-        210 + 1 ,/*BUFFER_delete*/
-
-
-        214+1, /*STRING_c_str*/
-        216+1, /*STRING_c_str*/
-        218+1, /*BUFFER_delete*/
-        219+1, /*STRING_delete*/
-        220+1, /*STRING_delete*/
-        221+1, /*HTTPAPIEX_Destroy*/
-        222+1, /*gballoc_free*/
-    };
 
     (void)umock_c_negative_tests_init();
 
@@ -1313,7 +1138,8 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_64MB_with_certificate_unhappy_
             .IgnoreArgument_s2();
 
         STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)) /*this is getting the relative path as const char* */ /*12, 25, 38...*/
-            .IgnoreArgument_handle();
+            .IgnoreArgument_handle()
+            .CallCannotFail();
 
         STRICT_EXPECTED_CALL(HTTPAPIEX_ExecuteRequest(IGNORED_PTR_ARG, HTTPAPI_REQUEST_PUT, IGNORED_PTR_ARG, NULL, IGNORED_PTR_ARG, &httpResponse, NULL, testValidBufferHandle))
             .IgnoreArgument_handle()
@@ -1339,13 +1165,15 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_64MB_with_certificate_unhappy_
         .IgnoreArgument_handle();
 
     STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)) /*this is getting the XML as const char* so it can be passed to _ExecuteRequest*/
-        .IgnoreArgument_handle();
+        .IgnoreArgument_handle()
+        .CallCannotFail();
 
     STRICT_EXPECTED_CALL(BUFFER_create(IGNORED_PTR_ARG, IGNORED_NUM_ARG)) /*this is creating the XML body as BUFFER_HANDLE*/
         .IgnoreAllArguments();
 
     STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)) /*this is getting the relative path*/
-        .IgnoreArgument_handle();
+        .IgnoreArgument_handle()
+        .CallCannotFail();
 
     STRICT_EXPECTED_CALL(HTTPAPIEX_ExecuteRequest(
         IGNORED_PTR_ARG,
@@ -1367,27 +1195,15 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_64MB_with_certificate_unhappy_
         .IgnoreArgument_handle();
     STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG)) /*this is destroying the relative path for Put Block List*/
         .IgnoreArgument_handle();
-    STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG))/*this is the XML string used for Put Block List operation*/
-        .IgnoreArgument_handle();
-    STRICT_EXPECTED_CALL(HTTPAPIEX_Destroy(IGNORED_PTR_ARG)) /*this is the HTTPAPIEX handle*/
-        .IgnoreArgument_handle();
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG)) /*this is freeing the copy of the hostname*/ /* 223 */
-        .IgnoreArgument_ptr();
+    set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
 
     umock_c_negative_tests_snapshot();
 
     for (size_t i = 0; i < umock_c_negative_tests_call_count(); i++)
     {
-        size_t j;
         umock_c_negative_tests_reset();
 
-        for (j = 0;j<sizeof(calls_that_cannot_fail) / sizeof(calls_that_cannot_fail[0]);j++) /*not running the tests that cannot fail*/
-        {
-            if (calls_that_cannot_fail[j] == i)
-                break;
-        }
-
-        if (j == sizeof(calls_that_cannot_fail) / sizeof(calls_that_cannot_fail[0]))
+        if (umock_c_negative_tests_can_call_fail(i))
         {
 
             umock_c_negative_tests_fail_call(i);
@@ -1480,12 +1296,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_when_http_code_is_404_it_immediately_succeed
 
     /*this part is Put Block list*/ /*notice: no op because it failed before with 404*/
 
-    STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG))/*this is the XML string used for Put Block List operation*/
-        .IgnoreArgument_handle();
-    STRICT_EXPECTED_CALL(HTTPAPIEX_Destroy(IGNORED_PTR_ARG)) /*this is the HTTPAPIEX handle*/
-        .IgnoreArgument_handle();
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG)) /*this is freeing the copy of hte hostname*/
-        .IgnoreArgument_ptr();
+    set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
 
     ///act
     BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL);


### PR DESCRIPTION
Part1
First, fix #1698 which is explained in depth there.  But since there's extra changes in this PR the only part to this is initializing some variables.

```c
    unsigned char const * source = NULL; /* data set by getDataCallbackEx */
    size_t size = 0; /* source size set by getDataCallbackEx */
```

Part2 
The code is originally written though needed some cleanup.  `Blob_UploadMultipleBlocksFromSasUri` is almost 250 lines long and got to 15 levels of indentation.  

Fixed so that there's not as deep nesting of the else and created two helper functions, the most important being `InvokeUserCallbackAndSendBlobs` where we could put the loop.

Part3
Fix up the UT.  The _required_ changes were just fixing up the UT call list.  

The UT were also using the old-style hard-coded index of tests to skip in failure mode.  Replace with `umock_c_negative_tests_can_call_fail(i))`.