### PR TITLE
Update ECC certificate info in docs

### DIFF
--- a/certs/certs.c
+++ b/certs/certs.c
@@ -65,33 +65,6 @@ const char certificates[] =
 "-----END CERTIFICATE-----\r\n"
 #endif /* DIGICERT_G3_CERT */
 
-#if defined(USE_PORTAL_AZURE_CN_CERT)
-/* DigiCert Global Root CA */
-// This cert should be used when connecting to Azure IoT on the https://portal.azure.cn Cloud address.
-"-----BEGIN CERTIFICATE-----\r\n"
-"MIIDrzCCApegAwIBAgIQCDvgVpBCRrGhdWrJWZHHSjANBgkqhkiG9w0BAQUFADBh\r\n"
-"MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3\r\n"
-"d3cuZGlnaWNlcnQuY29tMSAwHgYDVQQDExdEaWdpQ2VydCBHbG9iYWwgUm9vdCBD\r\n"
-"QTAeFw0wNjExMTAwMDAwMDBaFw0zMTExMTAwMDAwMDBaMGExCzAJBgNVBAYTAlVT\r\n"
-"MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5j\r\n"
-"b20xIDAeBgNVBAMTF0RpZ2lDZXJ0IEdsb2JhbCBSb290IENBMIIBIjANBgkqhkiG\r\n"
-"9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4jvhEXLeqKTTo1eqUKKPC3eQyaKl7hLOllsB\r\n"
-"CSDMAZOnTjC3U/dDxGkAV53ijSLdhwZAAIEJzs4bg7/fzTtxRuLWZscFs3YnFo97\r\n"
-"nh6Vfe63SKMI2tavegw5BmV/Sl0fvBf4q77uKNd0f3p4mVmFaG5cIzJLv07A6Fpt\r\n"
-"43C/dxC//AH2hdmoRBBYMql1GNXRor5H4idq9Joz+EkIYIvUX7Q6hL+hqkpMfT7P\r\n"
-"T19sdl6gSzeRntwi5m3OFBqOasv+zbMUZBfHWymeMr/y7vrTC0LUq7dBMtoM1O/4\r\n"
-"gdW7jVg/tRvoSSiicNoxBN33shbyTApOB6jtSj1etX+jkMOvJwIDAQABo2MwYTAO\r\n"
-"BgNVHQ8BAf8EBAMCAYYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUA95QNVbR\r\n"
-"TLtm8KPiGxvDl7I90VUwHwYDVR0jBBgwFoAUA95QNVbRTLtm8KPiGxvDl7I90VUw\r\n"
-"DQYJKoZIhvcNAQEFBQADggEBAMucN6pIExIK+t1EnE9SsPTfrgT1eXkIoyQY/Esr\r\n"
-"hMAtudXH/vTBH1jLuG2cenTnmCmrEbXjcKChzUyImZOMkXDiqw8cvpOp/2PV5Adg\r\n"
-"06O/nVsJ8dWO41P0jmP6P6fbtGbfYmbW0W5BjfIttep3Sp+dWOIrWcBAI+0tKIJF\r\n"
-"PnlUkiaY4IBIqDfv8NZ5YBberOgOzW6sRBc4L0na4UU+Krk2U886UAb3LujEV0ls\r\n"
-"YSEY1QSteDwsOoBrp+uvFRTp2InBuThs4pFsiv9kuXclVzDAGySj4dzp30d8tbQk\r\n"
-"CAUw7C29C79Fv1C5qfPrmAESrciIxpg0X40KPMbp1ZWVbd4=\r\n"
-"-----END CERTIFICATE-----\r\n"
-#endif /* PORTAL_AZURE_CN_CERT */
-
 #if defined(USE_MICROSOFTAZURE_DE_CERT)
 /* D-TRUST Root Class 3 CA 2 2009 */
 // This cert should be used when connecting to Azure IoT on the https://portal.microsoftazure.de Cloud address.
@@ -121,5 +94,32 @@ const char certificates[] =
 "Johw1+qRzT65ysCQblrGXnRl11z+o+I=\r\n"
 "-----END CERTIFICATE-----\r\n"
 #endif /* MICROSOFTAZURE_DE_CERT */
+
+#if defined(USE_PORTAL_AZURE_CN_CERT)
+/* DigiCert Global Root CA */
+// This cert should be used when connecting to Azure IoT on the https://portal.azure.cn Cloud address.
+"-----BEGIN CERTIFICATE-----\r\n"
+"MIIDrzCCApegAwIBAgIQCDvgVpBCRrGhdWrJWZHHSjANBgkqhkiG9w0BAQUFADBh\r\n"
+"MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3\r\n"
+"d3cuZGlnaWNlcnQuY29tMSAwHgYDVQQDExdEaWdpQ2VydCBHbG9iYWwgUm9vdCBD\r\n"
+"QTAeFw0wNjExMTAwMDAwMDBaFw0zMTExMTAwMDAwMDBaMGExCzAJBgNVBAYTAlVT\r\n"
+"MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5j\r\n"
+"b20xIDAeBgNVBAMTF0RpZ2lDZXJ0IEdsb2JhbCBSb290IENBMIIBIjANBgkqhkiG\r\n"
+"9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4jvhEXLeqKTTo1eqUKKPC3eQyaKl7hLOllsB\r\n"
+"CSDMAZOnTjC3U/dDxGkAV53ijSLdhwZAAIEJzs4bg7/fzTtxRuLWZscFs3YnFo97\r\n"
+"nh6Vfe63SKMI2tavegw5BmV/Sl0fvBf4q77uKNd0f3p4mVmFaG5cIzJLv07A6Fpt\r\n"
+"43C/dxC//AH2hdmoRBBYMql1GNXRor5H4idq9Joz+EkIYIvUX7Q6hL+hqkpMfT7P\r\n"
+"T19sdl6gSzeRntwi5m3OFBqOasv+zbMUZBfHWymeMr/y7vrTC0LUq7dBMtoM1O/4\r\n"
+"gdW7jVg/tRvoSSiicNoxBN33shbyTApOB6jtSj1etX+jkMOvJwIDAQABo2MwYTAO\r\n"
+"BgNVHQ8BAf8EBAMCAYYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUA95QNVbR\r\n"
+"TLtm8KPiGxvDl7I90VUwHwYDVR0jBBgwFoAUA95QNVbRTLtm8KPiGxvDl7I90VUw\r\n"
+"DQYJKoZIhvcNAQEFBQADggEBAMucN6pIExIK+t1EnE9SsPTfrgT1eXkIoyQY/Esr\r\n"
+"hMAtudXH/vTBH1jLuG2cenTnmCmrEbXjcKChzUyImZOMkXDiqw8cvpOp/2PV5Adg\r\n"
+"06O/nVsJ8dWO41P0jmP6P6fbtGbfYmbW0W5BjfIttep3Sp+dWOIrWcBAI+0tKIJF\r\n"
+"PnlUkiaY4IBIqDfv8NZ5YBberOgOzW6sRBc4L0na4UU+Krk2U886UAb3LujEV0ls\r\n"
+"YSEY1QSteDwsOoBrp+uvFRTp2InBuThs4pFsiv9kuXclVzDAGySj4dzp30d8tbQk\r\n"
+"CAUw7C29C79Fv1C5qfPrmAESrciIxpg0X40KPMbp1ZWVbd4=\r\n"
+"-----END CERTIFICATE-----\r\n"
+#endif /* PORTAL_AZURE_CN_CERT */
 
 ;

--- a/certs/readme.md
+++ b/certs/readme.md
@@ -20,7 +20,7 @@ cmake .. -Duse_portal_azure_cn_cert    // To use DigiCert Global Root CA (RSA ba
 
 For other regions (and private cloud environments), please use the appropriate root CA certificate.
 
-IMPORTANT: Always prefer using the local system's Trusted Root Certificate Authority store instead of hardcoding the certificates (i.e. using certs.c such as our samples require in certain combinations).
+IMPORTANT: Always prefer using the local system's Trusted Root Certificate Authority store instead of hardcoding the certificates (i.e. using certs.c which our samples require in certain combinations).
 
 A couple of examples:
 

--- a/certs/readme.md
+++ b/certs/readme.md
@@ -2,7 +2,7 @@
 
 The Azure IoT Hub certificates presented during TLS negotiation shall be always validated using the appropriate root CA certificate(s).
 
-The samples in this repository leverage the certificates in `certs.c` for the United States, Germany sovereign cloud and China sovereign cloud. Additionally, we provide the root certificate for use with ECC (enabled in IoT Hub Gateway V2). By default, all certs are included in the build. To select a specific cert, use one of th efollowing options during the cmake step of your [environment setup](https://github.com/Azure/azure-iot-sdk-c/doc/devbox_setup.md).
+The samples in this repository leverage the certificates in `certs.c` for the United States, Germany sovereign cloud and China sovereign cloud. Additionally, we provide the root certificate for use with ECC (enabled in IoT Hub Gateway V2). By default, all certs are included in the build. To select a specific cert, use one of the following options during the cmake step of your [environment setup](https://github.com/Azure/azure-iot-sdk-c/doc/devbox_setup.md).
 
 ```
 cmake .. -Duse_baltimore_cert         // Baltimore CyberTrust Root. Standard.
@@ -13,17 +13,12 @@ cmake .. -Duse_portal_azure_cn_cert   // China region.
 
 For other regions (and private cloud environments), please use the appropriate root CA certificate.
 
-
-
-
-
 IMPORTANT: Always prefer using the local system's Trusted Root Certificate Authority store instead of hardcoding the certificates (i.e. using certs.c such as our samples require in certain combinations).
 
 A couple of examples:
 
 - Windows: Schannel will automatically pick up CA certificates from the store managed using `certmgr.msc`.
 - Debian Linux: OpenSSL will automatically pick up CA certificates from the store installed using `apt install ca-certificates`. Adding a certificate to the store is described here: http://manpages.ubuntu.com/manpages/precise/man8/update-ca-certificates.8.html
-
 
 ## Additional Information
 

--- a/certs/readme.md
+++ b/certs/readme.md
@@ -5,10 +5,17 @@ The Azure IoT Hub certificates presented during TLS negotiation shall be always 
 The samples in this repository leverage the certificates in `certs.c` for the United States, Germany sovereign cloud and China sovereign cloud. Additionally, we provide the root certificate for use with ECC (enabled in IoT Hub Gateway V2). By default, all certs are included in the build. To select a specific cert, use one of the following options during the cmake step of your [environment setup](https://github.com/Azure/azure-iot-sdk-c/doc/devbox_setup.md).
 
 ```
-cmake .. -Duse_baltimore_cert         // Baltimore CyberTrust Root. Standard.
-cmake .. -Duse_digicert_g3_cert       // To use ECC with IoT Hub Gateway V2.
-cmake .. -Duse_microsoftazure_de_cert // Germany region.
-cmake .. -Duse_portal_azure_cn_cert   // China region.
+cmake .. -Duse_baltimore_cert          // To use Baltimore CyberTrust Root (RSA based Root cert).
+                                       // Default Root Cert supported by IoT Hub.
+
+cmake .. -Duse_digicert_g3_cert        // To use DigiCert Global Root G3 (ECC based Root cert).
+                                       // Only supported with IoT Hub Gateway V2.
+
+cmake .. -Duse_microsoftazure_de_cert  // To use D-TRUST Root Class 3 CA 2 2009
+                                       // Root cert for Germany region.
+
+cmake .. -Duse_portal_azure_cn_cert    // To use DigiCert Global Root CA (RSA based Root cert).
+                                       // Root cert for China region.
 ```
 
 For other regions (and private cloud environments), please use the appropriate root CA certificate.

--- a/certs/readme.md
+++ b/certs/readme.md
@@ -2,11 +2,22 @@
 
 The Azure IoT Hub certificates presented during TLS negotiation shall be always validated using the appropriate root CA certificate(s).
 
-The samples in this repository leverage the certificates in `certs.c` for the United States, Germany sovereign cloud and China sovereign cloud.
+The samples in this repository leverage the certificates in `certs.c` for the United States, Germany sovereign cloud and China sovereign cloud. Additionally, we provide the root certificate for use with ECC (enabled in IoT Hub Gateway V2). By default, all certs are included in the build. To select a specific cert, use one of th efollowing options during the cmake step of your [environment setup](https://github.com/Azure/azure-iot-sdk-c/doc/devbox_setup.md).
+
+```
+cmake .. -Duse_baltimore_cert         // Baltimore CyberTrust Root. Standard.
+cmake .. -Duse_digicert_g3_cert       // To use ECC with IoT Hub Gateway V2.
+cmake .. -Duse_microsoftazure_de_cert // Germany region.
+cmake .. -Duse_portal_azure_cn_cert   // China region.
+```
 
 For other regions (and private cloud environments), please use the appropriate root CA certificate.
 
-Always prefer using the local system's Trusted Root Certificate Authority store instead of hardcoding the certificates (i.e. using certs.c such as our samples require in certain combinations). 
+
+
+
+
+IMPORTANT: Always prefer using the local system's Trusted Root Certificate Authority store instead of hardcoding the certificates (i.e. using certs.c such as our samples require in certain combinations).
 
 A couple of examples:
 
@@ -16,4 +27,4 @@ A couple of examples:
 
 ## Additional Information
 
-For additional guidance and important information about certificates, please refer to [this blog post](https://techcommunity.microsoft.com/t5/internet-of-things/azure-iot-tls-changes-are-coming-and-why-you-should-care/ba-p/1658456) from the security team. 
+For additional guidance and important information about certificates, please refer to [this blog post](https://techcommunity.microsoft.com/t5/internet-of-things/azure-iot-tls-changes-are-coming-and-why-you-should-care/ba-p/1658456) from the security team.

--- a/certs/readme.md
+++ b/certs/readme.md
@@ -11,7 +11,7 @@ cmake .. -Duse_baltimore_cert          // To use Baltimore CyberTrust Root (RSA 
 cmake .. -Duse_digicert_g3_cert        // To use DigiCert Global Root G3 (ECC based Root cert).
                                        // Only supported with IoT Hub Gateway V2.
 
-cmake .. -Duse_microsoftazure_de_cert  // To use D-TRUST Root Class 3 CA 2 2009
+cmake .. -Duse_microsoftazure_de_cert  // To use D-TRUST Root Class 3 CA 2 2009 (RSA based Root cert).
                                        // Root cert for Germany region.
 
 cmake .. -Duse_portal_azure_cn_cert    // To use DigiCert Global Root CA (RSA based Root cert).

--- a/doc/devbox_setup.md
+++ b/doc/devbox_setup.md
@@ -34,11 +34,11 @@ git submodule update --init
 
 >If you are using a release before 2019-04-15 then you will need to use the `--recursive` argument to instructs git to clone other GitHub repos this SDK depends on. Dependencies are listed [here](https://github.com/Azure/azure-iot-sdk-c/blob/master/.gitmodules).
 
-### Build sample application using vcpkg to build the SDK 
+### Build sample application using vcpkg to build the SDK
 
 The sample applications build with the help of C SDK libraries and headers built with vcpkg (a C++ package manager who facilitate building C and C++ libraries). To install the C SDK libraries and headers, follow these steps [Setup C SDK vcpkg for Windows development environment](https://github.com/Azure/azure-iot-sdk-c/blob/master/doc/setting_up_vcpkg.md#setup-c-sdk-vcpkg-for-windows-development-environment).
 
-note: vcpkg creates a directory with all the headers and .lib files on your machine, if you are using Visual Studio (from 2015) the command 'vcpkg integrate install' let Visual Studio knows where are the headers and lib. If you're using other IDE just add the vcpkg directories to your compiler as usual. 
+note: vcpkg creates a directory with all the headers and .lib files on your machine, if you are using Visual Studio (from 2015) the command 'vcpkg integrate install' let Visual Studio knows where are the headers and lib. If you're using other IDE just add the vcpkg directories to your compiler as usual.
 
 To quickly build one of our sample applications, open the corresponding [solution file][sln-file] (.sln) in Visual Studio.
   For example, to build the **telemetry message sample**, open **iothub_client\samples\iothub_ll_telemetry_sample\windows\iothub_ll_telemetry_sample.sln**.
@@ -52,7 +52,7 @@ static const char* connectionString = "[device connection string]";
 ...and replace `[device connection string]` with a valid device connection string for a device registered with your IoT Hub. For more information, see the [samples section](#samplecode) below.
 
 Build the sample project.
- 
+
 
 ### Build the C SDK with CMake on Windows
 
@@ -93,7 +93,7 @@ cmake -G "Visual Studio 15 2017" -Duse_amqp=OFF .. // same with 2017 and 2019 ge
 > Also, you can build and run unit tests:
 
 ```Shell
-cmake -G "Visual Studio 15 2017" -Drun_unittests=ON ..  // same with 2017 and 2019 generator (see above) 
+cmake -G "Visual Studio 15 2017" -Drun_unittests=ON ..  // same with 2017 and 2019 generator (see above)
 cmake --build . -- /m /p:Configuration=Debug
 ctest -C "debug" -V
 ```
@@ -102,11 +102,17 @@ ctest -C "debug" -V
 
 By default the C-SDK will have web sockets enabled for AMQP and MQTT.  The sample **iothub_client\samples\iothub_ll_telemetry_sample** lets you specify the `protocol` variable.
 
+### Build a sample using a specific server root certificate
+
+By default all samples are built to handle a variety of server root certificates. If you would like to decrease the size of the sample, select the appropriate root cert by following the instructions [here](https://github.com/Azure/azure-iot-sdk-c/certs).
+
+> Note: Any samples you build will not work until you configure them with a valid IoT Hub device connection string. For more information, see the [samples section](#samplecode) below.
+
 ### Using OpenSSL in the SDK
 
 For TLS operations, by default the C-SDK uses Schannel on Windows Platforms.  You can use OpenSSL instead on Windows if you desire.  **NOTE:  this configuration presently receives only basic manual testing and does not have gated e2e tests.**
 
-**IMPORTANT SECURITY NOTE WHEN USING OPENSSL ON WINDOWS**  
+**IMPORTANT SECURITY NOTE WHEN USING OPENSSL ON WINDOWS**
 You are responsible for updating your OpenSSL dependencies as security fixes for it become available.  Schannel on Windows is a system component automatically serviced by Windows Update.  OpenSSL on Linux is updated by Linux packaging mechanisms, such as apt-get on Debian based distributions.  Shipping the C-SDK on Windows using OpenSSL means you are responsible for getting updated versions of it to your devices.
 
 [OpenSSL] binaries that the C-SDK depends on are **ssleay32** and **libeay32**. To enable OpenSSL to be used on Windows, you need to
@@ -151,6 +157,9 @@ This section describes how to set up a development environment for the C SDK on 
   sudo apt-get update
   sudo apt-get install -y git cmake build-essential curl libcurl4-openssl-dev libssl-dev uuid-dev
   ```
+  NOTE: If you are planning to use HTTP with wolfSSL, you must configure curl before installation.
+  1. Download the latest [curl](https://github.com/curl/curl/releases).
+  2. See curl [documentation](https://curl.se/docs/install.html) to use the wolfSSL option for configuration.  Install.
 
 - Verify that CMake is at least version **2.8.12**:
 
@@ -171,7 +180,7 @@ This section describes how to set up a development environment for the C SDK on 
 - Patch CURL to the latest version available.
   > The minimum version of curl required is 7.56, as recent previous versions [presented critical failures](https://github.com/Azure/azure-iot-sdk-c/issues/308).
   > To upgrade see "Upgrade CURL on Mac OS" steps below.
-  
+
 - Locate the tag name for the [latest release][latest-release] of the SDK.
   > Our release tag names are date values in `lts_mm_yyyy` format.
 
@@ -217,13 +226,21 @@ cmake --build .
 ctest -C "debug" -V
 ```
 
-> Note: Any samples you built will not work until you configure them with a valid IoT Hub device connection string. For more information, see the [samples section](#samplecode) below.
+### Build a sample that uses different protocols, including over WebSockets
+
+By default the C-SDK will have web sockets enabled for AMQP and MQTT.  The sample **iothub_client\samples\iothub_ll_telemetry_sample** lets you specify the `protocol` variable.
+
+### Build a sample using a specific server root certificate
+
+By default all samples are built to handle a variety of server root certificates. If you would like to decrease the size of the sample, select the appropriate root cert by following the instructions [here](https://github.com/Azure/azure-iot-sdk-c/certs).
+
+> Note: Any samples you build will not work until you configure them with a valid IoT Hub device connection string. For more information, see the [samples section](#samplecode) below.
 
 <a name="macos"></a>
 
 ## Set up a macOS (Mac OS X) development environment
 
-This section describes how to set up a development environment for the C SDK on [macOS]. [CMake] will 
+This section describes how to set up a development environment for the C SDK on [macOS]. [CMake] will
 create an XCode project containing the various SDK libraries and samples.
 
 We've tested the device SDK for C on macOS High Sierra, with XCode version 9.2.
@@ -244,7 +261,7 @@ We've tested the device SDK for C on macOS High Sierra, with XCode version 9.2.
 - Patch CURL to the latest version available.
   > The minimum version of curl required is 7.56, as recent previous versions [presented critical failures](https://github.com/Azure/azure-iot-sdk-c/issues/308).
   > To upgrade see "Upgrade CURL on Mac OS" steps below.
-  
+
 - Locate the tag name for the [latest release][latest-release] of the SDK.
   > Our release tag names are date values in `lts_mm_yyyy` format.
 
@@ -289,18 +306,16 @@ export DYLD_LIBRARY_PATH="/usr/local/Cellar/curl/7.58.0/lib:$DYLD_LIBRARY_PATH"
 ```
 
 Make sure the path above matches the one saved on step 1.
-  
+
 ### Build the C SDK
 
 If you upgraded CURL, make sure to set DYLD_LIBRARY_PATH each time you open a new shell.
-The next command assumes curl was saved on the path below mentioned ("keg install"). 
+The next command assumes curl was saved on the path below mentioned ("keg install").
 Make sure you use the path as informed by `brew` when curl was upgraded.
 
 ```
 export DYLD_LIBRARY_PATH="/usr/local/Cellar/curl/7.58.0/lib:$DYLD_LIBRARY_PATH"
-``` 
-
-Note: Any samples you built will not work until you configure them with a valid IoT Hub device connection string. For more information, see the [samples section](#samplecode) below.
+```
 
 Next you can either build the C SDK with CMake directly, or you can use CMake to generate an XCode project.
 
@@ -334,6 +349,16 @@ Also, you can build and run unit tests:
   > ctest -C "debug" -V
   > ```
 
+### Build a sample that uses different protocols, including over WebSockets
+
+By default the C-SDK will have web sockets enabled for AMQP and MQTT.  The sample **iothub_client\samples\iothub_ll_telemetry_sample** lets you specify the `protocol` variable.
+
+### Build a sample using a specific server root certificate
+
+By default all samples are built to handle a variety of server root certificates. If you would like to decrease the size of the sample, select the appropriate root cert by following the instructions [here](https://github.com/Azure/azure-iot-sdk-c/certs).
+
+> Note: Any samples you build will not work until you configure them with a valid IoT Hub device connection string. For more information, see the [samples section](#samplecode) below.
+
 #### Generate an XCode Project
 
 To generate the XCode project:
@@ -346,8 +371,8 @@ cmake -G Xcode ..
 ```
 All of the CMake options described above will work for XCode generation as well.
 
-When project generation completes you will see an XCode project file (.xcodeproj) under 
-the `cmake` folder. To build the SDK, open **cmake\azure_iot_sdks.xcodeproj** in XCode and 
+When project generation completes you will see an XCode project file (.xcodeproj) under
+the `cmake` folder. To build the SDK, open **cmake\azure_iot_sdks.xcodeproj** in XCode and
 use XCode's build and run features.
 
 **Note:** Until Mac updates the Curl library to version to 7.58 or greater it will also be necessary

--- a/doc/devbox_setup.md
+++ b/doc/devbox_setup.md
@@ -104,7 +104,7 @@ By default the C-SDK will have web sockets enabled for AMQP and MQTT.  The sampl
 
 ### Build a sample using a specific server root certificate
 
-By default all samples are built to handle a variety of server root certificates. If you would like to decrease the size of the sample, select the appropriate root cert by following the instructions [here](https://github.com/Azure/azure-iot-sdk-c/certs).
+By default all samples are built to handle a variety of server root CA certificates during TLS negotiation. If you would like to decrease the size of the sample, select the appropriate root certificate option during the cmake step. Follow the instructions [here](https://github.com/Azure/azure-iot-sdk-c/certs).
 
 > Note: Any samples you build will not work until you configure them with a valid IoT Hub device connection string. For more information, see the [samples section](#samplecode) below.
 
@@ -232,7 +232,7 @@ By default the C-SDK will have web sockets enabled for AMQP and MQTT.  The sampl
 
 ### Build a sample using a specific server root certificate
 
-By default all samples are built to handle a variety of server root certificates. If you would like to decrease the size of the sample, select the appropriate root cert by following the instructions [here](https://github.com/Azure/azure-iot-sdk-c/certs).
+By default all samples are built to handle a variety of server root CA certificates during TLS negotiation. If you would like to decrease the size of the sample, select the appropriate root certificate option during the cmake step. Follow the instructions [here](https://github.com/Azure/azure-iot-sdk-c/certs).
 
 > Note: Any samples you build will not work until you configure them with a valid IoT Hub device connection string. For more information, see the [samples section](#samplecode) below.
 
@@ -355,7 +355,7 @@ By default the C-SDK will have web sockets enabled for AMQP and MQTT.  The sampl
 
 ### Build a sample using a specific server root certificate
 
-By default all samples are built to handle a variety of server root certificates. If you would like to decrease the size of the sample, select the appropriate root cert by following the instructions [here](https://github.com/Azure/azure-iot-sdk-c/certs).
+By default all samples are built to handle a variety of server root CA certificates during TLS negotiation. If you would like to decrease the size of the sample, select the appropriate root certificate option during the cmake step. Follow the instructions [here](https://github.com/Azure/azure-iot-sdk-c/certs).
 
 > Note: Any samples you build will not work until you configure them with a valid IoT Hub device connection string. For more information, see the [samples section](#samplecode) below.
 


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [x] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

This change adds information to the documentation about the new DigiCert Global Root G3 certificate presented by IoT Hub Gateway V2 during TLS negotiation when ECC cipher suite is selected.  It also updates areas to mention server root certificate selection during the sample build process.