### PR TITLE
Updating dependencies for Xcode 12 compatibility.

### DIFF
--- a/iothub_client/inc/internal/blob.h
+++ b/iothub_client/inc/internal/blob.h
@@ -13,7 +13,7 @@
 #ifndef BLOB_H
 #define BLOB_H
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/buffer_.h"
 #include "azure_c_shared_utility/strings_types.h"
 #include "azure_c_shared_utility/httpapiex.h"

--- a/iothub_client/inc/internal/iothub_client_authorization.h
+++ b/iothub_client/inc/internal/iothub_client_authorization.h
@@ -4,7 +4,7 @@
 #ifndef IOTHUB_CLIENT_AUTHORIZATION_H
 #define IOTHUB_CLIENT_AUTHORIZATION_H
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c_prod.h"
 #include "azure_c_shared_utility/xio.h"
 

--- a/iothub_client/inc/internal/iothub_client_edge.h
+++ b/iothub_client/inc/internal/iothub_client_edge.h
@@ -3,7 +3,7 @@
 
 #include <stddef.h>
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c_prod.h"
 
 #include "iothub_client_authorization.h"

--- a/iothub_client/inc/internal/iothub_client_hsm_ll.h
+++ b/iothub_client/inc/internal/iothub_client_hsm_ll.h
@@ -8,7 +8,7 @@
 #ifndef IOTHUB_CLIENT_PROVISIONING_H
 #define IOTHUB_CLIENT_PROVISIONING_H
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c_prod.h"
 
 #ifdef USE_PROV_MODULE

--- a/iothub_client/inc/internal/iothubtransport_amqp_connection.h
+++ b/iothub_client/inc/internal/iothubtransport_amqp_connection.h
@@ -5,7 +5,7 @@
 #define IOTHUBTRANSPORTAMQP_AMQP_CONNECTION_H
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/xio.h"
 #include "azure_uamqp_c/session.h"
 #include "azure_uamqp_c/cbs.h"

--- a/iothub_client/inc/internal/iothubtransport_amqp_twin_messenger.h
+++ b/iothub_client/inc/internal/iothubtransport_amqp_twin_messenger.h
@@ -4,7 +4,7 @@
 #ifndef IOTHUBTRANSPORT_AMQP_TWIN_MESSENGER
 #define IOTHUBTRANSPORT_AMQP_TWIN_MESSENGER
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c_prod.h"
 #include "azure_c_shared_utility/optionhandler.h"
 #include "azure_uamqp_c/session.h"

--- a/iothub_client/inc/internal/message_queue.h
+++ b/iothub_client/inc/internal/message_queue.h
@@ -8,7 +8,7 @@
 #ifndef MESSAGE_QUEUE_H
 #define MESSAGE_QUEUE_H
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c_prod.h"
 #include "azure_c_shared_utility/optionhandler.h"
 

--- a/iothub_client/inc/iothub_client_core_common.h
+++ b/iothub_client/inc/iothub_client_core_common.h
@@ -6,7 +6,7 @@
 #ifndef IOTHUB_CLIENT_CORE_COMMON_H
 #define IOTHUB_CLIENT_CORE_COMMON_H
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c_prod.h"
 
 #include "iothub_transport_ll.h"

--- a/iothub_client/inc/iothub_device_client_ll.h
+++ b/iothub_client/inc/iothub_device_client_ll.h
@@ -26,7 +26,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c_prod.h"
 
 #include "iothub_transport_ll.h"

--- a/iothub_client/inc/iothub_message.h
+++ b/iothub_client/inc/iothub_message.h
@@ -9,7 +9,7 @@
 #ifndef IOTHUB_MESSAGE_H
 #define IOTHUB_MESSAGE_H
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/map.h"
 #include "umock_c/umock_c_prod.h"
 

--- a/iothub_client/inc/iothub_module_client_ll.h
+++ b/iothub_client/inc/iothub_module_client_ll.h
@@ -24,7 +24,7 @@
 #define IOTHUB_MODULE_CLIENT_LL_H
 
 #include <time.h>
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c_prod.h"
 
 #include "iothub_transport_ll.h"

--- a/iothub_client/samples/iothub_client_device_twin_and_methods_sample/iothub_client_device_twin_and_methods_sample.c
+++ b/iothub_client/samples/iothub_client_device_twin_and_methods_sample/iothub_client_device_twin_and_methods_sample.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <inttypes.h>
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/threadapi.h"
 #include "azure_c_shared_utility/platform.h"
 #include "iothub_device_client.h"

--- a/iothub_client/src/iothub.c
+++ b/iothub_client/src/iothub.c
@@ -5,7 +5,7 @@
 
 #include "azure_c_shared_utility/platform.h"
 #include "azure_c_shared_utility/xlogging.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "iothub.h"
 
 int IoTHub_Init(void)

--- a/iothub_client/src/iothub_client_authorization.c
+++ b/iothub_client/src/iothub_client_authorization.c
@@ -3,7 +3,7 @@
 
 #include <stdlib.h>
 #include "azure_c_shared_utility/gballoc.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c_prod.h"
 #include "azure_c_shared_utility/crt_abstractions.h"
 #include "azure_c_shared_utility/agenttime.h"

--- a/iothub_client/src/iothubtransport_amqp_common.c
+++ b/iothub_client/src/iothubtransport_amqp_common.c
@@ -19,7 +19,7 @@
 #include "azure_c_shared_utility/tlsio.h"
 #include "azure_c_shared_utility/optionhandler.h"
 #include "azure_c_shared_utility/shared_util_options.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #include "azure_uamqp_c/cbs.h"
 #include "azure_uamqp_c/amqp_definitions.h"

--- a/iothub_client/tests/iothub_client_authorization_ut/iothub_client_authorization_ut.c
+++ b/iothub_client/tests/iothub_client_authorization_ut/iothub_client_authorization_ut.c
@@ -21,7 +21,7 @@ static void my_gballoc_free(void* ptr)
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_charptr.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #define ENABLE_MOCKS
 #include "azure_c_shared_utility/gballoc.h"

--- a/iothub_client/tests/iothub_transport_ll_private_ut/iothub_transport_ll_private_ut.c
+++ b/iothub_client/tests/iothub_transport_ll_private_ut/iothub_transport_ll_private_ut.c
@@ -41,7 +41,7 @@ void my_gballoc_free(void* ptr)
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_charptr.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #include "internal/iothub_transport_ll_private.h"
 

--- a/iothub_client/tests/iothub_ut/iothub_ut.c
+++ b/iothub_client/tests/iothub_ut/iothub_ut.c
@@ -11,7 +11,7 @@
 #endif
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #include "umock_c/umock_c.h"
 #include "umock_c/umock_c_negative_tests.h"

--- a/iothub_client/tests/iothubclient_edge_ut/iothubclient_edge_ut.c
+++ b/iothub_client/tests/iothubclient_edge_ut/iothubclient_edge_ut.c
@@ -15,7 +15,7 @@
 #endif
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #include "umock_c/umock_c.h"
 #include "umock_c/umock_c_negative_tests.h"

--- a/iothub_client/tests/iothubclient_ll_u2b_ut/iothub_client_ll_u2b_ut.c
+++ b/iothub_client/tests/iothubclient_ll_u2b_ut/iothub_client_ll_u2b_ut.c
@@ -26,7 +26,7 @@ static void* my_gballoc_calloc(size_t nmemb, size_t size)
 
 #include "testrunnerswitcher.h"
 #include "azure_c_shared_utility/optimize_size.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_charptr.h"
 #include "umock_c/umock_c_negative_tests.h"

--- a/iothub_client/tests/iothubclient_ll_ut/iothubclient_ll_ut.c
+++ b/iothub_client/tests/iothubclient_ll_ut/iothubclient_ll_ut.c
@@ -11,7 +11,7 @@
 #endif
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #include "umock_c/umock_c.h"
 #include "umock_c/umock_c_negative_tests.h"

--- a/iothub_client/tests/iothubclient_ut/iothubclient_ut.c
+++ b/iothub_client/tests/iothubclient_ut/iothubclient_ut.c
@@ -11,7 +11,7 @@
 #endif
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #include "umock_c/umock_c.h"
 #include "umock_c/umock_c_negative_tests.h"

--- a/iothub_client/tests/iothubdeviceclient_ll_ut/iothubdeviceclient_ll_ut.c
+++ b/iothub_client/tests/iothubdeviceclient_ll_ut/iothubdeviceclient_ll_ut.c
@@ -11,7 +11,7 @@
 #endif
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #include "umock_c/umock_c.h"
 #include "umock_c/umock_c_negative_tests.h"

--- a/iothub_client/tests/iothubdeviceclient_ut/iothubdeviceclient_ut.c
+++ b/iothub_client/tests/iothubdeviceclient_ut/iothubdeviceclient_ut.c
@@ -11,7 +11,7 @@
 #endif
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #include "umock_c/umock_c.h"
 #include "umock_c/umock_c_negative_tests.h"

--- a/iothub_client/tests/iothubmoduleclient_ll_ut/iothubmoduleclient_ll_ut.c
+++ b/iothub_client/tests/iothubmoduleclient_ll_ut/iothubmoduleclient_ll_ut.c
@@ -11,7 +11,7 @@
 #endif
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #include "umock_c/umock_c.h"
 #include "umock_c/umock_c_negative_tests.h"

--- a/iothub_client/tests/iothubmoduleclient_ut/iothubmoduleclient_ut.c
+++ b/iothub_client/tests/iothubmoduleclient_ut/iothubmoduleclient_ut.c
@@ -11,7 +11,7 @@
 #endif
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #include "umock_c/umock_c.h"
 #include "umock_c/umock_c_negative_tests.h"

--- a/iothub_client/tests/iothubtr_amqp_msgr_ut/iothubtr_amqp_msgr_ut.c
+++ b/iothub_client/tests/iothubtr_amqp_msgr_ut/iothubtr_amqp_msgr_ut.c
@@ -30,7 +30,7 @@ static void real_free(void* ptr)
 
 #include "testrunnerswitcher.h"
 #include "azure_c_shared_utility/optimize_size.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_charptr.h"
 #include "umock_c/umocktypes_bool.h"

--- a/iothub_client/tests/iothubtr_amqp_tel_msgr_ut/iothubtr_amqp_tel_msgr_ut.c
+++ b/iothub_client/tests/iothubtr_amqp_tel_msgr_ut/iothubtr_amqp_tel_msgr_ut.c
@@ -30,7 +30,7 @@ void real_free(void* ptr)
 
 #include "testrunnerswitcher.h"
 #include "azure_c_shared_utility/optimize_size.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_charptr.h"
 #include "umock_c/umocktypes_bool.h"

--- a/iothub_client/tests/iothubtr_amqp_twin_msgr_ut/iothubtr_amqp_twin_msgr_ut.c
+++ b/iothub_client/tests/iothubtr_amqp_twin_msgr_ut/iothubtr_amqp_twin_msgr_ut.c
@@ -30,7 +30,7 @@ void real_free(void* ptr)
 
 #include "testrunnerswitcher.h"
 #include "azure_c_shared_utility/optimize_size.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_charptr.h"
 #include "umock_c/umocktypes_bool.h"

--- a/iothub_client/tests/iothubtransport_amqp_cbs_auth_ut/iothubtransport_amqp_cbs_auth_ut.c
+++ b/iothub_client/tests/iothubtransport_amqp_cbs_auth_ut/iothubtransport_amqp_cbs_auth_ut.c
@@ -36,7 +36,7 @@ static int real_strcmp(const char* str1, const char* str2)
 
 #include "testrunnerswitcher.h"
 #include "azure_c_shared_utility/optimize_size.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_charptr.h"
 #include "umock_c/umocktypes_stdint.h"

--- a/iothub_client/tests/iothubtransport_amqp_common_ut/iothubtransport_amqp_common_ut.c
+++ b/iothub_client/tests/iothubtransport_amqp_common_ut/iothubtransport_amqp_common_ut.c
@@ -30,7 +30,7 @@ void real_free(void* ptr)
 
 #include "testrunnerswitcher.h"
 #include "azure_c_shared_utility/optimize_size.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/shared_util_options.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_charptr.h"

--- a/iothub_client/tests/iothubtransport_amqp_device_ut/iothubtransport_amqp_device_ut.c
+++ b/iothub_client/tests/iothubtransport_amqp_device_ut/iothubtransport_amqp_device_ut.c
@@ -29,7 +29,7 @@ void real_free(void* ptr)
 }
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_charptr.h"
 #include "umock_c/umocktypes_bool.h"

--- a/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
+++ b/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
@@ -33,7 +33,7 @@ void* my_gballoc_realloc(void* ptr, size_t size)
 
 #include "testrunnerswitcher.h"
 #include "azure_c_shared_utility/optimize_size.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/shared_util_options.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umock_c_prod.h"

--- a/iothub_client/tests/iothubtransport_ut/iothubtransport_ut.c
+++ b/iothub_client/tests/iothubtransport_ut/iothubtransport_ut.c
@@ -27,7 +27,7 @@ static void my_gballoc_free(void* ptr)
 #include "umock_c/umocktypes_stdint.h"
 #include "umock_c/umocktypes_bool.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #include "iothub_transport_ll.h"
 

--- a/iothub_client/tests/iothubtransportamqp_ut/iothubtransportamqp_ut.c
+++ b/iothub_client/tests/iothubtransportamqp_ut/iothubtransportamqp_ut.c
@@ -8,7 +8,7 @@
 #endif
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_charptr.h"
 #include "umock_c/umocktypes_stdint.h"

--- a/iothub_client/tests/iothubtransportamqp_ws_ut/iothubtransportamqp_ws_ut.c
+++ b/iothub_client/tests/iothubtransportamqp_ws_ut/iothubtransportamqp_ws_ut.c
@@ -8,7 +8,7 @@
 #endif
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_charptr.h"
 #include "umock_c/umocktypes_stdint.h"

--- a/iothub_client/tests/uamqp_messaging_ut/uamqp_messaging_ut.c
+++ b/iothub_client/tests/uamqp_messaging_ut/uamqp_messaging_ut.c
@@ -21,7 +21,7 @@ static void real_free(void* ptr)
 }
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_charptr.h"
 #include "umock_c/umocktypes_stdint.h"

--- a/iothub_service_client/inc/iothub_registrymanager.h
+++ b/iothub_service_client/inc/iothub_registrymanager.h
@@ -6,7 +6,7 @@
 #ifndef IOTHUB_REGISTRYMANAGER_H
 #define IOTHUB_REGISTRYMANAGER_H
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c_prod.h"
 #include "azure_c_shared_utility/crt_abstractions.h"
 #include "azure_c_shared_utility/singlylinkedlist.h"

--- a/iothub_service_client/inc/iothub_service_client_auth.h
+++ b/iothub_service_client/inc/iothub_service_client_auth.h
@@ -19,7 +19,7 @@
 #ifndef IOTHUB_SERVICE_CLIENT_AUTH_H
 #define IOTHUB_SERVICE_CLIENT_AUTH_H
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c_prod.h"
 
 #define IOTHUB_DEVICE_STATUS_VALUES       \
@@ -40,7 +40,7 @@ extern "C"
 #else
 #endif
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 /** @brief Structure to store IoTHub authentication information
 */

--- a/provisioning_client/adapters/hsm_client_http_edge.h
+++ b/provisioning_client/adapters/hsm_client_http_edge.h
@@ -14,7 +14,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "hsm_client_data.h"
 
 MOCKABLE_FUNCTION(, HSM_CLIENT_HANDLE, hsm_client_http_edge_create);

--- a/provisioning_client/adapters/hsm_client_riot.h
+++ b/provisioning_client/adapters/hsm_client_riot.h
@@ -14,7 +14,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "hsm_client_data.h"
 
 MOCKABLE_FUNCTION(, HSM_CLIENT_HANDLE, hsm_client_riot_create);

--- a/provisioning_client/adapters/hsm_client_tpm.h
+++ b/provisioning_client/adapters/hsm_client_tpm.h
@@ -14,7 +14,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "hsm_client_data.h"
 
 MOCKABLE_FUNCTION(, HSM_CLIENT_HANDLE, hsm_client_tpm_create);

--- a/provisioning_client/inc/azure_prov_client/internal/iothub_auth_client.h
+++ b/provisioning_client/inc/azure_prov_client/internal/iothub_auth_client.h
@@ -14,7 +14,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 typedef struct IOTHUB_SECURITY_INFO_TAG* IOTHUB_SECURITY_HANDLE;
 

--- a/provisioning_client/inc/azure_prov_client/internal/prov_auth_client.h
+++ b/provisioning_client/inc/azure_prov_client/internal/prov_auth_client.h
@@ -14,7 +14,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/buffer_.h"
 
 typedef struct PROV_AUTH_INFO_TAG* PROV_AUTH_HANDLE;

--- a/provisioning_client/inc/azure_prov_client/internal/prov_transport_amqp_common.h
+++ b/provisioning_client/inc/azure_prov_client/internal/prov_transport_amqp_common.h
@@ -15,7 +15,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_prov_client/prov_transport.h"
 #include "azure_prov_client/internal/prov_transport_private.h"
 #include "azure_uamqp_c/saslclientio.h"

--- a/provisioning_client/inc/azure_prov_client/internal/prov_transport_mqtt_common.h
+++ b/provisioning_client/inc/azure_prov_client/internal/prov_transport_mqtt_common.h
@@ -15,7 +15,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_prov_client/prov_transport.h"
 #include "azure_prov_client/internal/prov_transport_private.h"
 #include "azure_c_shared_utility/http_proxy_io.h"

--- a/provisioning_client/inc/azure_prov_client/internal/prov_transport_private.h
+++ b/provisioning_client/inc/azure_prov_client/internal/prov_transport_private.h
@@ -5,7 +5,7 @@
 #define PROV_TRANSPORT_PRIVATE_H
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/shared_util_options.h"
 #include "azure_c_shared_utility/buffer_.h"
 #include "azure_prov_client/prov_transport.h"

--- a/provisioning_client/inc/azure_prov_client/iothub_security_factory.h
+++ b/provisioning_client/inc/azure_prov_client/iothub_security_factory.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/buffer_.h"
 
 #define IOTHUB_SECURITY_TYPE_VALUES \

--- a/provisioning_client/inc/azure_prov_client/prov_device_client.h
+++ b/provisioning_client/inc/azure_prov_client/prov_device_client.h
@@ -24,7 +24,7 @@ typedef struct PROV_DEVICE_INSTANCE_TAG* PROV_DEVICE_HANDLE;
 #include <stdint.h>
 #include "prov_device_ll_client.h"
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/const_defines.h"
 #include "azure_prov_client/prov_transport.h"
 

--- a/provisioning_client/inc/azure_prov_client/prov_device_ll_client.h
+++ b/provisioning_client/inc/azure_prov_client/prov_device_ll_client.h
@@ -5,7 +5,7 @@
 #define PROV_DEVICE_LL_CLIENT_H
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/const_defines.h"
 #include "azure_prov_client/prov_transport.h"
 

--- a/provisioning_client/inc/azure_prov_client/prov_security_factory.h
+++ b/provisioning_client/inc/azure_prov_client/prov_security_factory.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #define SECURE_DEVICE_TYPE_VALUES \
     SECURE_DEVICE_TYPE_UNKNOWN,   \

--- a/provisioning_client/inc/azure_prov_client/prov_transport.h
+++ b/provisioning_client/inc/azure_prov_client/prov_transport.h
@@ -5,7 +5,7 @@
 #define PROV_TRANSPORT_H
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/shared_util_options.h"
 #include "azure_c_shared_utility/buffer_.h"
 #include "azure_prov_client/prov_client_const.h"

--- a/provisioning_client/inc/azure_prov_client/prov_transport_amqp_client.h
+++ b/provisioning_client/inc/azure_prov_client/prov_transport_amqp_client.h
@@ -14,7 +14,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_prov_client/prov_transport.h"
 
 MOCKABLE_FUNCTION(, const PROV_DEVICE_TRANSPORT_PROVIDER*, Prov_Device_AMQP_Protocol);

--- a/provisioning_client/inc/azure_prov_client/prov_transport_amqp_ws_client.h
+++ b/provisioning_client/inc/azure_prov_client/prov_transport_amqp_ws_client.h
@@ -14,7 +14,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_prov_client/prov_transport.h"
 
 MOCKABLE_FUNCTION(, const PROV_DEVICE_TRANSPORT_PROVIDER*, Prov_Device_AMQP_WS_Protocol);

--- a/provisioning_client/inc/azure_prov_client/prov_transport_http_client.h
+++ b/provisioning_client/inc/azure_prov_client/prov_transport_http_client.h
@@ -14,7 +14,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_prov_client/prov_transport.h"
 
 MOCKABLE_FUNCTION(, const PROV_DEVICE_TRANSPORT_PROVIDER*, Prov_Device_HTTP_Protocol);

--- a/provisioning_client/inc/azure_prov_client/prov_transport_mqtt_client.h
+++ b/provisioning_client/inc/azure_prov_client/prov_transport_mqtt_client.h
@@ -14,7 +14,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_prov_client/prov_transport.h"
 
 MOCKABLE_FUNCTION(, const PROV_DEVICE_TRANSPORT_PROVIDER*, Prov_Device_MQTT_Protocol);

--- a/provisioning_client/inc/azure_prov_client/prov_transport_mqtt_ws_client.h
+++ b/provisioning_client/inc/azure_prov_client/prov_transport_mqtt_ws_client.h
@@ -14,7 +14,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_prov_client/prov_transport.h"
 
 MOCKABLE_FUNCTION(, const PROV_DEVICE_TRANSPORT_PROVIDER*, Prov_Device_MQTT_WS_Protocol);

--- a/provisioning_client/tests/common_prov_e2e/common_prov_e2e.c
+++ b/provisioning_client/tests/common_prov_e2e/common_prov_e2e.c
@@ -17,7 +17,7 @@
 
 #include "azure_c_shared_utility/threadapi.h"
 #include "azure_c_shared_utility/crt_abstractions.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/xlogging.h"
 #include "azure_c_shared_utility/strings.h"
 #include "azure_c_shared_utility/uniqueid.h"

--- a/provisioning_client/tests/device_auth_emulator_ut/device_auth_emulator_ut.c
+++ b/provisioning_client/tests/device_auth_emulator_ut/device_auth_emulator_ut.c
@@ -21,7 +21,7 @@ static void my_gballoc_free(void* ptr)
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_charptr.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #define ENABLE_MOCKS
 #include "azure_c_shared_utility/gballoc.h"

--- a/provisioning_client/tests/dps_client_e2e/dps_client_e2e.c
+++ b/provisioning_client/tests/dps_client_e2e/dps_client_e2e.c
@@ -12,7 +12,7 @@
 #include "azure_c_shared_utility/platform.h"
 #include "azure_c_shared_utility/threadapi.h"
 #include "azure_c_shared_utility/crt_abstractions.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/xlogging.h"
 #include "azure_c_shared_utility/azure_base64.h"
 

--- a/provisioning_client/tests/hsm_client_http_edge_ut/hsm_client_http_edge_ut.c
+++ b/provisioning_client/tests/hsm_client_http_edge_ut/hsm_client_http_edge_ut.c
@@ -27,7 +27,7 @@ static void my_gballoc_free(void* ptr)
 #include "umock_c/umocktypes_stdint.h"
 #include "umock_c/umocktypes_bool.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #if defined _MSC_VER
 #pragma warning(disable: 4054) /* MSC incorrectly fires this */

--- a/provisioning_client/tests/hsm_client_key_ut/hsm_client_key_ut.c
+++ b/provisioning_client/tests/hsm_client_key_ut/hsm_client_key_ut.c
@@ -31,7 +31,7 @@ static void my_gballoc_free(void* ptr)
 #include "umock_c/umocktypes_stdint.h"
 #include "umock_c/umocktypes_bool.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #define ENABLE_MOCKS
 #include "azure_c_shared_utility/gballoc.h"

--- a/provisioning_client/tests/hsm_client_riot_ut/hsm_client_riot_ut.c
+++ b/provisioning_client/tests/hsm_client_riot_ut/hsm_client_riot_ut.c
@@ -30,7 +30,7 @@ static void my_gballoc_free(void* ptr)
 #include "umock_c/umocktypes_charptr.h"
 #include "umock_c/umocktypes_stdint.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #include "RIoT.h"
 #include "RiotCrypt.h"

--- a/provisioning_client/tests/hsm_client_tpm_ut/hsm_client_tpm_ut.c
+++ b/provisioning_client/tests/hsm_client_tpm_ut/hsm_client_tpm_ut.c
@@ -31,7 +31,7 @@ static void my_gballoc_free(void* ptr)
 #include "umock_c/umocktypes_stdint.h"
 #include "umock_c/umocktypes_bool.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #define ENABLE_MOCKS
 #include "azure_c_shared_utility/gballoc.h"

--- a/provisioning_client/tests/iothub_auth_client_ut/iothub_auth_client_ut.c
+++ b/provisioning_client/tests/iothub_auth_client_ut/iothub_auth_client_ut.c
@@ -24,7 +24,7 @@ static void my_gballoc_free(void* ptr)
 #include "umock_c/umocktypes_charptr.h"
 #include "umock_c/umocktypes_stdint.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #include "azure_prov_client/internal/iothub_auth_client.h"
 

--- a/provisioning_client/tests/prov_auth_client_ut/prov_auth_client_ut.c
+++ b/provisioning_client/tests/prov_auth_client_ut/prov_auth_client_ut.c
@@ -26,7 +26,7 @@ static void my_gballoc_free(void* ptr)
 #include "umock_c/umocktypes_charptr.h"
 #include "umock_c/umocktypes_stdint.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #define ENABLE_MOCKS
 #include "azure_c_shared_utility/gballoc.h"

--- a/provisioning_client/tests/prov_device_client_ll_ut/prov_device_client_ll_ut.c
+++ b/provisioning_client/tests/prov_device_client_ll_ut/prov_device_client_ll_ut.c
@@ -23,7 +23,7 @@ static void my_gballoc_free(void* ptr)
 #include "umock_c/umocktypes_bool.h"
 #include "umock_c/umocktypes_stdint.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #define ENABLE_MOCKS
 #include "azure_c_shared_utility/gballoc.h"

--- a/provisioning_client/tests/prov_sasl_tpm_ut/prov_sasl_tpm_ut.c
+++ b/provisioning_client/tests/prov_sasl_tpm_ut/prov_sasl_tpm_ut.c
@@ -25,7 +25,7 @@ static void my_gballoc_free(void* ptr)
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_charptr.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #define ENABLE_MOCKS
 #include "azure_c_shared_utility/gballoc.h"

--- a/provisioning_client/tests/prov_security_factory_ut/prov_security_factory_ut.c
+++ b/provisioning_client/tests/prov_security_factory_ut/prov_security_factory_ut.c
@@ -25,7 +25,7 @@ static void my_gballoc_free(void* ptr)
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_charptr.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #define ENABLE_MOCKS
 #include "azure_c_shared_utility/gballoc.h"

--- a/provisioning_client/tests/prov_symm_key_client_e2e/prov_symm_key_client_e2e.c
+++ b/provisioning_client/tests/prov_symm_key_client_e2e/prov_symm_key_client_e2e.c
@@ -8,7 +8,7 @@
 #include "azure_c_shared_utility/platform.h"
 #include "azure_c_shared_utility/threadapi.h"
 #include "azure_c_shared_utility/crt_abstractions.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/xlogging.h"
 
 #include "azure_prov_client/prov_security_factory.h"

--- a/provisioning_client/tests/prov_tpm_client_e2e/prov_tpm_client_e2e.c
+++ b/provisioning_client/tests/prov_tpm_client_e2e/prov_tpm_client_e2e.c
@@ -8,7 +8,7 @@
 #include "azure_c_shared_utility/platform.h"
 #include "azure_c_shared_utility/threadapi.h"
 #include "azure_c_shared_utility/crt_abstractions.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/xlogging.h"
 
 #include "azure_prov_client/prov_security_factory.h"

--- a/provisioning_client/tests/prov_transport_amqp_client_ut/prov_transport_amqp_client_ut.c
+++ b/provisioning_client/tests/prov_transport_amqp_client_ut/prov_transport_amqp_client_ut.c
@@ -23,7 +23,7 @@ static void my_gballoc_free(void* ptr)
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_bool.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #define ENABLE_MOCKS
 #include "azure_prov_client/internal/prov_transport_amqp_common.h"

--- a/provisioning_client/tests/prov_transport_amqp_common_ut/prov_transport_amqp_common_ut.c
+++ b/provisioning_client/tests/prov_transport_amqp_common_ut/prov_transport_amqp_common_ut.c
@@ -28,7 +28,7 @@ static void my_gballoc_free(void* ptr)
 #include "umock_c/umocktypes_stdint.h"
 #include "umock_c/umocktypes_bool.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #define ENABLE_MOCKS
 #include "azure_c_shared_utility/xio.h"

--- a/provisioning_client/tests/prov_transport_amqp_ws_client_ut/prov_transport_amqp_ws_client_ut.c
+++ b/provisioning_client/tests/prov_transport_amqp_ws_client_ut/prov_transport_amqp_ws_client_ut.c
@@ -23,7 +23,7 @@ static void my_gballoc_free(void* ptr)
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_bool.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #define ENABLE_MOCKS
 #include "azure_prov_client/internal/prov_transport_amqp_common.h"

--- a/provisioning_client/tests/prov_transport_http_client_ut/prov_transport_http_client_ut.c
+++ b/provisioning_client/tests/prov_transport_http_client_ut/prov_transport_http_client_ut.c
@@ -25,7 +25,7 @@ static void my_gballoc_free(void* ptr)
 #include "umock_c/umocktypes_stdint.h"
 #include "umock_c/umocktypes_bool.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #define ENABLE_MOCKS
 #include "azure_c_shared_utility/shared_util_options.h"

--- a/provisioning_client/tests/prov_transport_mqtt_client_ut/prov_transport_mqtt_client_ut.c
+++ b/provisioning_client/tests/prov_transport_mqtt_client_ut/prov_transport_mqtt_client_ut.c
@@ -23,7 +23,7 @@ static void my_gballoc_free(void* ptr)
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_bool.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #define ENABLE_MOCKS
 #include "azure_prov_client/internal/prov_transport_mqtt_common.h"

--- a/provisioning_client/tests/prov_transport_mqtt_common_ut/prov_transport_mqtt_common_ut.c
+++ b/provisioning_client/tests/prov_transport_mqtt_common_ut/prov_transport_mqtt_common_ut.c
@@ -28,7 +28,7 @@ static void my_gballoc_free(void* ptr)
 #include "umock_c/umocktypes_stdint.h"
 #include "umock_c/umocktypes_bool.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #define ENABLE_MOCKS
 #include "azure_c_shared_utility/xio.h"

--- a/provisioning_client/tests/prov_transport_mqtt_ws_client_ut/prov_transport_mqtt_ws_client_ut.c
+++ b/provisioning_client/tests/prov_transport_mqtt_ws_client_ut/prov_transport_mqtt_ws_client_ut.c
@@ -23,7 +23,7 @@ static void my_gballoc_free(void* ptr)
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_bool.h"
 #include "umock_c/umock_c_negative_tests.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #define ENABLE_MOCKS
 #include "azure_prov_client/internal/prov_transport_mqtt_common.h"

--- a/provisioning_client/tests/prov_x509_client_e2e/prov_x509_client_e2e.c
+++ b/provisioning_client/tests/prov_x509_client_e2e/prov_x509_client_e2e.c
@@ -8,7 +8,7 @@
 #include "azure_c_shared_utility/platform.h"
 #include "azure_c_shared_utility/threadapi.h"
 #include "azure_c_shared_utility/crt_abstractions.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/xlogging.h"
 
 #include "azure_prov_client/prov_security_factory.h"

--- a/provisioning_service_client/inc/prov_service_client/provisioning_sc_attestation_mechanism.h
+++ b/provisioning_service_client/inc/prov_service_client/provisioning_sc_attestation_mechanism.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "provisioning_sc_tpm_attestation.h"
 #include "provisioning_sc_x509_attestation.h"
 #include "parson.h"

--- a/provisioning_service_client/inc/prov_service_client/provisioning_sc_bulk_operation.h
+++ b/provisioning_service_client/inc/prov_service_client/provisioning_sc_bulk_operation.h
@@ -16,7 +16,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "provisioning_sc_models.h"
 #include "parson.h"
 

--- a/provisioning_service_client/inc/prov_service_client/provisioning_sc_device_registration_state.h
+++ b/provisioning_service_client/inc/prov_service_client/provisioning_sc_device_registration_state.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "parson.h"
 
 typedef struct DEVICE_REGISTRATION_STATE_TAG* DEVICE_REGISTRATION_STATE_HANDLE;

--- a/provisioning_service_client/inc/prov_service_client/provisioning_sc_enrollment.h
+++ b/provisioning_service_client/inc/prov_service_client/provisioning_sc_enrollment.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "azure_c_shared_utility/agenttime.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c_prod.h"
 #include "provisioning_sc_attestation_mechanism.h"
 #include "provisioning_sc_device_registration_state.h"

--- a/provisioning_service_client/inc/prov_service_client/provisioning_sc_models_serializer.h
+++ b/provisioning_service_client/inc/prov_service_client/provisioning_sc_models_serializer.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "provisioning_sc_enrollment.h"
 #include "provisioning_sc_query.h"
 #include "provisioning_sc_bulk_operation.h"

--- a/provisioning_service_client/inc/prov_service_client/provisioning_sc_query.h
+++ b/provisioning_service_client/inc/prov_service_client/provisioning_sc_query.h
@@ -12,7 +12,7 @@ extern "C" {
 #include <stdlib.h>
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "provisioning_sc_models.h"
 #include "parson.h"
 

--- a/provisioning_service_client/inc/prov_service_client/provisioning_sc_shared_helpers.h
+++ b/provisioning_service_client/inc/prov_service_client/provisioning_sc_shared_helpers.h
@@ -4,7 +4,7 @@
 #ifndef PROVISIONING_SC_SHARED_HELPERS_H
 #define PROVISIONING_SC_SHARED_HELPERS_H
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c_prod.h"
 #include "parson.h"
 

--- a/provisioning_service_client/inc/prov_service_client/provisioning_sc_tpm_attestation.h
+++ b/provisioning_service_client/inc/prov_service_client/provisioning_sc_tpm_attestation.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "parson.h"
 
 typedef struct TPM_ATTESTATION_TAG* TPM_ATTESTATION_HANDLE;

--- a/provisioning_service_client/inc/prov_service_client/provisioning_sc_twin.h
+++ b/provisioning_service_client/inc/prov_service_client/provisioning_sc_twin.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "parson.h"
 
 typedef struct INITIAL_TWIN_TAG* INITIAL_TWIN_HANDLE;

--- a/provisioning_service_client/inc/prov_service_client/provisioning_sc_x509_attestation.h
+++ b/provisioning_service_client/inc/prov_service_client/provisioning_sc_x509_attestation.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include "umock_c/umock_c_prod.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "parson.h"
 
 #define X509_CERTIFICATE_TYPE_VALUES \

--- a/provisioning_service_client/inc/prov_service_client/provisioning_service_client.h
+++ b/provisioning_service_client/inc/prov_service_client/provisioning_service_client.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c_prod.h"
 #include "azure_c_shared_utility/shared_util_options.h"
 

--- a/provisioning_service_client/tests/prov_sc_bulk_operation_ut/prov_sc_bulk_operation_ut.c
+++ b/provisioning_service_client/tests/prov_sc_bulk_operation_ut/prov_sc_bulk_operation_ut.c
@@ -20,7 +20,7 @@ void real_free(void* ptr)
 }
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/const_defines.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umock_c_negative_tests.h"

--- a/provisioning_service_client/tests/prov_sc_dev_caps_ut/prov_sc_dev_caps_ut.c
+++ b/provisioning_service_client/tests/prov_sc_dev_caps_ut/prov_sc_dev_caps_ut.c
@@ -20,7 +20,7 @@ void real_free(void* ptr)
 }
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_bool.h"
 #include "umock_c/umock_c_negative_tests.h"

--- a/provisioning_service_client/tests/prov_sc_registration_state_ut/prov_sc_registration_state_ut.c
+++ b/provisioning_service_client/tests/prov_sc_registration_state_ut/prov_sc_registration_state_ut.c
@@ -20,7 +20,7 @@ static void real_free(void* ptr)
 }
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umock_c_negative_tests.h"
 

--- a/provisioning_service_client/tests/prov_sc_shared_helpers_ut/prov_sc_shared_helpers_ut.c
+++ b/provisioning_service_client/tests/prov_sc_shared_helpers_ut/prov_sc_shared_helpers_ut.c
@@ -20,7 +20,7 @@ void real_free(void* ptr)
 }
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umock_c_negative_tests.h"
 

--- a/provisioning_service_client/tests/prov_sc_tpm_attestation_ut/prov_sc_tpm_attestation_ut.c
+++ b/provisioning_service_client/tests/prov_sc_tpm_attestation_ut/prov_sc_tpm_attestation_ut.c
@@ -20,7 +20,7 @@ void real_free(void* ptr)
 }
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umock_c_negative_tests.h"
 

--- a/provisioning_service_client/tests/prov_sc_x509_attestation_ut/prov_sc_x509_attestation_ut.c
+++ b/provisioning_service_client/tests/prov_sc_x509_attestation_ut/prov_sc_x509_attestation_ut.c
@@ -20,7 +20,7 @@ static void real_free(void* ptr)
 }
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umock_c_negative_tests.h"
 

--- a/provisioning_service_client/tests/provisioning_sc_attestation_ut/provisioning_sc_attestation_ut.c
+++ b/provisioning_service_client/tests/provisioning_sc_attestation_ut/provisioning_sc_attestation_ut.c
@@ -20,7 +20,7 @@ void real_free(void* ptr)
 }
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umock_c_negative_tests.h"
 #include "azure_c_shared_utility/const_defines.h"

--- a/provisioning_service_client/tests/provisioning_sc_enrollment_ut/provisioning_sc_enrollment_ut.c
+++ b/provisioning_service_client/tests/provisioning_sc_enrollment_ut/provisioning_sc_enrollment_ut.c
@@ -20,7 +20,7 @@ void real_free(void* ptr)
 }
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_bool.h"
 #include "umock_c/umock_c_negative_tests.h"

--- a/provisioning_service_client/tests/provisioning_sc_query_ut/provisioning_sc_query_ut.c
+++ b/provisioning_service_client/tests/provisioning_sc_query_ut/provisioning_sc_query_ut.c
@@ -20,7 +20,7 @@ void real_free(void* ptr)
 }
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umock_c_negative_tests.h"
 

--- a/provisioning_service_client/tests/provisioning_sc_twin_int/provisioning_sc_twin_int.c
+++ b/provisioning_service_client/tests/provisioning_sc_twin_int/provisioning_sc_twin_int.c
@@ -20,7 +20,7 @@ static void my_gballoc_free(void* ptr)
 }
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umock_c_negative_tests.h"
 

--- a/provisioning_service_client/tests/provisioning_sc_twin_ut/provisioning_sc_twin_ut.c
+++ b/provisioning_service_client/tests/provisioning_sc_twin_ut/provisioning_sc_twin_ut.c
@@ -20,7 +20,7 @@ void real_free(void* ptr)
 }
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umock_c_negative_tests.h"
 

--- a/provisioning_service_client/tests/provisioning_service_client_ut/provisioning_service_client_ut.c
+++ b/provisioning_service_client/tests/provisioning_service_client_ut/provisioning_service_client_ut.c
@@ -20,7 +20,7 @@ static void real_free(void* ptr)
 }
 
 #include "testrunnerswitcher.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_bool.h"
 #include "umock_c/umock_c_negative_tests.h"

--- a/serializer/inc/agenttypesystem.h
+++ b/serializer/inc/agenttypesystem.h
@@ -18,7 +18,7 @@
 #endif
 
 #include "azure_c_shared_utility/agenttime.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/strings.h"
 
 /*Codes_SRS_AGENT_TYPE_SYSTEM_99_001:[ AGENT_TYPE_SYSTEM shall have the following interface]*/

--- a/serializer/inc/codefirst.h
+++ b/serializer/inc/codefirst.h
@@ -7,7 +7,7 @@
 #include "methodreturn.h"
 #include "agenttypesystem.h"
 #include "schema.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/strings.h"
 #include "iotdevice.h"
 

--- a/serializer/inc/commanddecoder.h
+++ b/serializer/inc/commanddecoder.h
@@ -7,7 +7,7 @@
 #include "multitree.h"
 #include "schema.h"
 #include "agenttypesystem.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "methodreturn.h"
 
 #ifdef __cplusplus

--- a/serializer/inc/datamarshaller.h
+++ b/serializer/inc/datamarshaller.h
@@ -7,7 +7,7 @@
 #include <stdbool.h>
 #include "agenttypesystem.h"
 #include "schema.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/vector.h"
 #ifdef __cplusplus
 extern "C"

--- a/serializer/inc/dataserializer.h
+++ b/serializer/inc/dataserializer.h
@@ -4,7 +4,7 @@
 #ifndef DATASERIALIZER_H
 #define DATASERIALIZER_H
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "multitree.h"
 #include "azure_c_shared_utility/buffer_.h"
 

--- a/serializer/inc/iotdevice.h
+++ b/serializer/inc/iotdevice.h
@@ -5,7 +5,7 @@
 #define IOTDEVICE_H
 
 #include <stdbool.h>
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "schema.h"
 #include "datapublisher.h"
 #include "commanddecoder.h"

--- a/serializer/inc/jsonencoder.h
+++ b/serializer/inc/jsonencoder.h
@@ -4,7 +4,7 @@
 #ifndef JSONENCODER_H
 #define JSONENCODER_H
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/strings.h"
 
 #ifdef __cplusplus

--- a/serializer/inc/methodreturn.h
+++ b/serializer/inc/methodreturn.h
@@ -6,7 +6,7 @@
 
 typedef struct METHODRETURN_HANDLE_DATA_TAG* METHODRETURN_HANDLE;
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 typedef struct METHODRETURN_DATA_TAG
 {

--- a/serializer/inc/multitree.h
+++ b/serializer/inc/multitree.h
@@ -5,7 +5,7 @@
 #define MULTITREE_H
 
 #include "azure_c_shared_utility/strings.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #ifdef __cplusplus
 #include <cstddef>

--- a/serializer/inc/schema.h
+++ b/serializer/inc/schema.h
@@ -4,7 +4,7 @@
 #ifndef SCHEMA_H
 #define SCHEMA_H
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/crt_abstractions.h"
 #include "agenttypesystem.h"
 

--- a/serializer/inc/schemalib.h
+++ b/serializer/inc/schemalib.h
@@ -9,7 +9,7 @@
 #ifndef SCHEMALIB_H
 #define SCHEMALIB_H
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/strings.h"
 #include "iotdevice.h"
 

--- a/serializer/inc/serializer.h
+++ b/serializer/inc/serializer.h
@@ -48,7 +48,7 @@
 #endif
 
 #include "azure_c_shared_utility/gballoc.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "iotdevice.h"
 #include "azure_c_shared_utility/crt_abstractions.h"
 #include "azure_c_shared_utility/xlogging.h"

--- a/serializer/src/codefirst.c
+++ b/serializer/src/codefirst.c
@@ -6,7 +6,7 @@
 #include "azure_c_shared_utility/gballoc.h"
 
 #include "codefirst.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/crt_abstractions.h"
 #include "azure_c_shared_utility/xlogging.h"
 #include <stddef.h>

--- a/serializer/src/multitree.c
+++ b/serializer/src/multitree.c
@@ -8,7 +8,7 @@
 #include <string.h>
 #include "azure_c_shared_utility/crt_abstractions.h"
 #include "azure_c_shared_utility/xlogging.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/const_defines.h"
 
 /*assume a name cannot be longer than 100 characters*/

--- a/serializer/src/schemaserializer.c
+++ b/serializer/src/schemaserializer.c
@@ -7,7 +7,7 @@
 #include <stddef.h>
 #include "schemaserializer.h"
 #include "azure_c_shared_utility/xlogging.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 MU_DEFINE_ENUM_STRINGS_WITHOUT_INVALID(SCHEMA_SERIALIZER_RESULT, SCHEMA_SERIALIZER_RESULT_VALUES);
 

--- a/serializer/tests/agentmacros_ut/agentmacros_ut.cpp
+++ b/serializer/tests/agentmacros_ut/agentmacros_ut.cpp
@@ -4,7 +4,7 @@
 #include <cstdlib>
 #include <cstddef>
 #include "azure_c_shared_utility/optimize_size.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "testrunnerswitcher.h"
 #include "micromock.h"
 #include "micromockenumtostring.h"

--- a/serializer/tests/codefirst_ut/codefirst_ut.c
+++ b/serializer/tests/codefirst_ut/codefirst_ut.c
@@ -42,7 +42,7 @@ static void my_gballoc_free(void * t)
 #include "real_strings.h"
 
 #include "serializer.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #include "testrunnerswitcher.h"
 #include "codefirst.h"

--- a/serializer/tests/codefirst_withstructs_ut/codefirst_withstructs_ut.c
+++ b/serializer/tests/codefirst_withstructs_ut/codefirst_withstructs_ut.c
@@ -23,7 +23,7 @@ void my_gballoc_free(void * t)
     free(t);
 }
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_charptr.h"
 #include "umock_c/umocktypes_bool.h"
@@ -38,7 +38,7 @@ void my_gballoc_free(void * t)
 
 #include "testrunnerswitcher.h"
 #include "codefirst.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #include "serializer.h"
 

--- a/serializer/tests/dataserializer_ut/dataserializer_ut.cpp
+++ b/serializer/tests/dataserializer_ut/dataserializer_ut.cpp
@@ -9,7 +9,7 @@
 #include "micromockenumtostring.h"
 #include "micromockcharstararenullterminatedstrings.h"
 #include "multitree.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 /*this is what we test*/
 #include "dataserializer.h"

--- a/serializer/tests/jsonencoder_ut/jsonencoder_ut.cpp
+++ b/serializer/tests/jsonencoder_ut/jsonencoder_ut.cpp
@@ -11,7 +11,7 @@
 #include <stdexcept>
 #include "multitree.h"
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 /*this is what we test*/
 #include "jsonencoder.h"

--- a/serializer/tests/multitree_ut/multitree_ut.cpp
+++ b/serializer/tests/multitree_ut/multitree_ut.cpp
@@ -9,7 +9,7 @@
 #include "multitree.h"
 #include "azure_c_shared_utility/optimize_size.h"
 #include "azure_c_shared_utility/crt_abstractions.h"
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/lock.h"
 
 #ifndef SIZE_MAX

--- a/serializer/tests/serializer_dt_int/serializer_dt_int.c
+++ b/serializer/tests/serializer_dt_int/serializer_dt_int.c
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "testrunnerswitcher.h"
 
 #include "umock_c/umock_c.h"

--- a/serializer/tests/serializer_dt_ut/serializer_dt_ut.c
+++ b/serializer/tests/serializer_dt_ut/serializer_dt_ut.c
@@ -25,7 +25,7 @@ static void my_gballoc_free(void* s)
 #include "real_vector.h"
 #include "real_crt_abstractions.h"
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "testrunnerswitcher.h"
 
 #include "umock_c/umock_c.h"

--- a/serializer/tests/serializer_e2e/serializer_e2e.c
+++ b/serializer/tests/serializer_e2e/serializer_e2e.c
@@ -12,7 +12,7 @@
 #include <time.h>
 #endif
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 
 #include "testrunnerswitcher.h"
 #include "umock_c/umock_c.h"

--- a/testtools/iothub_test/inc/iothubtest.h
+++ b/testtools/iothub_test/inc/iothubtest.h
@@ -14,7 +14,7 @@ extern "C"
 #include <time.h>
 #endif
 
-#include "azure_macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h"
 #include "azure_c_shared_utility/buffer_.h"
 
 typedef void* IOTHUB_TEST_HANDLE;


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [x] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)
#1729 

# Description of the problem
The CocoaPod no longer compiles in Xcode 12 as the libraries are being imported from the incorrect place.

# Description of the solution
Importing the files from `macro_utils` instead of `azure_macro_utils` has resolved this issue.