### PR TITLE
Fix for Issue #1255: Disconnect without connection status callback called

### DIFF
--- a/iothub_client/src/iothubtransport_mqtt_common.c
+++ b/iothub_client/src/iothubtransport_mqtt_common.c
@@ -2106,7 +2106,11 @@ static void process_queued_ack_messages(PMQTTTRANSPORT_HANDLE_DATA transport_dat
                 free(msg_detail_entry);
 
                 DisconnectFromClient(transport_data);
-                transport_data->transport_callbacks.connection_status_cb(IOTHUB_CLIENT_CONNECTION_UNAUTHENTICATED, IOTHUB_CLIENT_CONNECTION_RETRY_EXPIRED, transport_data->transport_ctx);
+                if (!transport_data->isRetryExpiredCallbackSet) // Only call once
+                {
+                    transport_data->transport_callbacks.connection_status_cb(IOTHUB_CLIENT_CONNECTION_UNAUTHENTICATED, IOTHUB_CLIENT_CONNECTION_RETRY_EXPIRED, transport_data->transport_ctx);
+                    transport_data->isRetryExpiredCallbackSet = true; // Reset to false upon successful call to sendMqttConnectMsg in new connection
+                }
             }
             else
             {

--- a/iothub_client/src/iothubtransport_mqtt_common.c
+++ b/iothub_client/src/iothubtransport_mqtt_common.c
@@ -1063,7 +1063,7 @@ static void sendPendingGetTwinRequests(PMQTTTRANSPORT_HANDLE_DATA transportData)
 static void removeExpiredTwinRequestsFromList(PMQTTTRANSPORT_HANDLE_DATA transport_data, tickcounter_ms_t current_ms, DLIST_ENTRY* twin_list)
 {
     PDLIST_ENTRY list_item = twin_list->Flink;
-    
+
     while (list_item != twin_list)
     {
         DLIST_ENTRY next_list_item;
@@ -2106,6 +2106,7 @@ static void process_queued_ack_messages(PMQTTTRANSPORT_HANDLE_DATA transport_dat
                 free(msg_detail_entry);
 
                 DisconnectFromClient(transport_data);
+                transport_data->transport_callbacks.connection_status_cb(IOTHUB_CLIENT_CONNECTION_UNAUTHENTICATED, IOTHUB_CLIENT_CONNECTION_RETRY_EXPIRED, transport_data->transport_ctx);
             }
             else
             {
@@ -2231,7 +2232,7 @@ static int buildConfigForUsernameStep2IfNeeded(PMQTTTRANSPORT_HANDLE_DATA transp
         // https://github.com/Azure/azure-iot-sdk-c/issues/1547 tracks removing this once non-preview API versions support modelId.
         const char* apiVersion = IOTHUB_API_VERSION;
         const char* appSpecifiedProductInfo = transport_data->transport_callbacks.prod_info_cb(transport_data->transport_ctx);
-        STRING_HANDLE productInfoEncoded = NULL; 
+        STRING_HANDLE productInfoEncoded = NULL;
 
         if ((productInfoEncoded = URL_EncodeString((appSpecifiedProductInfo != NULL) ? appSpecifiedProductInfo : DEFAULT_IOTHUB_PRODUCT_IDENTIFIER)) == NULL)
         {

--- a/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
+++ b/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
@@ -2335,7 +2335,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_Destroy_from_disconnected_state)
     // The initial call to DoWork() is required to process the disconnection and move us into the disconnected state.
     IoTHubTransport_MQTT_Common_DoWork(handle);
 
-    // A future Dowork call is required to re-allocate the xio.  As part of this, make the mqtt_client_connect fail.  
+    // A future Dowork call is required to re-allocate the xio.  As part of this, make the mqtt_client_connect fail.
     // This has the effect of allocationg the xio but leaving us in a disconnected state.
 
     // Using the REGISTER_GLOBAL_MOCK_RETURN to force an error in a LONG list of calls there's not otherwise need
@@ -2347,7 +2347,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_Destroy_from_disconnected_state)
     umock_c_reset_all_calls();
 
     set_expected_calls_for_IoTHubTransport_MQTT_Common_Destroy();
-   
+
     // act
     IoTHubTransport_MQTT_Common_Destroy(handle);
 
@@ -5232,6 +5232,8 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_message_timeout_succeeds)
     }
     STRICT_EXPECTED_CALL(mqtt_client_clear_xio(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(xio_destroy(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(Transport_ConnectionStatusCallBack(IOTHUB_CLIENT_CONNECTION_UNAUTHENTICATED, IOTHUB_CLIENT_CONNECTION_RETRY_EXPIRED, transport_cb_ctx));
+
     // removeExpiredTwinRequests
     STRICT_EXPECTED_CALL(tickcounter_get_current_ms(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
 
@@ -5312,6 +5314,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_2_message_timeout_succeeds)
     }
     STRICT_EXPECTED_CALL(mqtt_client_clear_xio(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(xio_destroy(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(Transport_ConnectionStatusCallBack(IOTHUB_CLIENT_CONNECTION_UNAUTHENTICATED, IOTHUB_CLIENT_CONNECTION_RETRY_EXPIRED, transport_cb_ctx));
 
     STRICT_EXPECTED_CALL(DList_InitializeListHead(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(DList_InsertTailList(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
@@ -6316,7 +6319,7 @@ TEST_FUNCTION(IoTHubTransportMqtt_implicit_gettwin_timeout)
     suback.qosReturn = QosValue;
     g_fnMqttOperationCallback(TEST_MQTT_CLIENT_HANDLE, MQTT_CLIENT_ON_SUBSCRIBE_ACK, &suback, g_callbackCtx);
 
-    IoTHubTransport_MQTT_Common_DoWork(handle);    
+    IoTHubTransport_MQTT_Common_DoWork(handle);
 
     umock_c_reset_all_calls();
     set_expected_calls_for_DoWork_for_twin_timeouts();


### PR DESCRIPTION
Addresses Issue #1255.

Bug occurs in logic of `IoTHubTransport_MQTT_Common_DoWork` --> `process_queued_ack_messages`, when the `RESEND_TIMEOUT_VALUE_MIN` is met and `MAX_SEND_RECOUNT_LIMIT` is reached.  Upon modifying those macro values, bug was reproduced using a modified `iothub_ll_telemetry_sample`, with similar output:

```
Confirmation callback received for message 5 with result IOTHUB_CLIENT_CONFIRMATION_MESSAGE_TIMEOUT
-> 22:11:58 DISCONNECT
Sending message 6 to IoTHub
-> 22:12:00 CONNECT | VER: 4 | KEEPALIVE: 240 | FLAGS: 192 | USERNAME: xxx | PWD: XXXX | CLEAN: 0
Sending message 7 to IoTHub
<- 22:12:06 CONNACK | SESSION_PRESENT: true | RETURN_CODE: 0x0
The device client is connected to iothub
```

The problem is that the `connection_status_cb` is never called post `DisconnectFromClient`, as it is done other places, such as in `InitializeConnection` when the SAS token has expired.

After making the change, the callback ocurs:

```
Confirmation callback received for message 5 with result IOTHUB_CLIENT_CONFIRMATION_MESSAGE_TIMEOUT
-> 22:18:01 DISCONNECT
The device client has been disconnected
Sending message 6 to IoTHub
-> 22:18:02 CONNECT | VER: 4 | KEEPALIVE: 240 | FLAGS: 192 | USERNAME: xxx | PWD: XXXX | CLEAN: 0
Sending message 7 to IoTHub
<- 22:18:07 CONNACK | SESSION_PRESENT: true | RETURN_CODE: 0x0
The device client is connected to iothub
```