### PR TITLE
Turn on mqtt encode/decode option

### DIFF
--- a/iothub_client/samples/iotedge_downstream_device_sample/iotedge_downstream_device_sample.c
+++ b/iothub_client/samples/iotedge_downstream_device_sample/iotedge_downstream_device_sample.c
@@ -250,8 +250,8 @@ int main(void)
         //Setting the auto URL Encoder (recommended for MQTT). Please use this option unless
         //you are URL Encoding inputs yourself.
         //ONLY valid for use with MQTT
-        //bool urlEncodeOn = true;
-        //(void)IoTHubDeviceClient_SetOption(device_handle, OPTION_AUTO_URL_ENCODE_DECODE, &urlEncodeOn);
+        bool urlEncodeOn = true;
+        (void)IoTHubDeviceClient_SetOption(device_handle, OPTION_AUTO_URL_ENCODE_DECODE, &urlEncodeOn);
 #endif
 
         for (size_t index = 0; index < MESSAGE_COUNT; index++)

--- a/iothub_client/samples/iothub_client_device_twin_and_methods_sample/iothub_client_device_twin_and_methods_sample.c
+++ b/iothub_client/samples/iothub_client_device_twin_and_methods_sample/iothub_client_device_twin_and_methods_sample.c
@@ -244,7 +244,7 @@ static void deviceTwinCallback(DEVICE_TWIN_UPDATE_STATE update_state, const unsi
             {
                 free(oldCar->changeOilReminder);
             }
-            
+
             if (oldCar->changeOilReminder == NULL)
             {
                 printf("Received a new changeOilReminder = %s\n", newCar->changeOilReminder);
@@ -282,7 +282,7 @@ static void deviceTwinCallback(DEVICE_TWIN_UPDATE_STATE update_state, const unsi
                 oldCar->settings.location.longitude = newCar->settings.location.longitude;
             }
         }
-        
+
         free(newCar);
     }
 }
@@ -331,7 +331,13 @@ static void iothub_client_device_twin_and_methods_sample_run(void)
             // Uncomment the following lines to enable verbose logging (e.g., for debugging).
             //bool traceOn = true;
             //(void)IoTHubDeviceClient_SetOption(iotHubClientHandle, OPTION_LOG_TRACE, &traceOn);
-
+#if defined SAMPLE_MQTT || defined SAMPLE_MQTT_OVER_WEBSOCKETS
+        //Setting the auto URL Encoder (recommended for MQTT). Please use this option unless
+        //you are URL Encoding inputs yourself.
+        //ONLY valid for use with MQTT
+        bool urlEncodeOn = true;
+        (void)IoTHubDeviceClient_SetOption(iotHubClientHandle, OPTION_AUTO_URL_ENCODE_DECODE, &urlEncodeOn);
+#endif
 #ifdef SET_TRUSTED_CERT_IN_SAMPLES
             // For mbed add the certificate information
             if (IoTHubDeviceClient_SetOption(iotHubClientHandle, "TrustedCerts", certificates) != IOTHUB_CLIENT_OK)

--- a/iothub_client/samples/iothub_client_sample_module_sender/iothub_client_sample_module_sender.c
+++ b/iothub_client/samples/iothub_client_sample_module_sender/iothub_client_sample_module_sender.c
@@ -64,12 +64,6 @@ int main(void)
         // bool traceOn = true;
         // IoTHubModuleClient_LL_SetOption(iotHubModuleClientHandle, OPTION_LOG_TRACE, &traceOn);
 
-        //Setting the auto URL Encoder (recommended for MQTT). Please use this option unless
-        //you are URL Encoding responses yourself.
-        //ONLY valid for use with MQTT
-        bool urlEncodeOn = true;
-        (void)IoTHubDeviceClient_LL_SetOption(iotHubModuleClientHandle, OPTION_AUTO_URL_ENCODE_DECODE, &urlEncodeOn);
-
         size_t iterator = 0;
         double temperature = 0;
         double humidity = 0;

--- a/iothub_client/samples/iothub_client_sample_module_sender/iothub_client_sample_module_sender.c
+++ b/iothub_client/samples/iothub_client_sample_module_sender/iothub_client_sample_module_sender.c
@@ -64,6 +64,12 @@ int main(void)
         // bool traceOn = true;
         // IoTHubModuleClient_LL_SetOption(iotHubModuleClientHandle, OPTION_LOG_TRACE, &traceOn);
 
+        //Setting the auto URL Encoder (recommended for MQTT). Please use this option unless
+        //you are URL Encoding responses yourself.
+        //ONLY valid for use with MQTT
+        bool urlEncodeOn = true;
+        (void)IoTHubDeviceClient_LL_SetOption(iotHubModuleClientHandle, OPTION_AUTO_URL_ENCODE_DECODE, &urlEncodeOn);
+
         size_t iterator = 0;
         double temperature = 0;
         double humidity = 0;
@@ -119,4 +125,3 @@ int main(void)
     IoTHub_Deinit();
     return 0;
 }
-

--- a/iothub_client/samples/iothub_client_sample_mqtt_esp8266/iothub_client_sample_mqtt_esp8266.c
+++ b/iothub_client/samples/iothub_client_sample_mqtt_esp8266/iothub_client_sample_mqtt_esp8266.c
@@ -209,12 +209,6 @@ void iothub_client_sample_mqtt_esp8266_run(void)
 
 int main(void)
 {
-    //Setting the auto URL Decoder (recommended for MQTT). Please use this option unless
-    //you are URL Decoding responses yourself.
-    //ONLY valid for use with MQTT
-    bool urlDecodeOn = true;
-    (void)IoTHubDeviceClient_LL_SetOption(iotHubClientHandle, OPTION_AUTO_URL_ENCODE_DECODE, &urlDecodeOn);
-
     iothub_client_sample_mqtt_esp8266_run();
     return 0;
 }

--- a/iothub_client/samples/iothub_client_sample_mqtt_esp8266/iothub_client_sample_mqtt_esp8266.c
+++ b/iothub_client/samples/iothub_client_sample_mqtt_esp8266/iothub_client_sample_mqtt_esp8266.c
@@ -209,6 +209,12 @@ void iothub_client_sample_mqtt_esp8266_run(void)
 
 int main(void)
 {
+    //Setting the auto URL Decoder (recommended for MQTT). Please use this option unless
+    //you are URL Decoding responses yourself.
+    //ONLY valid for use with MQTT
+    bool urlDecodeOn = true;
+    (void)IoTHubDeviceClient_LL_SetOption(iotHubClientHandle, OPTION_AUTO_URL_ENCODE_DECODE, &urlDecodeOn);
+
     iothub_client_sample_mqtt_esp8266_run();
     return 0;
 }

--- a/iothub_client/samples/iothub_convenience_sample/iothub_convenience_sample.c
+++ b/iothub_client/samples/iothub_convenience_sample/iothub_convenience_sample.c
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 /*
-CAUTION: Checking of return codes and error values shall be omitted for brevity in this sample. 
+CAUTION: Checking of return codes and error values shall be omitted for brevity in this sample.
 This sample is to demonstrate azure IoT client concepts only and is not a guide design principles or style.
 Please practice sound engineering practices when writing production code.
 */
@@ -20,17 +20,17 @@ Please practice sound engineering practices when writing production code.
 #include "azure_c_shared_utility/shared_util_options.h"
 #include "azure_c_shared_utility/tickcounter.h"
 
-/* 
-This sample uses the multithreaded APIs of iothub_client for example purposes. 
+/*
+This sample uses the multithreaded APIs of iothub_client for example purposes.
 The difference between multithreaded and singlethreaded (_ll_) API?
-Multithreaded creates a separate thread to perform DoWork calls, which are necessary 
-for the device client library to do anything. The benefit of using the 
-multithreaded API is that the calls to DoWork are abstracted away from your code. 
+Multithreaded creates a separate thread to perform DoWork calls, which are necessary
+for the device client library to do anything. The benefit of using the
+multithreaded API is that the calls to DoWork are abstracted away from your code.
 */
 
 
 // The protocol you wish to use should be uncommented
-// 
+//
 #define SAMPLE_MQTT
 //#define SAMPLE_MQTT_OVER_WEBSOCKETS
 //#define SAMPLE_AMQP
@@ -165,7 +165,7 @@ static int device_method_callback(const char* method_name, const unsigned char* 
     {
         memcpy(*response, RESPONSE_STRING, *resp_size);
     }
-    
+
     return status;
 }
 
@@ -251,7 +251,7 @@ int main(void)
             {
                 (void)printf("failure to set proxy\n");
             }
-        }		
+        }
 
         // Setting message callback to get C2D messages
         (void)IoTHubDeviceClient_SetMessageCallback(device_handle, receive_msg_callback, NULL);
@@ -264,7 +264,7 @@ int main(void)
         // Set any option that are necessary.
         // For available options please see the iothub_sdk_options.md documentation
 
-        // Setting Log Tracing. 
+        // Setting Log Tracing.
         // Log tracing is supported in MQTT and AMQP. Not HTTP.
 #ifndef SAMPLE_HTTP
         bool traceOn = true;
@@ -272,9 +272,9 @@ int main(void)
 #endif
 
         // Setting the frequency of DoWork calls by the underlying process thread.
-        // The value ms_delay is a delay between DoWork calls, in milliseconds. 
-        // ms_delay can only be between 1 and 100 milliseconds. 
-        // Without the SetOption, the delay defaults to 1 ms. 
+        // The value ms_delay is a delay between DoWork calls, in milliseconds.
+        // ms_delay can only be between 1 and 100 milliseconds.
+        // Without the SetOption, the delay defaults to 1 ms.
         tickcounter_ms_t ms_delay = 10;
         (void)IoTHubDeviceClient_SetOption(device_handle, OPTION_DO_WORK_FREQUENCY_IN_MS, &ms_delay);
 
@@ -288,8 +288,8 @@ int main(void)
         //Setting the auto URL Encoder (recommended for MQTT). Please use this option unless
         //you are URL Encoding inputs yourself.
         //ONLY valid for use with MQTT
-        //bool urlEncodeOn = true;
-        //(void)IoTHubDeviceClient_SetOption(device_handle, OPTION_AUTO_URL_ENCODE_DECODE, &urlEncodeOn);
+        bool urlEncodeOn = true;
+        (void)IoTHubDeviceClient_SetOption(device_handle, OPTION_AUTO_URL_ENCODE_DECODE, &urlEncodeOn);
 #endif
 
         while(g_continueRunning)
@@ -298,7 +298,7 @@ int main(void)
             telemetry_temperature = 20.0f + ((float)rand() / RAND_MAX) * 15.0f;
             telemetry_humidity = 60.0f + ((float)rand() / RAND_MAX) * 20.0f;
 
-            sprintf(telemetry_msg_buffer, "{\"temperature\":%.3f,\"humidity\":%.3f,\"scale\":\"%s\"}", 
+            sprintf(telemetry_msg_buffer, "{\"temperature\":%.3f,\"humidity\":%.3f,\"scale\":\"%s\"}",
                 telemetry_temperature, telemetry_humidity, telemetry_scale);
 
             message_handle = IoTHubMessage_CreateFromString(telemetry_msg_buffer);

--- a/iothub_client/samples/iothub_ll_c2d_sample/iothub_ll_c2d_sample.c
+++ b/iothub_client/samples/iothub_ll_c2d_sample/iothub_ll_c2d_sample.c
@@ -153,12 +153,12 @@ int main(void)
         IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_TRUSTED_CERT, certificates);
 #endif // SET_TRUSTED_CERT_IN_SAMPLES
 
-#if defined SAMPLE_MQTT || defined SAMPLE_MQTT_WS
+#if defined SAMPLE_MQTT || defined SAMPLE_MQTT_OVER_WEBSOCKETS
         //Setting the auto URL Decoder (recommended for MQTT). Please use this option unless
         //you are URL Decoding responses yourself.
         //ONLY valid for use with MQTT
-        //bool urlDecodeOn = true;
-        //IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_AUTO_URL_ENCODE_DECODE, &urlDecodeOn);
+        bool urlDecodeOn = true;
+        (void)IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_AUTO_URL_ENCODE_DECODE, &urlDecodeOn);
 #endif
 
 #ifdef SAMPLE_HTTP

--- a/iothub_client/samples/iothub_ll_client_shared_sample/iothub_ll_client_shared_sample.c
+++ b/iothub_client/samples/iothub_ll_client_shared_sample/iothub_ll_client_shared_sample.c
@@ -27,9 +27,6 @@
 #ifdef SAMPLE_AMQP
 #include "iothubtransportamqp.h"
 #endif // SAMPLE_AMQP
-#ifdef SAMPLE_MQTT_OVER_WEBSOCKETS
-#include "iothubtransportmqtt_websockets.h"
-#endif // SAMPLE_MQTT_OVER_WEBSOCKETS
 #ifdef SAMPLE_AMQP_OVER_WEBSOCKETS
 #include "iothubtransportamqp_websockets.h"
 #endif // SAMPLE_AMQP_OVER_WEBSOCKETS

--- a/iothub_client/samples/iothub_ll_client_x509_sample/iothub_ll_client_x509_sample.c
+++ b/iothub_client/samples/iothub_ll_client_x509_sample/iothub_ll_client_x509_sample.c
@@ -142,6 +142,13 @@ int main(void)
         IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_TRUSTED_CERT, certificates);
 #endif // SET_TRUSTED_CERT_IN_SAMPLES
 
+#if defined SAMPLE_MQTT || defined SAMPLE_MQTT_OVER_WEBSOCKETS
+        //Setting the auto URL Encoder (recommended for MQTT). Please use this option unless
+        //you are URL Encoding inputs yourself.
+        //ONLY valid for use with MQTT
+        bool urlEncodeOn = true;
+        (void)IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_AUTO_URL_ENCODE_DECODE, &urlEncodeOn);
+#endif
         // Set the X509 certificates in the SDK
         if (
             (IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_X509_CERT, x509certificate) != IOTHUB_CLIENT_OK) ||

--- a/iothub_client/samples/iothub_ll_telemetry_sample/iothub_ll_telemetry_sample.c
+++ b/iothub_client/samples/iothub_ll_telemetry_sample/iothub_ll_telemetry_sample.c
@@ -131,12 +131,12 @@ int main(void)
             IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_TRUSTED_CERT, certificates);
 #endif // SET_TRUSTED_CERT_IN_SAMPLES
 
-#if defined SAMPLE_MQTT || defined SAMPLE_MQTT_WS
+#if defined SAMPLE_MQTT || defined SAMPLE_MQTT_OVER_WEBSOCKETS
         //Setting the auto URL Encoder (recommended for MQTT). Please use this option unless
         //you are URL Encoding inputs yourself.
         //ONLY valid for use with MQTT
-        //bool urlEncodeOn = true;
-        //IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_AUTO_URL_ENCODE_DECODE, &urlEncodeOn);
+        bool urlEncodeOn = true;
+        (void)IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_AUTO_URL_ENCODE_DECODE, &urlEncodeOn);
 #endif
 
         // Setting connection status callback to get indication of connection to iothub


### PR DESCRIPTION
# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

Updates existing samples that use mqtt to set the encode/decode option.  This solves the encoding failure in Issue #1695 .
It also points the developer to use this in their code by including it and turning it on as default in the other mqtt samples.