### PR TITLE
Fix Device Streaming samples to check args in callbacks and avoid buffer underrun (gh#1767)

### DIFF
--- a/iothub_client/samples/iothub_client_c2d_streaming_proxy_sample/iothub_client_c2d_streaming_proxy_sample.c
+++ b/iothub_client/samples/iothub_client_c2d_streaming_proxy_sample/iothub_client_c2d_streaming_proxy_sample.c
@@ -109,6 +109,12 @@ static void on_bytes_received(void* context, const unsigned char* buffer, size_t
 {
     (void)context;
 
+    if (buffer == NULL)
+    {
+        (void)printf("[ERROR] on_bytes_received invoked with NULL buffer (unexpected)\r\n");
+        exit(1);
+    }
+
     if (g_is_uws_client_ready)
     {
         size_t send_size;
@@ -218,7 +224,21 @@ static void on_ws_peer_closed(void* context, uint16_t* close_code, const unsigne
 {
     (void)context;
     (void)extra_data_length;
-    (void)printf("on_ws_peer_closed (Code: %d, Data: %.*s)\r\n", *close_code, (int)extra_data_length, extra_data);
+
+    (void)printf("on_ws_peer_closed (");
+
+    if (close_code != NULL)
+    {
+        (void)printf("Code: %d, ", *close_code);
+    }
+
+    if (extra_data != NULL)
+    {
+        (void)printf("Data: %.*s", (int)extra_data_length, extra_data);
+    }
+
+    (void)printf(")\r\n");
+
     g_continueRunning = false;
 }
 


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-c/issues/1767

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 