### PR TITLE
Fix samples vcproj files to load from correct vcpkg path, update vc++ deps

### DIFF
--- a/iothub_client/samples/iothub_client_sample_upload_to_blob/windows/iothub_client_sample_upload_to_blob.vcxproj
+++ b/iothub_client/samples/iothub_client_sample_upload_to_blob/windows/iothub_client_sample_upload_to_blob.vcxproj
@@ -94,7 +94,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>GB_MEASURE_MEMORY_FOR_THIS;GB_DEBUG_ALLOC;WIN32;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -109,7 +109,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>GB_MEASURE_MEMORY_FOR_THIS;GB_DEBUG_ALLOC;WIN32;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -126,7 +126,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -145,7 +145,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -167,6 +167,6 @@
     <PropertyGroup>
       <ErrorText>This project references Vcpkg package(s) that are missing on this computer. For more information, see https://github.com/Azure/azure-iot-sdk-c/tree/master/doc/setting_up_vcpkg.md. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(VcpkgRoot)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgRoot)include\azureiot\iothub.h'))" />
+    <Error Condition="!Exists('$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h'))" />
   </Target>
 </Project>

--- a/iothub_client/samples/iothub_client_sample_upload_to_blob_mb/windows/iothub_client_sample_upload_to_blob_mb.vcxproj
+++ b/iothub_client/samples/iothub_client_sample_upload_to_blob_mb/windows/iothub_client_sample_upload_to_blob_mb.vcxproj
@@ -94,7 +94,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -109,7 +109,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -126,7 +126,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -145,7 +145,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -165,6 +165,6 @@
     <PropertyGroup>
       <ErrorText>This project references Vcpkg package(s) that are missing on this computer. For more information, see https://github.com/Azure/azure-iot-sdk-c/tree/master/doc/setting_up_vcpkg.md. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(VcpkgRoot)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgRoot)include\azureiot\iothub.h'))" />
+    <Error Condition="!Exists('$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h'))" />
   </Target>
 </Project>

--- a/iothub_client/samples/iothub_ll_c2d_sample/windows/iothub_ll_c2d_sample.vcxproj
+++ b/iothub_client/samples/iothub_ll_c2d_sample/windows/iothub_ll_c2d_sample.vcxproj
@@ -90,7 +90,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions);USE_AMQP;USE_MQTT;USE_HTTP</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;..\..\..\..\certs</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;..\..\..\..\certs</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -113,7 +113,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions);USE_AMQP;USE_MQTT;USE_HTTP</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;..\..\..\..\certs</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;..\..\..\..\certs</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -134,7 +134,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions);USE_AMQP;USE_MQTT;USE_HTTP</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;..\..\..\..\certs</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;..\..\..\..\certs</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -161,7 +161,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions);USE_AMQP;USE_MQTT;USE_HTTP</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;..\..\..\..\certs</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;..\..\..\..\certs</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -187,6 +187,6 @@
     <PropertyGroup>
       <ErrorText>This project references Vcpkg package(s) that are missing on this computer. For more information, see https://github.com/Azure/azure-iot-sdk-c/tree/master/doc/setting_up_vcpkg.md. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(VcpkgRoot)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgRoot)include\azureiot\iothub.h'))" />
+    <Error Condition="!Exists('$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h'))" />
   </Target>
 </Project>

--- a/iothub_client/samples/iothub_ll_client_sample_amqp_shared/windows/iothub_ll_client_sample_amqp_shared.vcxproj
+++ b/iothub_client/samples/iothub_ll_client_sample_amqp_shared/windows/iothub_ll_client_sample_amqp_shared.vcxproj
@@ -92,7 +92,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>GB_MEASURE_MEMORY_FOR_THIS;GB_DEBUG_ALLOC;WIN32;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -107,7 +107,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -124,7 +124,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -143,7 +143,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -164,6 +164,6 @@
     <PropertyGroup>
       <ErrorText>This project references Vcpkg package(s) that are missing on this computer. For more information, see https://github.com/Azure/azure-iot-sdk-c/tree/master/doc/setting_up_vcpkg.md. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(VcpkgRoot)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgRoot)include\azureiot\iothub.h'))" />
+    <Error Condition="!Exists('$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h'))" />
   </Target>
 </Project>

--- a/iothub_client/samples/iothub_ll_telemetry_sample/windows/iothub_ll_telemetry_sample.vcxproj
+++ b/iothub_client/samples/iothub_ll_telemetry_sample/windows/iothub_ll_telemetry_sample.vcxproj
@@ -90,7 +90,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions);USE_AMQP;USE_MQTT;USE_HTTP</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;..\..\..\..\certs</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;..\..\..\..\certs</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -113,7 +113,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions);USE_AMQP;USE_MQTT;USE_HTTP</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;..\..\..\..\certs</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;..\..\..\..\certs</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -134,7 +134,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions);USE_AMQP;USE_MQTT;USE_HTTP</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;..\..\..\..\certs</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;..\..\..\..\certs</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -161,7 +161,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions);USE_AMQP;USE_MQTT;USE_HTTP</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;..\..\..\..\certs</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;..\..\..\..\certs</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -187,6 +187,6 @@
     <PropertyGroup>
       <ErrorText>This project references Vcpkg package(s) that are missing on this computer. For more information, see https://github.com/Azure/azure-iot-sdk-c/tree/master/doc/setting_up_vcpkg.md. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(VcpkgRoot)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgRoot)include\azureiot\iothub.h'))" />
+    <Error Condition="!Exists('$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h'))" />
   </Target>
 </Project>

--- a/serializer/samples/devicemethod_simplesample/windows/devicemethod_simplesample.vcxproj
+++ b/serializer/samples/devicemethod_simplesample/windows/devicemethod_simplesample.vcxproj
@@ -94,7 +94,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -109,7 +109,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -126,7 +126,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -145,7 +145,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -167,6 +167,6 @@
     <PropertyGroup>
       <ErrorText>This project references Vcpkg package(s) that are missing on this computer. For more information, see https://github.com/Azure/azure-iot-sdk-c/tree/master/doc/setting_up_vcpkg.md. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(VcpkgRoot)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgRoot)include\azureiot\iothub.h'))" />
+    <Error Condition="!Exists('$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h'))" />
   </Target>
 </Project>

--- a/serializer/samples/remote_monitoring/windows/remote_monitoring.vcxproj
+++ b/serializer/samples/remote_monitoring/windows/remote_monitoring.vcxproj
@@ -94,7 +94,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>GB_DEBUG_ALLOC;GB_MEASURE_MEMORY_FOR_THIS;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -109,7 +109,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>GB_DEBUG_ALLOC;GB_MEASURE_MEMORY_FOR_THIS;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -126,7 +126,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>GB_DEBUG_ALLOC;GB_MEASURE_MEMORY_FOR_THIS;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -145,7 +145,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>GB_DEBUG_ALLOC;GB_MEASURE_MEMORY_FOR_THIS;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -166,6 +166,6 @@
     <PropertyGroup>
       <ErrorText>This project references Vcpkg package(s) that are missing on this computer. For more information, see https://github.com/Azure/azure-iot-sdk-c/tree/master/doc/setting_up_vcpkg.md. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(VcpkgRoot)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgRoot)include\azureiot\iothub.h'))" />
+    <Error Condition="!Exists('$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h'))" />
   </Target>
 </Project>

--- a/serializer/samples/simplesample_amqp/windows/simplesample_amqp.vcxproj
+++ b/serializer/samples/simplesample_amqp/windows/simplesample_amqp.vcxproj
@@ -92,7 +92,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>GB_DEBUG_ALLOC;GB_MEASURE_MEMORY_FOR_THIS;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -112,7 +112,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>GB_DEBUG_ALLOC;GB_MEASURE_MEMORY_FOR_THIS;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -132,7 +132,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>GB_DEBUG_ALLOC;GB_MEASURE_MEMORY_FOR_THIS;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -156,7 +156,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>GB_DEBUG_ALLOC;GB_MEASURE_MEMORY_FOR_THIS;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -179,6 +179,6 @@
     <PropertyGroup>
       <ErrorText>This project references Vcpkg package(s) that are missing on this computer. For more information, see https://github.com/Azure/azure-iot-sdk-c/tree/master/doc/setting_up_vcpkg.md. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(VcpkgRoot)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgRoot)include\azureiot\iothub.h'))" />
+    <Error Condition="!Exists('$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h'))" />
   </Target>
 </Project>

--- a/serializer/samples/simplesample_http/windows/simplesample_http.vcxproj
+++ b/serializer/samples/simplesample_http/windows/simplesample_http.vcxproj
@@ -92,7 +92,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>GB_DEBUG_ALLOC;GB_MEASURE_MEMORY_FOR_THIS;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -112,7 +112,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>GB_DEBUG_ALLOC;GB_MEASURE_MEMORY_FOR_THIS;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -130,7 +130,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>GB_DEBUG_ALLOC;GB_MEASURE_MEMORY_FOR_THIS;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -154,7 +154,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>GB_DEBUG_ALLOC;GB_MEASURE_MEMORY_FOR_THIS;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -176,6 +176,6 @@
     <PropertyGroup>
       <ErrorText>This project references Vcpkg package(s) that are missing on this computer. For more information, see https://github.com/Azure/azure-iot-sdk-c/tree/master/doc/setting_up_vcpkg.md. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(VcpkgRoot)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgRoot)include\azureiot\iothub.h'))" />
+    <Error Condition="!Exists('$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h'))" />
   </Target>
 </Project>

--- a/serializer/samples/simplesample_mqtt/windows/simplesample_mqtt.vcxproj
+++ b/serializer/samples/simplesample_mqtt/windows/simplesample_mqtt.vcxproj
@@ -94,7 +94,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -109,7 +109,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -126,7 +126,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -145,7 +145,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -167,6 +167,6 @@
     <PropertyGroup>
       <ErrorText>This project references Vcpkg package(s) that are missing on this computer. For more information, see https://github.com/Azure/azure-iot-sdk-c/tree/master/doc/setting_up_vcpkg.md. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(VcpkgRoot)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgRoot)include\azureiot\iothub.h'))" />
+    <Error Condition="!Exists('$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h'))" />
   </Target>
 </Project>

--- a/serializer/samples/temp_sensor_anomaly/windows/temp_sensor_anomaly.vcxproj
+++ b/serializer/samples/temp_sensor_anomaly/windows/temp_sensor_anomaly.vcxproj
@@ -89,7 +89,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>GB_DEBUG_ALLOC;GB_MEASURE_MEMORY_FOR_THIS;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -108,7 +108,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>GB_DEBUG_ALLOC;GB_MEASURE_MEMORY_FOR_THIS;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -127,7 +127,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>GB_DEBUG_ALLOC;GB_MEASURE_MEMORY_FOR_THIS;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>GB_DEBUG_ALLOC;GB_MEASURE_MEMORY_FOR_THIS;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(VcpkgRoot)include\azureiot;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;$(VcpkgCurrentInstalledDir)include\azureiot;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -170,6 +170,6 @@
     <PropertyGroup>
       <ErrorText>This project references Vcpkg package(s) that are missing on this computer. For more information, see https://github.com/Azure/azure-iot-sdk-c/tree/master/doc/setting_up_vcpkg.md. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(VcpkgRoot)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgRoot)include\azureiot\iothub.h'))" />
+    <Error Condition="!Exists('$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h')" Text="$([System.String]::Format('$(ErrorText)', '$(VcpkgCurrentInstalledDir)include\azureiot\iothub.h'))" />
   </Target>
   </Project>


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-c/issues/1691

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
Projects of the samples were using the incorrect vcpkg variable to find installed packages.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Updated VcpkgRoot var to VcpkgCurrentInstalledDir.
Also upgraded target on samples projects to VS2019.