### PR TITLE
Fixes for device multiplexing in AMQP transport

### DIFF
--- a/iothub_client/inc/internal/iothubtransport_amqp_device.h
+++ b/iothub_client/inc/internal/iothubtransport_amqp_device.h
@@ -111,6 +111,7 @@ MOCKABLE_FUNCTION(, AMQP_DEVICE_HANDLE, amqp_device_create, AMQP_DEVICE_CONFIG*,
 MOCKABLE_FUNCTION(, void, amqp_device_destroy, AMQP_DEVICE_HANDLE, handle);
 MOCKABLE_FUNCTION(, int, amqp_device_start_async, AMQP_DEVICE_HANDLE, handle, SESSION_HANDLE, session_handle, CBS_HANDLE, cbs_handle);
 MOCKABLE_FUNCTION(, int, amqp_device_stop, AMQP_DEVICE_HANDLE, handle);
+MOCKABLE_FUNCTION(, int, amqp_device_delayed_stop, AMQP_DEVICE_HANDLE, handle, size_t, delay_secs);
 MOCKABLE_FUNCTION(, void, amqp_device_do_work, AMQP_DEVICE_HANDLE, handle);
 MOCKABLE_FUNCTION(, int, amqp_device_send_event_async, AMQP_DEVICE_HANDLE, handle, IOTHUB_MESSAGE_LIST*, message, ON_DEVICE_D2C_EVENT_SEND_COMPLETE, on_device_d2c_event_send_complete_callback, void*, context);
 MOCKABLE_FUNCTION(, int, amqp_device_send_twin_update_async, AMQP_DEVICE_HANDLE, handle, CONSTBUFFER_HANDLE, data, DEVICE_SEND_TWIN_UPDATE_COMPLETE_CALLBACK, on_send_twin_update_complete_callback, void*, context);

--- a/iothub_client/inc/iothub_client_options.h
+++ b/iothub_client/inc/iothub_client_options.h
@@ -88,6 +88,20 @@ extern "C"
 
     static STATIC_VAR_UNUSED const char* OPTION_DO_WORK_FREQUENCY_IN_MS = "do_work_freq_ms";
 
+// Minimum percentage (in the 0 to 1 range) of multiplexed registered devices that must be failing for a transport-wide reconnection to be triggered.
+// A value of zero results in a single registered device to be able to cause a general transport reconnection 
+// (thus causing all other multiplexed registered devices to be also reconnected, meaning an agressive reconnection strategy).
+// Setting this parameter to one indicates that 100% of the multiplexed registered devices must be failing in parallel for a 
+// transport-wide reconnection to be triggered (resulting in a very lenient reconnection strategy).  
+#define DEVICE_MULTIPLEXING_FAULTY_DEVICE_RATIO_RECONNECTION_THRESHOLD 0
+
+// Minimum number of consecutive failures an individual registered device must have to be considered a faulty device.
+// This is used along with DEVICE_MULTIPLEXING_FAULTY_DEVICE_RATIO_RECONNECTION_THRESHOLD to trigger transport-wide reconnections.
+// The device may fail to authenticate, timeout establishing the connection, get disconnected by the service for some reason or fail sending messages.
+// In all these cases the failures are cummulatively counted; if the count is equal to or greater than DEVICE_FAILURE_COUNT_RECONNECTION_THRESHOLD
+// the device is considered to be in a faulty state.    
+#define DEVICE_FAILURE_COUNT_RECONNECTION_THRESHOLD 5
+
 #ifdef __cplusplus
 }
 #endif

--- a/iothub_client/samples/iothub_ll_client_shared_sample/iothub_ll_client_shared_sample.c
+++ b/iothub_client/samples/iothub_ll_client_shared_sample/iothub_ll_client_shared_sample.c
@@ -34,28 +34,42 @@
 #include "iothubtransporthttp.h"
 #endif // SAMPLE_HTTP
 
-static const char* hubName = "[IoT Hub Name]";
-static const char* hubSuffix = "[IoT Hub Suffix]";
-static const char* deviceId1 = "[device id 1]";
-static const char* deviceId2 = "[device id 2]";
-static const char* deviceKey1 = "[device key 1]";
-static const char* deviceKey2 = "[device key 2]";
+#define sizeofarray(x) (sizeof(x)/sizeof(x[0]))
 
-//static int callbackCounter;
+typedef struct DEVICE_CREDENTIAL_TAG
+{
+    const char* id;
+    const char* key;
+} DEVICE_CREDENTIAL;
+
+typedef struct DEVICE_STATE_TAG
+{
+    const DEVICE_CREDENTIAL* credential;
+    IOTHUB_DEVICE_CLIENT_LL_HANDLE client_handle;
+    size_t messages_received;
+} DEVICE_STATE;
+
+static const char* hubName = "<iot hub name>";
+static const char* hubSuffix = "azure-devices.net";
+
+static const DEVICE_CREDENTIAL g_deviceCredentials[] = {
+    { .id = "<device id 1>", .key = "<device key 1>" },
+    { .id = "<device id 2>", .key = "<device key 2>" }
+};
+
+#define NUMBER_OF_DEVICES sizeofarray(g_deviceCredentials)
+
+static DEVICE_STATE g_device_states[NUMBER_OF_DEVICES];
+
 static bool g_continueRunning;
 static char msgText[1024];
 static char propText[1024];
 #define MESSAGE_COUNT       5
 #define DOWORK_LOOP_NUM     3
 
-typedef struct EVENT_INSTANCE_TAG
-{
-    const char* deviceId;
-} EVENT_INSTANCE;
-
 static IOTHUBMESSAGE_DISPOSITION_RESULT ReceiveMessageCallback(IOTHUB_MESSAGE_HANDLE message, void* userContextCallback)
 {
-    int* counter = (int*)userContextCallback;
+    DEVICE_STATE* device_state = (DEVICE_STATE*)userContextCallback;
     const unsigned char* buffer = NULL;
     size_t size = 0;
     const char* messageId;
@@ -73,7 +87,7 @@ static IOTHUBMESSAGE_DISPOSITION_RESULT ReceiveMessageCallback(IOTHUB_MESSAGE_HA
     }
 
     // Increment the counter
-    *counter = (*counter) + 1;
+    device_state->messages_received++;
 
     // Message content
     IOTHUBMESSAGE_CONTENT_TYPE contentType = IoTHubMessage_GetContentType(message);
@@ -81,7 +95,8 @@ static IOTHUBMESSAGE_DISPOSITION_RESULT ReceiveMessageCallback(IOTHUB_MESSAGE_HA
     {
         if (IoTHubMessage_GetByteArray(message, &buffer, &size) == IOTHUB_MESSAGE_OK)
         {
-            (void)printf("Received Message [%d]\r\n Message ID: %s\r\n Correlation ID: %s\r\n BINARY Data: <<<%.*s>>> & Size=%d\r\n", *counter, messageId, correlationId, (int)size, buffer, (int)size);
+            (void)printf("Received Message [%s; %zu]\r\n Message ID: %s\r\n Correlation ID: %s\r\n BINARY Data: <<<%.*s>>> & Size=%d\r\n", 
+                device_state->credential->id, device_state->messages_received, messageId, correlationId, (int)size, buffer, (int)size);
         }
         else
         {
@@ -92,7 +107,8 @@ static IOTHUBMESSAGE_DISPOSITION_RESULT ReceiveMessageCallback(IOTHUB_MESSAGE_HA
     {
         if ((buffer = (const unsigned char*)IoTHubMessage_GetString(message)) != NULL && (size = strlen((const char*)buffer)) > 0)
         {
-            (void)printf("Received Message [%d]\r\n Message ID: %s\r\n Correlation ID: %s\r\n STRING Data: <<<%.*s>>> & Size=%d\r\n", *counter, messageId, correlationId, (int)size, buffer, (int)size);
+            (void)printf("Received Message [%s; %zu]\r\n Message ID: %s\r\n Correlation ID: %s\r\n STRING Data: <<<%.*s>>> & Size=%d\r\n", 
+                device_state->credential->id, device_state->messages_received, messageId, correlationId, (int)size, buffer, (int)size);
 
             // If we receive the work 'quit' then we stop running
         }
@@ -124,12 +140,12 @@ static IOTHUBMESSAGE_DISPOSITION_RESULT ReceiveMessageCallback(IOTHUB_MESSAGE_HA
 
 static void SendConfirmationCallback(IOTHUB_CLIENT_CONFIRMATION_RESULT result, void* userContextCallback)
 {
-    EVENT_INSTANCE* event_info = (EVENT_INSTANCE*)userContextCallback;
-    (void)printf("Confirmation message received from device %s with result = %s\r\n", event_info->deviceId, MU_ENUM_TO_STRING(IOTHUB_CLIENT_CONFIRMATION_RESULT, result));
+    DEVICE_STATE* device_state = (DEVICE_STATE*)userContextCallback;
+    (void)printf("Confirmation message received from device %s with result = %s\r\n", device_state->credential->id, MU_ENUM_TO_STRING(IOTHUB_CLIENT_CONFIRMATION_RESULT, result));
     /* Some device specific action code goes here... */
 }
 
-static IOTHUB_MESSAGE_HANDLE create_events(const EVENT_INSTANCE* event_info)
+static IOTHUB_MESSAGE_HANDLE create_events(const DEVICE_STATE* device_state)
 {
     IOTHUB_MESSAGE_HANDLE message_handle;
 
@@ -143,9 +159,8 @@ static IOTHUB_MESSAGE_HANDLE create_events(const EVENT_INSTANCE* event_info)
     temperature = minTemperature + (rand() % 10);
     humidity = minHumidity +  (rand() % 20);
 
-    (void)sprintf_s(msgText, sizeof(msgText), "{\"deviceId\":\"%s\",\"windSpeed\":%.2f,\"temperature\":%.2f,\"humidity\":%.2f}", event_info->deviceId, avgWindSpeed + ((double)(rand() % 4) + 2.0), temperature, humidity);
+    (void)sprintf_s(msgText, sizeof(msgText), "{\"deviceId\":\"%s\",\"windSpeed\":%.2f,\"temperature\":%.2f,\"humidity\":%.2f}", device_state->credential->id, avgWindSpeed + ((double)(rand() % 4) + 2.0), temperature, humidity);
     message_handle = IoTHubMessage_CreateFromString(msgText);
-    //message_handle = IoTHubMessage_CreateFromByteArray((const unsigned char*)msgText, strlen(msgText))) == NULL)
 
     (void)sprintf_s(propText, sizeof(propText), temperature > 28 ? "true" : "false");
     (void)IoTHubMessage_SetProperty(message_handle, "temperatureAlert", propText);
@@ -157,8 +172,13 @@ int main(void)
 {
     TRANSPORT_HANDLE transport_handle;
     IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol;
-    IOTHUB_DEVICE_CLIENT_LL_HANDLE device_ll_handle1;
-    IOTHUB_DEVICE_CLIENT_LL_HANDLE device_ll_handle2;
+
+    for (int i = 0; i < NUMBER_OF_DEVICES; i++)
+    {
+        g_device_states[i].credential = &g_deviceCredentials[i];
+        g_device_states[i].client_handle = NULL;
+        g_device_states[i].messages_received = 0;
+    }
 
 #ifdef SAMPLE_AMQP
     protocol = AMQP_Protocol;
@@ -172,10 +192,6 @@ int main(void)
 
     g_continueRunning = true;
 
-    //callbackCounter = 0;
-    int receiveContext1 = 0;
-    int receiveContext2 = 0;
-
     (void)printf("Starting the IoTHub client shared sample.  Send `quit` message to either device to close...\r\n");
 
     // Used to initialize IoTHub SDK subsystem
@@ -187,105 +203,125 @@ int main(void)
     }
     else
     {
-        EVENT_INSTANCE device1_event;
-        EVENT_INSTANCE device2_event;
+        bool setup_ok = true;
 
-        device1_event.deviceId = deviceId1;
-
-        IOTHUB_CLIENT_DEVICE_CONFIG config1 = { 0 };
-        config1.deviceId = deviceId1;
-        config1.deviceKey = deviceKey1;
-        config1.deviceSasToken = NULL;
-        config1.protocol = protocol;
-        config1.transportHandle = IoTHubTransport_GetLLTransport(transport_handle);
-
-        device2_event.deviceId = deviceId2;
-
-        IOTHUB_CLIENT_DEVICE_CONFIG config2 = { 0 };
-        config2.deviceId = deviceId2;
-        config2.deviceKey = deviceKey2;
-        config2.deviceSasToken = NULL;
-        config2.protocol = protocol;
-        config2.transportHandle = IoTHubTransport_GetLLTransport(transport_handle);
-
-        if ((device_ll_handle1 = IoTHubDeviceClient_LL_CreateWithTransport(&config1)) == NULL)
+        for (int i = 0; i < NUMBER_OF_DEVICES && setup_ok; i++)
         {
-            (void)printf("ERROR: iotHubClientHandle1 is NULL!\r\n");
+            IOTHUB_CLIENT_DEVICE_CONFIG config = { 0 };
+            config.deviceId = g_device_states[i].credential->id;
+            config.deviceKey = g_device_states[i].credential->key;
+            config.deviceSasToken = NULL;
+            config.protocol = protocol;
+            config.transportHandle = IoTHubTransport_GetLLTransport(transport_handle);
+
+            if ((g_device_states[i].client_handle = IoTHubDeviceClient_LL_CreateWithTransport(&config)) == NULL)
+            {
+                (void)printf("ERROR: iotHubClientHandle is NULL (%s)!\r\n", config.deviceId);
+                setup_ok = false;
+            }
+            else
+            {            
+                bool traceOn = true;
+                
+    #ifdef SAMPLE_HTTP
+                unsigned int timeout = 241000;
+                // Because it can poll "after 9 seconds" polls will happen effectively // at ~10 seconds.
+                // Note that for scalabilty, the default value of minimumPollingTime
+                // is 25 minutes. For more information, see:
+                // https://azure.microsoft.com/documentation/articles/iot-hub-devguide/#messaging
+                unsigned int minimumPollingTime = 9;
+    #endif
+                
+                if (IoTHubDeviceClient_LL_SetOption(g_device_states[i].client_handle, OPTION_LOG_TRACE, &traceOn) != IOTHUB_CLIENT_OK)
+                {
+                    (void)printf("Failed setting log tracing (%s)!\r\n", config.deviceId);
+                    setup_ok = false;
+                }
+    #ifdef SET_TRUSTED_CERT_IN_SAMPLES
+                // Setting the Trusted Certificate. This is only necessary on systems without
+                // built in certificate stores.
+                else if (IoTHubDeviceClient_LL_SetOption(g_device_states[i].client_handle, OPTION_TRUSTED_CERT, certificates) != IOTHUB_CLIENT_OK)
+                {
+                    (void)printf("Failed setting log tracing (%s)!\r\n", config.deviceId);
+                    setup_ok = false;
+                }
+    #endif // SET_TRUSTED_CERT_IN_SAMPLES
+
+    #ifdef SAMPLE_HTTP
+                else if (IoTHubDeviceClient_LL_SetOption(g_device_states[i].client_handle, OPTION_MIN_POLLING_TIME, &minimumPollingTime) != IOTHUB_CLIENT_OK)
+                {
+                    (void)printf("Failed setting log tracing (%s)!\r\n", config.deviceId);
+                    setup_ok = false;
+                }
+                else if (IoTHubDeviceClient_LL_SetOption(g_device_states[i].client_handle, OPTION_HTTP_TIMEOUT, &timeout) != IOTHUB_CLIENT_OK)
+                {
+                    (void)printf("Failed setting log tracing (%s)!\r\n", config.deviceId);
+                    setup_ok = false;
+                }
+    #endif // SAMPLE_HTTP
+                /* Setting Message call back, so we can receive Commands. */
+                else if (IoTHubDeviceClient_LL_SetMessageCallback(g_device_states[i].client_handle, ReceiveMessageCallback, &g_device_states[i]) != IOTHUB_CLIENT_OK)
+                {
+                    (void)printf("Failed setting cloud-to-device message callback (%s)!\r\n", config.deviceId);
+                    setup_ok = false;
+                }
+            }
         }
-        else if ((device_ll_handle2 = IoTHubDeviceClient_LL_CreateWithTransport(&config2)) == NULL)
+
+        if (setup_ok)
         {
-            (void)printf("ERROR: iotHubClientHandle1 is NULL!\r\n");
-        }
-        else
-        {
-            // Set any option that are neccessary.
-            // For available options please see the iothub_sdk_options.md documentation
-            //bool traceOn = true;
-            //IoTHubDeviceClient_LL_SetOption(device_ll_handle1, OPTION_LOG_TRACE, &traceOn);
-            //IoTHubDeviceClient_LL_SetOption(device_ll_handle2, OPTION_LOG_TRACE, &traceOn);
-#ifdef SET_TRUSTED_CERT_IN_SAMPLES
-            // Setting the Trusted Certificate. This is only necessary on systems without
-            // built in certificate stores.
-            IoTHubDeviceClient_LL_SetOption(device_ll_handle1, OPTION_TRUSTED_CERT, certificates);
-            IoTHubDeviceClient_LL_SetOption(device_ll_handle2, OPTION_TRUSTED_CERT, certificates);
-#endif // SET_TRUSTED_CERT_IN_SAMPLES
-
-#ifdef SAMPLE_HTTP
-            unsigned int timeout = 241000;
-            // Because it can poll "after 9 seconds" polls will happen effectively // at ~10 seconds.
-            // Note that for scalabilty, the default value of minimumPollingTime
-            // is 25 minutes. For more information, see:
-            // https://azure.microsoft.com/documentation/articles/iot-hub-devguide/#messaging
-            unsigned int minimumPollingTime = 9;
-            IoTHubDeviceClient_LL_SetOption(device_ll_handle1, OPTION_MIN_POLLING_TIME, &minimumPollingTime);
-            IoTHubDeviceClient_LL_SetOption(device_ll_handle1, OPTION_HTTP_TIMEOUT, &timeout);
-            IoTHubDeviceClient_LL_SetOption(device_ll_handle2, OPTION_MIN_POLLING_TIME, &minimumPollingTime);
-            IoTHubDeviceClient_LL_SetOption(device_ll_handle2, OPTION_HTTP_TIMEOUT, &timeout);
-#endif // SAMPLE_HTTP
-
-            /* Setting Message call back, so we can receive Commands. */
-            (void)IoTHubDeviceClient_LL_SetMessageCallback(device_ll_handle1, ReceiveMessageCallback, &receiveContext1);
-            (void)IoTHubDeviceClient_LL_SetMessageCallback(device_ll_handle2, ReceiveMessageCallback, &receiveContext2);
-
             /* Now that we are ready to receive commands, let's send some messages */
             size_t messages_sent = 0;
+            size_t send_frequency_ms = 3000;
+            size_t sleep_ms = 100;
+            size_t counter = send_frequency_ms;
             IOTHUB_MESSAGE_HANDLE message_handle;
             do
             {
-                if (messages_sent < MESSAGE_COUNT)
+                if (counter >= send_frequency_ms && messages_sent < MESSAGE_COUNT)
                 {
-                    // Create the event hub message
-                    message_handle = create_events(&device1_event);
-                    (void)IoTHubDeviceClient_LL_SendEventAsync(device_ll_handle1, message_handle, SendConfirmationCallback, &device1_event);
-                    // The message is copied to the sdk so the we can destroy it
-                    IoTHubMessage_Destroy(message_handle);
-
-                    message_handle = create_events(&device2_event);
-                    (void)IoTHubDeviceClient_LL_SendEventAsync(device_ll_handle2, message_handle, SendConfirmationCallback, &device2_event);
-                    // The message is copied to the sdk so the we can destroy it
-                    IoTHubMessage_Destroy(message_handle);
+                    for (int i = 0; i < NUMBER_OF_DEVICES; i++)
+                    {
+                        // Create the event hub message
+                        message_handle = create_events(&g_device_states[i]);
+                        (void)IoTHubDeviceClient_LL_SendEventAsync(g_device_states[i].client_handle, message_handle, SendConfirmationCallback, &g_device_states[i]);
+                        // The message is copied to the sdk so the we can destroy it
+                        IoTHubMessage_Destroy(message_handle);
+                    }                    
 
                     messages_sent++;
+                    counter = 0;
                 }
 
-                IoTHubDeviceClient_LL_DoWork(device_ll_handle1);
-                IoTHubDeviceClient_LL_DoWork(device_ll_handle2);
-                ThreadAPI_Sleep(1);
+                for (int i = 0; i < NUMBER_OF_DEVICES; i++)
+                {
+                    IoTHubDeviceClient_LL_DoWork(g_device_states[i].client_handle);
+                }
+                ThreadAPI_Sleep((unsigned int)sleep_ms);
+                counter += sleep_ms;
+
+                g_continueRunning = !(messages_sent > MESSAGE_COUNT);
             } while (g_continueRunning);
 
-            (void)printf("client_amqp_shared_sample has gotten quit message, call DoWork %d more time to complete final sending...\r\n", DOWORK_LOOP_NUM);
+            (void)printf("client_amqp_shared_sample has received a quit message, call DoWork %d more time to complete final sending...\r\n", DOWORK_LOOP_NUM);
             for (size_t index = 0; index < DOWORK_LOOP_NUM; index++)
             {
-                IoTHubDeviceClient_LL_DoWork(device_ll_handle1);
-                IoTHubDeviceClient_LL_DoWork(device_ll_handle2);
+                for (int i = 0; i < NUMBER_OF_DEVICES; i++)
+                {
+                    IoTHubDeviceClient_LL_DoWork(g_device_states[i].client_handle);
+                }
                 ThreadAPI_Sleep(1);
             }
-
-            // Clean up the iothub sdk handle
-            IoTHubDeviceClient_LL_Destroy(device_ll_handle1);
-            IoTHubDeviceClient_LL_Destroy(device_ll_handle2);
         }
+
+        // Clean up the iothub sdk handle
+        for (int i = 0; i < NUMBER_OF_DEVICES; i++)
+        {
+            IoTHubDeviceClient_LL_Destroy(g_device_states[i].client_handle);
+        }
+
         IoTHubTransport_Destroy(transport_handle);
+
         // Free all the sdk subsystem
         IoTHub_Deinit();
     }

--- a/iothub_client/src/iothubtransport_amqp_common.c
+++ b/iothub_client/src/iothubtransport_amqp_common.c
@@ -51,6 +51,7 @@
 // DEFAULT_MAX_RETRY_TIME_IN_SECS = 0 means infinite retry.
 #define DEFAULT_MAX_RETRY_TIME_IN_SECS            0
 #define MAX_SERVICE_KEEP_ALIVE_RATIO              0.9
+#define DEFAULT_DEVICE_STOP_DELAY                 10
 
 // ---------- Data Definitions ---------- //
 
@@ -1146,18 +1147,17 @@ static int IoTHubTransport_AMQP_Common_Device_DoWork(AMQP_TRANSPORT_DEVICE_INSTA
         }
         else // i.e., DEVICE_STATE_ERROR_AUTH || DEVICE_STATE_ERROR_AUTH_TIMEOUT || DEVICE_STATE_ERROR_MSG
         {
-            LogError("Failed performing DoWork for device '%s' (device reported state %d; number of previous failures: %lu)",
-                STRING_c_str(registered_device->device_id), (int)registered_device->device_state, (unsigned long)registered_device->number_of_previous_failures);
-
             registered_device->number_of_previous_failures++;
 
             // Codes_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_046: [If the device has failed for MAX_NUMBER_OF_DEVICE_FAILURES in a row, it shall trigger a connection retry on the transport]
             if (registered_device->number_of_previous_failures >= MAX_NUMBER_OF_DEVICE_FAILURES)
             {
+                LogError("Failed performing DoWork for device '%s' (device reported state %d; number of previous failures: %lu)",
+                    STRING_c_str(registered_device->device_id), (int)registered_device->device_state, (unsigned long)registered_device->number_of_previous_failures);
                 result = MU_FAILURE;
             }
             // Codes_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_045: [If the registered device has a failure, it shall be stopped using amqp_device_stop()]
-            else if (amqp_device_stop(registered_device->device_handle) != RESULT_OK)
+            else if (amqp_device_delayed_stop(registered_device->device_handle, DEFAULT_DEVICE_STOP_DELAY) != RESULT_OK)
             {
                 LogError("Failed to stop reset device '%s' (amqp_device_stop failed)", STRING_c_str(registered_device->device_id));
                 result = MU_FAILURE;
@@ -1596,6 +1596,9 @@ void IoTHubTransport_AMQP_Common_DoWork(TRANSPORT_LL_HANDLE handle)
                 // Codes_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_020: [If the amqp_connection is OPENED, the transport shall iterate through each registered device and perform a device-specific do_work on each]
                 else if (transport_instance->amqp_connection_state == AMQP_CONNECTION_STATE_OPENED)
                 {
+                    size_t number_of_devices = 0;
+                    size_t number_of_faulty_devices = 0;
+
                     while (list_item != NULL)
                     {
                         AMQP_TRANSPORT_DEVICE_INSTANCE* registered_device;
@@ -1604,24 +1607,29 @@ void IoTHubTransport_AMQP_Common_DoWork(TRANSPORT_LL_HANDLE handle)
                         {
                             LogError("Transport had an unexpected failure during DoWork (failed to fetch a registered_devices list item value)");
                         }
-                        else if (registered_device->number_of_send_event_complete_failures >= MAX_NUMBER_OF_DEVICE_FAILURES)
+                        else if (registered_device->number_of_send_event_complete_failures >= DEVICE_FAILURE_COUNT_RECONNECTION_THRESHOLD)
                         {
-                            LogError("Device '%s' reported a critical failure (events completed sending with failures); connection retry will be triggered.", STRING_c_str(registered_device->device_id));
-
-                            update_state(transport_instance, AMQP_TRANSPORT_STATE_RECONNECTION_REQUIRED);
+                            number_of_faulty_devices++;
                         }
                         else if (IoTHubTransport_AMQP_Common_Device_DoWork(registered_device) != RESULT_OK)
                         {
-                            // Codes_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_021: [If DoWork fails for the registered device for more than MAX_NUMBER_OF_DEVICE_FAILURES, connection retry shall be triggered]
-                            if (registered_device->number_of_previous_failures >= MAX_NUMBER_OF_DEVICE_FAILURES)
+                            // Codes_SRS_IOTHUBTRANSPORT_AMQP_COMMON_09_021: [If DoWork fails for the registered device for more than DEVICE_FAILURE_COUNT_RECONNECTION_THRESHOLD, connection retry shall be triggered]
+                            if (registered_device->number_of_previous_failures >= DEVICE_FAILURE_COUNT_RECONNECTION_THRESHOLD)
                             {
-                                LogError("Device '%s' reported a critical failure; connection retry will be triggered.", STRING_c_str(registered_device->device_id));
-
-                                update_state(transport_instance, AMQP_TRANSPORT_STATE_RECONNECTION_REQUIRED);
+                                number_of_faulty_devices++;
                             }
                         }
 
                         list_item = singlylinkedlist_get_next_item(list_item);
+                        number_of_devices++;
+                    }
+
+                    if (number_of_faulty_devices > 0 &&
+                        ((float)number_of_faulty_devices/(float)number_of_devices) >= DEVICE_MULTIPLEXING_FAULTY_DEVICE_RATIO_RECONNECTION_THRESHOLD)
+                    {
+                        LogError("Reconnection required. %zd of %zd registered devices are failing.", number_of_faulty_devices, number_of_devices);
+
+                        update_state(transport_instance, AMQP_TRANSPORT_STATE_RECONNECTION_REQUIRED);
                     }
                 }
             }

--- a/iothub_client/src/iothubtransport_amqp_device.c
+++ b/iothub_client/src/iothubtransport_amqp_device.c
@@ -7,6 +7,7 @@
 #include "azure_c_shared_utility/agenttime.h"
 #include "azure_c_shared_utility/xlogging.h"
 #include "azure_c_shared_utility/strings.h"
+#include "azure_c_shared_utility/tickcounter.h"
 #include "internal/iothubtransport_amqp_cbs_auth.h"
 #include "internal/iothubtransport_amqp_device.h"
 #include "internal/iothubtransport_amqp_telemetry_messenger.h"
@@ -56,6 +57,10 @@ typedef struct DEVICE_INSTANCE_TAG
     size_t twin_msgr_state_change_timeout_secs;
     DEVICE_TWIN_UPDATE_RECEIVED_CALLBACK on_device_twin_update_received_callback;
     void* on_device_twin_update_received_context;
+
+    TICK_COUNTER_HANDLE tick_counter_handle;
+    tickcounter_ms_t last_stop_request_time;
+    size_t stop_delay_ms;
 } AMQP_DEVICE_INSTANCE;
 
 typedef struct DEVICE_SEND_EVENT_TASK_TAG
@@ -563,6 +568,7 @@ static void internal_destroy_device(AMQP_DEVICE_INSTANCE* instance)
             authentication_destroy(instance->authentication_handle);
         }
 
+        tickcounter_destroy(instance->tick_counter_handle);
         destroy_device_config(instance->config);
         free(instance);
     }
@@ -736,6 +742,11 @@ AMQP_DEVICE_HANDLE amqp_device_create(AMQP_DEVICE_CONFIG *config)
             LogError("Failed creating the device instance for device '%s' (failed copying the configuration)", config->device_id);
             result = MU_FAILURE;
         }
+        else if ((instance->tick_counter_handle = tickcounter_create()) == NULL)
+        {
+            LogError("Failed creating the internal tick counter for device '%s'", instance->config->device_id);
+            result = MU_FAILURE;
+        }
         // Codes_SRS_DEVICE_09_006: [If `instance->authentication_mode` is DEVICE_AUTH_MODE_CBS, `instance->authentication_handle` shall be set using authentication_create()]
         else if (instance->config->authentication_mode == DEVICE_AUTH_MODE_CBS &&
                  create_authentication_instance(instance) != RESULT_OK)
@@ -770,6 +781,8 @@ AMQP_DEVICE_HANDLE amqp_device_create(AMQP_DEVICE_CONFIG *config)
             instance->msgr_state_change_timeout_secs = DEFAULT_MSGR_STATE_CHANGED_TIMEOUT_SECS;
             instance->twin_msgr_state_last_changed_time = INDEFINITE_TIME;
             instance->twin_msgr_state_change_timeout_secs = DEFAULT_MSGR_STATE_CHANGED_TIMEOUT_SECS;
+            instance->stop_delay_ms = 0;
+            instance->last_stop_request_time = 0;
 
             result = RESULT_OK;
         }
@@ -823,6 +836,7 @@ int amqp_device_start_async(AMQP_DEVICE_HANDLE handle, SESSION_HANDLE session_ha
             // Codes_SRS_DEVICE_09_021: [`session_handle` and `cbs_handle` shall be saved into the `instance`]
             instance->session_handle = session_handle;
             instance->cbs_handle = cbs_handle;
+	    instance->stop_delay_ms = 0;
 
             // Codes_SRS_DEVICE_09_022: [The device state shall be updated to DEVICE_STATE_STARTING, and state changed callback invoked]
             update_state(instance, DEVICE_STATE_STARTING);
@@ -830,6 +844,50 @@ int amqp_device_start_async(AMQP_DEVICE_HANDLE handle, SESSION_HANDLE session_ha
             // Codes_SRS_DEVICE_09_023: [If no failures occur, amqp_device_start_async shall return 0]
             result = RESULT_OK;
         }
+    }
+
+    return result;
+}
+
+static int internal_device_stop(AMQP_DEVICE_INSTANCE* instance)
+{
+    int result;
+
+    // Codes_SRS_DEVICE_09_027: [If `instance->messenger_handle` state is not TELEMETRY_MESSENGER_STATE_STOPPED, messenger_stop shall be invoked]
+    if (instance->msgr_state != TELEMETRY_MESSENGER_STATE_STOPPED &&
+        instance->msgr_state != TELEMETRY_MESSENGER_STATE_STOPPING &&
+        telemetry_messenger_stop(instance->messenger_handle) != RESULT_OK)
+    {
+        // Codes_SRS_DEVICE_09_028: [If messenger_stop fails, the `instance` state shall be updated to DEVICE_STATE_ERROR_MSG and the function shall return non-zero result]
+        LogError("Failed stopping device '%s' (telemetry_messenger_stop failed)", instance->config->device_id);
+        update_state(instance, DEVICE_STATE_ERROR_MSG);
+        result = MU_FAILURE;
+    }
+    // Codes_SRS_DEVICE_09_131: [If `instance->twin_messenger_handle` state is not TWIN_MESSENGER_STATE_STOPPED, twin_messenger_stop shall be invoked]
+    else if (instance->twin_msgr_state != TWIN_MESSENGER_STATE_STOPPED &&
+        instance->twin_msgr_state != TWIN_MESSENGER_STATE_STOPPING &&
+        twin_messenger_stop(instance->twin_messenger_handle) != RESULT_OK)
+    {
+        // Codes_SRS_DEVICE_09_132: [If twin_messenger_stop fails, the `instance` state shall be updated to DEVICE_STATE_ERROR_MSG and the function shall return non-zero result]
+        LogError("Failed stopping device '%s' (twin_messenger_stop failed)", instance->config->device_id);
+        update_state(instance, DEVICE_STATE_ERROR_MSG);
+        result = MU_FAILURE;
+    }
+    // Codes_SRS_DEVICE_09_029: [If CBS authentication is used, if `instance->authentication_handle` state is not AUTHENTICATION_STATE_STOPPED, authentication_stop shall be invoked]
+    else if (instance->config->authentication_mode == DEVICE_AUTH_MODE_CBS &&
+        instance->auth_state != AUTHENTICATION_STATE_STOPPED &&
+        authentication_stop(instance->authentication_handle) != RESULT_OK)
+    {
+        // Codes_SRS_DEVICE_09_030: [If authentication_stop fails, the `instance` state shall be updated to DEVICE_STATE_ERROR_AUTH and the function shall return non-zero result]
+        LogError("Failed stopping device '%s' (authentication_stop failed)", instance->config->device_id);
+        update_state(instance, DEVICE_STATE_ERROR_AUTH);
+        result = MU_FAILURE;
+    }
+    else
+    {
+        // Codes_SRS_DEVICE_09_031: [The device state shall be updated to DEVICE_STATE_STOPPED, and state changed callback invoked]
+        update_state(instance, DEVICE_STATE_STOPPED);
+        result = RESULT_OK;
     }
 
     return result;
@@ -854,54 +912,66 @@ int amqp_device_stop(AMQP_DEVICE_HANDLE handle)
         AMQP_DEVICE_INSTANCE* instance = (AMQP_DEVICE_INSTANCE*)handle;
 
         // Codes_SRS_DEVICE_09_025: [If the device state is already DEVICE_STATE_STOPPED or DEVICE_STATE_STOPPING, amqp_device_stop shall return a non-zero result]
-        if (instance->state == DEVICE_STATE_STOPPED || instance->state == DEVICE_STATE_STOPPING)
+        if (instance->state == DEVICE_STATE_STOPPED || (instance->state == DEVICE_STATE_STOPPING && instance->stop_delay_ms == 0))
         {
             LogError("Failed stopping device '%s' (device is already stopped or stopping)", instance->config->device_id);
             result = MU_FAILURE;
         }
         else
         {
-            // Codes_SRS_DEVICE_09_026: [The device state shall be updated to DEVICE_STATE_STOPPING, and state changed callback invoked]
             update_state(instance, DEVICE_STATE_STOPPING);
-
-            // Codes_SRS_DEVICE_09_027: [If `instance->messenger_handle` state is not TELEMETRY_MESSENGER_STATE_STOPPED, messenger_stop shall be invoked]
-            if (instance->msgr_state != TELEMETRY_MESSENGER_STATE_STOPPED &&
-                instance->msgr_state != TELEMETRY_MESSENGER_STATE_STOPPING &&
-                telemetry_messenger_stop(instance->messenger_handle) != RESULT_OK)
+            
+            if (internal_device_stop(instance) != 0)
             {
-                // Codes_SRS_DEVICE_09_028: [If messenger_stop fails, the `instance` state shall be updated to DEVICE_STATE_ERROR_MSG and the function shall return non-zero result]
-                LogError("Failed stopping device '%s' (telemetry_messenger_stop failed)", instance->config->device_id);
+                LogError("Failed stopping device '%s' (immediate stop failed)", instance->config->device_id);
                 result = MU_FAILURE;
-                update_state(instance, DEVICE_STATE_ERROR_MSG);
-            }
-            // Codes_SRS_DEVICE_09_131: [If `instance->twin_messenger_handle` state is not TWIN_MESSENGER_STATE_STOPPED, twin_messenger_stop shall be invoked]
-            else if (instance->twin_msgr_state != TWIN_MESSENGER_STATE_STOPPED &&
-                instance->twin_msgr_state != TWIN_MESSENGER_STATE_STOPPING &&
-                twin_messenger_stop(instance->twin_messenger_handle) != RESULT_OK)
-            {
-                // Codes_SRS_DEVICE_09_132: [If twin_messenger_stop fails, the `instance` state shall be updated to DEVICE_STATE_ERROR_MSG and the function shall return non-zero result]
-                LogError("Failed stopping device '%s' (twin_messenger_stop failed)", instance->config->device_id);
-                result = MU_FAILURE;
-                update_state(instance, DEVICE_STATE_ERROR_MSG);
-            }
-            // Codes_SRS_DEVICE_09_029: [If CBS authentication is used, if `instance->authentication_handle` state is not AUTHENTICATION_STATE_STOPPED, authentication_stop shall be invoked]
-            else if (instance->config->authentication_mode == DEVICE_AUTH_MODE_CBS &&
-                instance->auth_state != AUTHENTICATION_STATE_STOPPED &&
-                authentication_stop(instance->authentication_handle) != RESULT_OK)
-            {
-                // Codes_SRS_DEVICE_09_030: [If authentication_stop fails, the `instance` state shall be updated to DEVICE_STATE_ERROR_AUTH and the function shall return non-zero result]
-                LogError("Failed stopping device '%s' (authentication_stop failed)", instance->config->device_id);
-                result = MU_FAILURE;
-                update_state(instance, DEVICE_STATE_ERROR_AUTH);
             }
             else
             {
-                // Codes_SRS_DEVICE_09_031: [The device state shall be updated to DEVICE_STATE_STOPPED, and state changed callback invoked]
-                update_state(instance, DEVICE_STATE_STOPPED);
-
-                // Codes_SRS_DEVICE_09_032: [If no failures occur, amqp_device_stop shall return 0]
                 result = RESULT_OK;
             }
+        }
+    }
+
+    return result;
+}
+
+// @brief
+//     stops a device instance (stops messenger and authentication) synchronously.
+// @returns
+//     0 if the function succeeds, non-zero otherwise.
+int amqp_device_delayed_stop(AMQP_DEVICE_HANDLE handle, size_t delay_secs)
+{
+    int result;
+
+    // Codes_SRS_DEVICE_09_024: [If `handle` is NULL, amqp_device_stop shall return a non-zero result]
+    if (handle == NULL)
+    {
+        LogError("Failed stopping device (handle is NULL)");
+        result = MU_FAILURE;
+    }
+    else
+    {
+        AMQP_DEVICE_INSTANCE* instance = (AMQP_DEVICE_INSTANCE*)handle;
+
+        // Codes_SRS_DEVICE_09_025: [If the device state is already DEVICE_STATE_STOPPED or DEVICE_STATE_STOPPING, amqp_device_stop shall return a non-zero result]
+        if (instance->state == DEVICE_STATE_STOPPED || instance->state == DEVICE_STATE_STOPPING)
+        {
+            LogError("Failed stopping device '%s' (device is already stopped or stopping)", instance->config->device_id);
+            result = MU_FAILURE;
+        }
+        else if (tickcounter_get_current_ms(instance->tick_counter_handle, &instance->last_stop_request_time) != 0)
+        {
+            LogError("Failed stopping device '%s' (could not get tickcounter time)", instance->config->device_id);
+            result = MU_FAILURE;
+        }
+        else
+        {
+            // Codes_SRS_DEVICE_09_026: [The device state shall be updated to DEVICE_STATE_STOPPING, and state changed callback invoked]
+            update_state(instance, DEVICE_STATE_STOPPING);
+            instance->stop_delay_ms = delay_secs * 1000;
+            // Codes_SRS_DEVICE_09_032: [If no failures occur, amqp_device_stop shall return 0]
+            result = RESULT_OK;
         }
     }
 
@@ -920,7 +990,25 @@ void amqp_device_do_work(AMQP_DEVICE_HANDLE handle)
         // Cranking the state monster:
         AMQP_DEVICE_INSTANCE* instance = (AMQP_DEVICE_INSTANCE*)handle;
 
-        if (instance->state == DEVICE_STATE_STARTING)
+        if (instance->state == DEVICE_STATE_STOPPING)
+        {
+            tickcounter_ms_t current_time_ms;
+
+            if (tickcounter_get_current_ms(instance->tick_counter_handle, &current_time_ms) != 0)
+            {
+                LogError("Failed stopping device '%s' (could not get tickcounter time)", instance->config->device_id);
+                update_state(instance, DEVICE_STATE_ERROR_MSG);
+            }
+            else if ((current_time_ms - instance->last_stop_request_time) > instance->stop_delay_ms)
+            {
+                if (internal_device_stop(instance) != 0)
+                {
+                    LogError("Failed stopping device '%s'", instance->config->device_id);
+                    update_state(instance, DEVICE_STATE_ERROR_MSG);
+                }
+            }
+        }
+        else if (instance->state == DEVICE_STATE_STARTING)
         {
             // Codes_SRS_DEVICE_09_034: [If CBS authentication is used and authentication state is AUTHENTICATION_STATE_STOPPED, authentication_start shall be invoked]
             if (instance->config->authentication_mode == DEVICE_AUTH_MODE_CBS)


### PR DESCRIPTION
Related to the github issue:
https://github.com/Azure/azure-iot-sdk-c/issues/1434

The device multiplexing reconnection can now be fine tuned by the
following options in iothub_client_options.h:

DEVICE_MULTIPLEXING_FAULTY_DEVICE_RATIO_RECONNECTION_THRESHOLD
DEVICE_FAILURE_COUNT_RECONNECTION_THRESHOLD

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 