### PR TITLE
fileupload network interface support

### DIFF
--- a/doc/Iothub_sdk_options.md
+++ b/doc/Iothub_sdk_options.md
@@ -140,6 +140,7 @@ The following options are supported when performing file uploads.  They are decl
 | `"x509privatekey"`           | OPTION_X509_PRIVATE_KEY         | const char*       | Sets the private key for the RSA x509 certificate
 | `"TrustedCerts"`             | OPTION_TRUSTED_CERT             | const char*       | Azure Server certificate used to validate TLS connection to IoT Hub and Azure Storage
 | `"proxy_data"`               | OPTION_HTTP_PROXY               | [HTTP_PROXY_OPTIONS*][shared-util-options-h] | Http proxy data object used for proxy connection to IoT Hub and Azure Storage
+| `"network_interface_upload_to_blob"`| OPTION_NETWORK_INTERFACE_UPLOAD_TO_BLOB | const char* | Set the interface name to use as outgoing network interface for upload to blob.
 
 ## Batching and IoT Hub Client SDK
 

--- a/doc/Iothub_sdk_options.md
+++ b/doc/Iothub_sdk_options.md
@@ -141,6 +141,7 @@ The following options are supported when performing file uploads.  They are decl
 | `"TrustedCerts"`             | OPTION_TRUSTED_CERT             | const char*       | Azure Server certificate used to validate TLS connection to IoT Hub and Azure Storage
 | `"proxy_data"`               | OPTION_HTTP_PROXY               | [HTTP_PROXY_OPTIONS*][shared-util-options-h] | Http proxy data object used for proxy connection to IoT Hub and Azure Storage
 | `"network_interface_upload_to_blob"`| OPTION_NETWORK_INTERFACE_UPLOAD_TO_BLOB | const char* | Set the interface name to use as outgoing network interface for upload to blob.
+NOTE: Not all HTTP clients support this option. It is currently only supported when using cURL.
 
 ## Batching and IoT Hub Client SDK
 

--- a/iothub_client/inc/internal/blob.h
+++ b/iothub_client/inc/internal/blob.h
@@ -56,10 +56,11 @@ MU_DEFINE_ENUM_WITHOUT_INVALID(BLOB_RESULT, BLOB_RESULT_VALUES)
 * @param  httpResponse      A BUFFER_HANDLE that receives the HTTP response from the server (available only when the return value is BLOB_OK)
 * @param  certificates      A null terminated string containing CA certificates to be used
 * @param    proxyOptions    A structure that contains optional web proxy information
+* @param  curl_interface    A null terminated string containing the network interface
 *
 * @return    A @c BLOB_RESULT. BLOB_OK means the blob has been uploaded successfully. Any other value indicates an error
 */
-MOCKABLE_FUNCTION(, BLOB_RESULT, Blob_UploadMultipleBlocksFromSasUri, const char*, SASURI, IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_CALLBACK_EX, getDataCallbackEx, void*, context, unsigned int*, httpStatus, BUFFER_HANDLE, httpResponse, const char*, certificates, HTTP_PROXY_OPTIONS*, proxyOptions)
+MOCKABLE_FUNCTION(, BLOB_RESULT, Blob_UploadMultipleBlocksFromSasUri, const char*, SASURI, IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_CALLBACK_EX, getDataCallbackEx, void*, context, unsigned int*, httpStatus, BUFFER_HANDLE, httpResponse, const char*, certificates, HTTP_PROXY_OPTIONS*, proxyOptions, const char*, curl_interface)
 
 /**
 * @brief  Synchronously uploads a byte array as a new block to blob storage

--- a/iothub_client/inc/internal/blob.h
+++ b/iothub_client/inc/internal/blob.h
@@ -56,11 +56,11 @@ MU_DEFINE_ENUM_WITHOUT_INVALID(BLOB_RESULT, BLOB_RESULT_VALUES)
 * @param  httpResponse      A BUFFER_HANDLE that receives the HTTP response from the server (available only when the return value is BLOB_OK)
 * @param  certificates      A null terminated string containing CA certificates to be used
 * @param    proxyOptions    A structure that contains optional web proxy information
-* @param  curl_interface    A null terminated string containing the network interface
+* @param  networkInterface    An optional null terminated string containing the network interface
 *
 * @return    A @c BLOB_RESULT. BLOB_OK means the blob has been uploaded successfully. Any other value indicates an error
 */
-MOCKABLE_FUNCTION(, BLOB_RESULT, Blob_UploadMultipleBlocksFromSasUri, const char*, SASURI, IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_CALLBACK_EX, getDataCallbackEx, void*, context, unsigned int*, httpStatus, BUFFER_HANDLE, httpResponse, const char*, certificates, HTTP_PROXY_OPTIONS*, proxyOptions, const char*, curl_interface)
+MOCKABLE_FUNCTION(, BLOB_RESULT, Blob_UploadMultipleBlocksFromSasUri, const char*, SASURI, IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_CALLBACK_EX, getDataCallbackEx, void*, context, unsigned int*, httpStatus, BUFFER_HANDLE, httpResponse, const char*, certificates, HTTP_PROXY_OPTIONS*, proxyOptions, const char*, networkInterface)
 
 /**
 * @brief  Synchronously uploads a byte array as a new block to blob storage

--- a/iothub_client/inc/iothub_client_options.h
+++ b/iothub_client/inc/iothub_client_options.h
@@ -43,6 +43,11 @@ extern "C"
     /* DEPRECATED:: OPTION_MESSAGE_TIMEOUT is DEPRECATED! Use OPTION_SERVICE_SIDE_KEEP_ALIVE_FREQ_SECS for AMQP; MQTT has no option available. OPTION_MESSAGE_TIMEOUT legacy variable will be kept for back-compat.  */
     static STATIC_VAR_UNUSED const char* OPTION_MESSAGE_TIMEOUT = "messageTimeout";
     static STATIC_VAR_UNUSED const char* OPTION_BLOB_UPLOAD_TIMEOUT_SECS = "blob_upload_timeout_secs";
+
+    /*
+    * @brief    Set the interface name to use as outgoing network interface for upload to blob.
+    */
+    static STATIC_VAR_UNUSED const char* const OPTION_NETWORK_INTERFACE_UPLOAD_TO_BLOB = "network_interface_upload_to_blob";
     static STATIC_VAR_UNUSED const char* OPTION_PRODUCT_INFO = "product_info";
 
     /*

--- a/iothub_client/inc/iothub_client_options.h
+++ b/iothub_client/inc/iothub_client_options.h
@@ -46,6 +46,7 @@ extern "C"
 
     /*
     * @brief    Set the interface name to use as outgoing network interface for upload to blob.
+    * NOTE: Not all HTTP clients support this option. It is currently only supported when using cURL.
     */
     static STATIC_VAR_UNUSED const char* const OPTION_NETWORK_INTERFACE_UPLOAD_TO_BLOB = "network_interface_upload_to_blob";
     static STATIC_VAR_UNUSED const char* OPTION_PRODUCT_INFO = "product_info";

--- a/iothub_client/src/blob.c
+++ b/iothub_client/src/blob.c
@@ -301,7 +301,7 @@ static BLOB_RESULT SendBlockIdList(HTTPAPIEX_HANDLE httpApiExHandle, const char*
 }
 
 
-BLOB_RESULT Blob_UploadMultipleBlocksFromSasUri(const char* SASURI, IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_CALLBACK_EX getDataCallbackEx, void* context, unsigned int* httpStatus, BUFFER_HANDLE httpResponse, const char* certificates, HTTP_PROXY_OPTIONS *proxyOptions)
+BLOB_RESULT Blob_UploadMultipleBlocksFromSasUri(const char* SASURI, IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_CALLBACK_EX getDataCallbackEx, void* context, unsigned int* httpStatus, BUFFER_HANDLE httpResponse, const char* certificates, HTTP_PROXY_OPTIONS *proxyOptions, const char* curl_interface)
 {
     BLOB_RESULT result;
     const char* hostnameBegin;
@@ -366,6 +366,11 @@ BLOB_RESULT Blob_UploadMultipleBlocksFromSasUri(const char* SASURI, IOTHUB_CLIEN
                 else if ((proxyOptions != NULL && proxyOptions->host_address != NULL) && HTTPAPIEX_SetOption(httpApiExHandle, OPTION_HTTP_PROXY, proxyOptions) == HTTPAPIEX_ERROR)
                 {
                     LogError("failure in setting proxy options");
+                    result = BLOB_ERROR;
+                }
+                else if (curl_interface != NULL && HTTPAPIEX_SetOption(httpApiExHandle, OPTION_CURL_INTERFACE, curl_interface) == HTTPAPIEX_ERROR)
+                {
+                    LogError("failure in setting network interface");
                     result = BLOB_ERROR;
                 }
                 /*Codes_SRS_BLOB_02_028: [ Blob_UploadMultipleBlocksFromSasUri shall construct an XML string with the following content: ]*/

--- a/iothub_client/src/blob.c
+++ b/iothub_client/src/blob.c
@@ -301,7 +301,7 @@ static BLOB_RESULT SendBlockIdList(HTTPAPIEX_HANDLE httpApiExHandle, const char*
 }
 
 
-BLOB_RESULT Blob_UploadMultipleBlocksFromSasUri(const char* SASURI, IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_CALLBACK_EX getDataCallbackEx, void* context, unsigned int* httpStatus, BUFFER_HANDLE httpResponse, const char* certificates, HTTP_PROXY_OPTIONS *proxyOptions, const char* curl_interface)
+BLOB_RESULT Blob_UploadMultipleBlocksFromSasUri(const char* SASURI, IOTHUB_CLIENT_FILE_UPLOAD_GET_DATA_CALLBACK_EX getDataCallbackEx, void* context, unsigned int* httpStatus, BUFFER_HANDLE httpResponse, const char* certificates, HTTP_PROXY_OPTIONS *proxyOptions, const char* networkInterface)
 {
     BLOB_RESULT result;
     const char* hostnameBegin;
@@ -368,7 +368,7 @@ BLOB_RESULT Blob_UploadMultipleBlocksFromSasUri(const char* SASURI, IOTHUB_CLIEN
                     LogError("failure in setting proxy options");
                     result = BLOB_ERROR;
                 }
-                else if (curl_interface != NULL && HTTPAPIEX_SetOption(httpApiExHandle, OPTION_CURL_INTERFACE, curl_interface) == HTTPAPIEX_ERROR)
+                else if ((networkInterface != NULL) && HTTPAPIEX_SetOption(httpApiExHandle, OPTION_CURL_INTERFACE, networkInterface) == HTTPAPIEX_ERROR)
                 {
                     LogError("failure in setting network interface");
                     result = BLOB_ERROR;

--- a/iothub_client/src/iothub_client_core_ll.c
+++ b/iothub_client/src/iothub_client_core_ll.c
@@ -2329,7 +2329,7 @@ IOTHUB_CLIENT_RESULT IoTHubClientCore_LL_SetOption(IOTHUB_CLIENT_CORE_LL_HANDLE 
                 result = IOTHUB_CLIENT_OK;
             }
         }
-        else if ((strcmp(optionName, OPTION_BLOB_UPLOAD_TIMEOUT_SECS) == 0) || (strcmp(optionName, OPTION_CURL_VERBOSE) == 0))
+        else if ((strcmp(optionName, OPTION_BLOB_UPLOAD_TIMEOUT_SECS) == 0) || (strcmp(optionName, OPTION_CURL_VERBOSE) == 0) || (strcmp(optionName, OPTION_CURL_INTERFACE) == 0))
         {
 #ifndef DONT_USE_UPLOADTOBLOB
             // This option just gets passed down into IoTHubClientCore_LL_UploadToBlob

--- a/iothub_client/src/iothub_client_core_ll.c
+++ b/iothub_client/src/iothub_client_core_ll.c
@@ -2329,7 +2329,7 @@ IOTHUB_CLIENT_RESULT IoTHubClientCore_LL_SetOption(IOTHUB_CLIENT_CORE_LL_HANDLE 
                 result = IOTHUB_CLIENT_OK;
             }
         }
-        else if ((strcmp(optionName, OPTION_BLOB_UPLOAD_TIMEOUT_SECS) == 0) || (strcmp(optionName, OPTION_CURL_VERBOSE) == 0) || (strcmp(optionName, OPTION_CURL_INTERFACE) == 0))
+        else if ((strcmp(optionName, OPTION_BLOB_UPLOAD_TIMEOUT_SECS) == 0) || (strcmp(optionName, OPTION_CURL_VERBOSE) == 0) || (strcmp(optionName, OPTION_NETWORK_INTERFACE_UPLOAD_TO_BLOB) == 0))
         {
 #ifndef DONT_USE_UPLOADTOBLOB
             // This option just gets passed down into IoTHubClientCore_LL_UploadToBlob

--- a/iothub_client/src/iothub_client_ll_uploadtoblob.c
+++ b/iothub_client/src/iothub_client_ll_uploadtoblob.c
@@ -700,10 +700,6 @@ IOTHUB_CLIENT_RESULT IoTHubClient_LL_UploadMultipleBlocksToBlob_Impl(IOTHUB_CLIE
                 (void)HTTPAPIEX_SetOption(iotHubHttpApiExHandle, OPTION_CURL_VERBOSE, &curl_verbose);
             }
 
-            if (upload_data->networkInterface != NULL)
-            {
-                (void)HTTPAPIEX_SetOption(iotHubHttpApiExHandle, OPTION_CURL_INTERFACE, upload_data->networkInterface);
-            }
             /*transmit the x509certificate and x509privatekey*/
             /*Codes_SRS_IOTHUBCLIENT_LL_02_106: [ - x509certificate and x509privatekey saved options shall be passed on the HTTPAPIEX_SetOption ]*/
             if ((upload_data->cred_type == IOTHUB_CREDENTIAL_TYPE_X509 || upload_data->cred_type == IOTHUB_CREDENTIAL_TYPE_X509_ECC) &&

--- a/iothub_client/src/iothub_client_ll_uploadtoblob.c
+++ b/iothub_client/src/iothub_client_ll_uploadtoblob.c
@@ -700,213 +700,221 @@ IOTHUB_CLIENT_RESULT IoTHubClient_LL_UploadMultipleBlocksToBlob_Impl(IOTHUB_CLIE
                 (void)HTTPAPIEX_SetOption(iotHubHttpApiExHandle, OPTION_CURL_VERBOSE, &curl_verbose);
             }
 
-            /*transmit the x509certificate and x509privatekey*/
-            /*Codes_SRS_IOTHUBCLIENT_LL_02_106: [ - x509certificate and x509privatekey saved options shall be passed on the HTTPAPIEX_SetOption ]*/
-            if ((upload_data->cred_type == IOTHUB_CREDENTIAL_TYPE_X509 || upload_data->cred_type == IOTHUB_CREDENTIAL_TYPE_X509_ECC) &&
-                ((HTTPAPIEX_SetOption(iotHubHttpApiExHandle, OPTION_X509_CERT, upload_data->credentials.x509_credentials.x509certificate) != HTTPAPIEX_OK) ||
-                (HTTPAPIEX_SetOption(iotHubHttpApiExHandle, OPTION_X509_PRIVATE_KEY, upload_data->credentials.x509_credentials.x509privatekey) != HTTPAPIEX_OK))
-                )
+            if ((upload_data->networkInterface) != NULL && (HTTPAPIEX_SetOption(iotHubHttpApiExHandle, OPTION_CURL_INTERFACE, upload_data->networkInterface) != HTTPAPIEX_OK))
             {
-                LogError("unable to HTTPAPIEX_SetOption for x509 certificate");
+                LogError("unable to set networkInteface!");
                 result = IOTHUB_CLIENT_ERROR;
             }
             else
             {
-                /*Codes_SRS_IOTHUBCLIENT_LL_02_111: [ If certificates is non-NULL then certificates shall be passed to HTTPAPIEX_SetOption with optionName TrustedCerts. ]*/
-                if ((upload_data->certificates != NULL) && (HTTPAPIEX_SetOption(iotHubHttpApiExHandle, OPTION_TRUSTED_CERT, upload_data->certificates) != HTTPAPIEX_OK))
+                /*transmit the x509certificate and x509privatekey*/
+                /*Codes_SRS_IOTHUBCLIENT_LL_02_106: [ - x509certificate and x509privatekey saved options shall be passed on the HTTPAPIEX_SetOption ]*/
+                if ((upload_data->cred_type == IOTHUB_CREDENTIAL_TYPE_X509 || upload_data->cred_type == IOTHUB_CREDENTIAL_TYPE_X509_ECC) &&
+                    ((HTTPAPIEX_SetOption(iotHubHttpApiExHandle, OPTION_X509_CERT, upload_data->credentials.x509_credentials.x509certificate) != HTTPAPIEX_OK) ||
+                    (HTTPAPIEX_SetOption(iotHubHttpApiExHandle, OPTION_X509_PRIVATE_KEY, upload_data->credentials.x509_credentials.x509privatekey) != HTTPAPIEX_OK))
+                    )
                 {
-                    LogError("unable to set TrustedCerts!");
+                    LogError("unable to HTTPAPIEX_SetOption for x509 certificate");
                     result = IOTHUB_CLIENT_ERROR;
                 }
                 else
                 {
-
-                    if (upload_data->http_proxy_options.host_address != NULL)
+                    /*Codes_SRS_IOTHUBCLIENT_LL_02_111: [ If certificates is non-NULL then certificates shall be passed to HTTPAPIEX_SetOption with optionName TrustedCerts. ]*/
+                    if ((upload_data->certificates != NULL) && (HTTPAPIEX_SetOption(iotHubHttpApiExHandle, OPTION_TRUSTED_CERT, upload_data->certificates) != HTTPAPIEX_OK))
                     {
-                        HTTP_PROXY_OPTIONS proxy_options;
-                        proxy_options = upload_data->http_proxy_options;
+                        LogError("unable to set TrustedCerts!");
+                        result = IOTHUB_CLIENT_ERROR;
+                    }
+                    else
+                    {
 
-                        if (HTTPAPIEX_SetOption(iotHubHttpApiExHandle, OPTION_HTTP_PROXY, &proxy_options) != HTTPAPIEX_OK)
+                        if (upload_data->http_proxy_options.host_address != NULL)
                         {
-                            LogError("unable to set http proxy!");
-                            result = IOTHUB_CLIENT_ERROR;
+                            HTTP_PROXY_OPTIONS proxy_options;
+                            proxy_options = upload_data->http_proxy_options;
+
+                            if (HTTPAPIEX_SetOption(iotHubHttpApiExHandle, OPTION_HTTP_PROXY, &proxy_options) != HTTPAPIEX_OK)
+                            {
+                                LogError("unable to set http proxy!");
+                                result = IOTHUB_CLIENT_ERROR;
+                            }
+                            else
+                            {
+                                result = IOTHUB_CLIENT_OK;
+                            }
                         }
                         else
                         {
                             result = IOTHUB_CLIENT_OK;
                         }
-                    }
-                    else
-                    {
-                        result = IOTHUB_CLIENT_OK;
-                    }
 
-                    if (result != IOTHUB_CLIENT_ERROR)
-                    {
-                        STRING_HANDLE sasUri;
-                        STRING_HANDLE correlationId;
-                        if ((correlationId = STRING_new()) == NULL)
+                        if (result != IOTHUB_CLIENT_ERROR)
                         {
-                            LogError("unable to STRING_new");
-                            result = IOTHUB_CLIENT_ERROR;
-                        }
-                        else if ((sasUri = STRING_new()) == NULL)
-                        {
-                            LogError("unable to create sas uri");
-                            result = IOTHUB_CLIENT_ERROR;
-                            STRING_delete(correlationId);
-                        }
-                        else
-                        {
-                            /*Codes_SRS_IOTHUBCLIENT_LL_02_070: [ IoTHubClient_LL_UploadMultipleBlocksToBlob(Ex) shall create request HTTP headers. ]*/
-                            HTTP_HEADERS_HANDLE requestHttpHeaders = HTTPHeaders_Alloc(); /*these are build by step 1 and used by step 3 too*/
-                            if (requestHttpHeaders == NULL)
+                            STRING_HANDLE sasUri;
+                            STRING_HANDLE correlationId;
+                            if ((correlationId = STRING_new()) == NULL)
                             {
-                                LogError("unable to HTTPHeaders_Alloc");
+                                LogError("unable to STRING_new");
                                 result = IOTHUB_CLIENT_ERROR;
+                            }
+                            else if ((sasUri = STRING_new()) == NULL)
+                            {
+                                LogError("unable to create sas uri");
+                                result = IOTHUB_CLIENT_ERROR;
+                                STRING_delete(correlationId);
                             }
                             else
                             {
-                                /*do step 1*/
-                                if (IoTHubClient_LL_UploadToBlob_step1and2(upload_data, iotHubHttpApiExHandle, requestHttpHeaders, destinationFileName, correlationId, sasUri) != 0)
+                                /*Codes_SRS_IOTHUBCLIENT_LL_02_070: [ IoTHubClient_LL_UploadMultipleBlocksToBlob(Ex) shall create request HTTP headers. ]*/
+                                HTTP_HEADERS_HANDLE requestHttpHeaders = HTTPHeaders_Alloc(); /*these are build by step 1 and used by step 3 too*/
+                                if (requestHttpHeaders == NULL)
                                 {
-                                    LogError("error in IoTHubClient_LL_UploadToBlob_step1");
+                                    LogError("unable to HTTPHeaders_Alloc");
                                     result = IOTHUB_CLIENT_ERROR;
                                 }
                                 else
                                 {
-                                    /*do step 2.*/
-
-                                    unsigned int httpResponse;
-                                    BUFFER_HANDLE responseToIoTHub = BUFFER_new();
-                                    if (responseToIoTHub == NULL)
+                                    /*do step 1*/
+                                    if (IoTHubClient_LL_UploadToBlob_step1and2(upload_data, iotHubHttpApiExHandle, requestHttpHeaders, destinationFileName, correlationId, sasUri) != 0)
                                     {
+                                        LogError("error in IoTHubClient_LL_UploadToBlob_step1");
                                         result = IOTHUB_CLIENT_ERROR;
-                                        LogError("unable to BUFFER_new");
                                     }
                                     else
                                     {
-                                        /*Codes_SRS_IOTHUBCLIENT_LL_02_083: [ IoTHubClient_LL_UploadMultipleBlocksToBlob(Ex) shall call Blob_UploadFromSasUri and capture the HTTP return code and HTTP body. ]*/
-                                        BLOB_RESULT uploadMultipleBlocksResult = Blob_UploadMultipleBlocksFromSasUri(STRING_c_str(sasUri), getDataCallbackEx, context, &httpResponse, responseToIoTHub, upload_data->certificates, &(upload_data->http_proxy_options), upload_data->networkInterface);
-                                        if (uploadMultipleBlocksResult == BLOB_ABORTED)
-                                        {
-                                            /*Codes_SRS_IOTHUBCLIENT_LL_99_008: [ If step 2 is aborted by the client, then the HTTP message body shall look like:  ]*/
-                                            LogInfo("Blob_UploadFromSasUri aborted file upload");
+                                        /*do step 2.*/
 
-                                            STRING_HANDLE aborted_response = STRING_construct_sprintf(RESPONSE_BODY_FORMAT,
-                                                                                        STRING_c_str(correlationId),
-                                                                                        RESPONSE_BODY_ERROR_BOOLEAN_STRING,
-                                                                                        RESPONSE_BODY_ERROR_RETURN_CODE,
-                                                                                        RESPONSE_BODY_ABORTED_MESSAGE);
-                                            if(aborted_response == NULL)
-                                            {
-                                                LogError("STRING_construct_sprintf failed");
-                                                result = IOTHUB_CLIENT_ERROR;
-                                            }
-                                            else
-                                            {
-                                                size_t response_length = STRING_length(aborted_response);
-                                                if (BUFFER_build(responseToIoTHub, (const unsigned char*)STRING_c_str(aborted_response), response_length) == 0)
-                                                {
-                                                    if (IoTHubClient_LL_UploadToBlob_step3(upload_data, iotHubHttpApiExHandle, requestHttpHeaders, responseToIoTHub) != 0)
-                                                    {
-                                                        LogError("IoTHubClient_LL_UploadToBlob_step3 failed");
-                                                        result = IOTHUB_CLIENT_ERROR;
-                                                    }
-                                                    else
-                                                    {
-                                                        /*Codes_SRS_IOTHUBCLIENT_LL_99_009: [ If step 2 is aborted by the client and if step 3 succeeds, then `IoTHubClient_LL_UploadMultipleBlocksToBlob(Ex)` shall return `IOTHUB_CLIENT_OK`. ] */
-                                                        result = IOTHUB_CLIENT_OK;
-                                                    }
-                                                }
-                                                else
-                                                {
-                                                    LogError("Unable to BUFFER_build, can't perform IoTHubClient_LL_UploadToBlob_step3");
-                                                    result = IOTHUB_CLIENT_ERROR;
-                                                }
-                                                STRING_delete(aborted_response);
-                                            }
-                                        }
-                                        else if (uploadMultipleBlocksResult != BLOB_OK)
+                                        unsigned int httpResponse;
+                                        BUFFER_HANDLE responseToIoTHub = BUFFER_new();
+                                        if (responseToIoTHub == NULL)
                                         {
-                                            /*Codes_SRS_IOTHUBCLIENT_LL_02_084: [ If Blob_UploadFromSasUri fails then IoTHubClient_LL_UploadMultipleBlocksToBlob(Ex) shall fail and return IOTHUB_CLIENT_ERROR. ]*/
-                                            LogError("unable to Blob_UploadFromSasUri");
-
-                                            /*do step 3*/ /*try*/
-                                            /*Codes_SRS_IOTHUBCLIENT_LL_02_091: [ If step 2 fails without establishing an HTTP dialogue, then the HTTP message body shall look like: ]*/
-                                            STRING_HANDLE failed_response = STRING_construct_sprintf(RESPONSE_BODY_FORMAT, 
-                                                                                        STRING_c_str(correlationId), 
-                                                                                        RESPONSE_BODY_ERROR_BOOLEAN_STRING,
-                                                                                        RESPONSE_BODY_ERROR_RETURN_CODE,
-                                                                                        RESPONSE_BODY_FAILED_MESSAGE);
-                                            if(failed_response == NULL)
-                                            {
-                                                LogError("STRING_construct_sprintf failed");
-                                                result = IOTHUB_CLIENT_ERROR;
-                                            }
-                                            else
-                                            {
-                                                size_t response_length = STRING_length(failed_response);
-                                                if (BUFFER_build(responseToIoTHub, (const unsigned char*)STRING_c_str(failed_response), response_length) == 0)
-                                                {
-                                                    if (IoTHubClient_LL_UploadToBlob_step3(upload_data, iotHubHttpApiExHandle, requestHttpHeaders, responseToIoTHub) != 0)
-                                                    {
-                                                        LogError("IoTHubClient_LL_UploadToBlob_step3 failed");
-                                                    }
-                                                }
-                                                STRING_delete(failed_response);
-                                                result = IOTHUB_CLIENT_ERROR;
-                                            }
+                                            result = IOTHUB_CLIENT_ERROR;
+                                            LogError("unable to BUFFER_new");
                                         }
                                         else
                                         {
-                                            /*must make a json*/
-                                            unsigned char * response = BUFFER_u_char(responseToIoTHub);
-                                            STRING_HANDLE req_string;
-                                            req_string = STRING_construct_sprintf(RESPONSE_BODY_FORMAT,
-                                                                                        STRING_c_str(correlationId),
-                                                                                        ((httpResponse < 300) ? "true" : "false"),
-                                                                                        httpResponse, 
-                                                                                        (response == NULL ? (const unsigned char*)"" : response));
-                                            if (req_string == NULL)
+                                            /*Codes_SRS_IOTHUBCLIENT_LL_02_083: [ IoTHubClient_LL_UploadMultipleBlocksToBlob(Ex) shall call Blob_UploadFromSasUri and capture the HTTP return code and HTTP body. ]*/
+                                            BLOB_RESULT uploadMultipleBlocksResult = Blob_UploadMultipleBlocksFromSasUri(STRING_c_str(sasUri), getDataCallbackEx, context, &httpResponse, responseToIoTHub, upload_data->certificates, &(upload_data->http_proxy_options), upload_data->networkInterface);
+                                            if (uploadMultipleBlocksResult == BLOB_ABORTED)
                                             {
-                                                LogError("Failure constructing string");
-                                                result = IOTHUB_CLIENT_ERROR;
-                                            }
-                                            else
-                                            {
-                                                /*do again snprintf*/
-                                                BUFFER_HANDLE toBeTransmitted = NULL;
-                                                size_t req_string_len = STRING_length(req_string);
-                                                const char* required_string = STRING_c_str(req_string);
-                                                if ((toBeTransmitted = BUFFER_create((const unsigned char*)required_string, req_string_len)) == NULL)
+                                                /*Codes_SRS_IOTHUBCLIENT_LL_99_008: [ If step 2 is aborted by the client, then the HTTP message body shall look like:  ]*/
+                                                LogInfo("Blob_UploadFromSasUri aborted file upload");
+
+                                                STRING_HANDLE aborted_response = STRING_construct_sprintf(RESPONSE_BODY_FORMAT,
+                                                                                            STRING_c_str(correlationId),
+                                                                                            RESPONSE_BODY_ERROR_BOOLEAN_STRING,
+                                                                                            RESPONSE_BODY_ERROR_RETURN_CODE,
+                                                                                            RESPONSE_BODY_ABORTED_MESSAGE);
+                                                if(aborted_response == NULL)
                                                 {
-                                                    LogError("unable to BUFFER_create");
+                                                    LogError("STRING_construct_sprintf failed");
                                                     result = IOTHUB_CLIENT_ERROR;
                                                 }
                                                 else
                                                 {
-                                                    if (IoTHubClient_LL_UploadToBlob_step3(upload_data, iotHubHttpApiExHandle, requestHttpHeaders, toBeTransmitted) != 0)
+                                                    size_t response_length = STRING_length(aborted_response);
+                                                    if (BUFFER_build(responseToIoTHub, (const unsigned char*)STRING_c_str(aborted_response), response_length) == 0)
                                                     {
-                                                        LogError("IoTHubClient_LL_UploadToBlob_step3 failed");
+                                                        if (IoTHubClient_LL_UploadToBlob_step3(upload_data, iotHubHttpApiExHandle, requestHttpHeaders, responseToIoTHub) != 0)
+                                                        {
+                                                            LogError("IoTHubClient_LL_UploadToBlob_step3 failed");
+                                                            result = IOTHUB_CLIENT_ERROR;
+                                                        }
+                                                        else
+                                                        {
+                                                            /*Codes_SRS_IOTHUBCLIENT_LL_99_009: [ If step 2 is aborted by the client and if step 3 succeeds, then `IoTHubClient_LL_UploadMultipleBlocksToBlob(Ex)` shall return `IOTHUB_CLIENT_OK`. ] */
+                                                            result = IOTHUB_CLIENT_OK;
+                                                        }
+                                                    }
+                                                    else
+                                                    {
+                                                        LogError("Unable to BUFFER_build, can't perform IoTHubClient_LL_UploadToBlob_step3");
+                                                        result = IOTHUB_CLIENT_ERROR;
+                                                    }
+                                                    STRING_delete(aborted_response);
+                                                }
+                                            }
+                                            else if (uploadMultipleBlocksResult != BLOB_OK)
+                                            {
+                                                /*Codes_SRS_IOTHUBCLIENT_LL_02_084: [ If Blob_UploadFromSasUri fails then IoTHubClient_LL_UploadMultipleBlocksToBlob(Ex) shall fail and return IOTHUB_CLIENT_ERROR. ]*/
+                                                LogError("unable to Blob_UploadFromSasUri");
+
+                                                /*do step 3*/ /*try*/
+                                                /*Codes_SRS_IOTHUBCLIENT_LL_02_091: [ If step 2 fails without establishing an HTTP dialogue, then the HTTP message body shall look like: ]*/
+                                                STRING_HANDLE failed_response = STRING_construct_sprintf(RESPONSE_BODY_FORMAT, 
+                                                                                            STRING_c_str(correlationId), 
+                                                                                            RESPONSE_BODY_ERROR_BOOLEAN_STRING,
+                                                                                            RESPONSE_BODY_ERROR_RETURN_CODE,
+                                                                                            RESPONSE_BODY_FAILED_MESSAGE);
+                                                if(failed_response == NULL)
+                                                {
+                                                    LogError("STRING_construct_sprintf failed");
+                                                    result = IOTHUB_CLIENT_ERROR;
+                                                }
+                                                else
+                                                {
+                                                    size_t response_length = STRING_length(failed_response);
+                                                    if (BUFFER_build(responseToIoTHub, (const unsigned char*)STRING_c_str(failed_response), response_length) == 0)
+                                                    {
+                                                        if (IoTHubClient_LL_UploadToBlob_step3(upload_data, iotHubHttpApiExHandle, requestHttpHeaders, responseToIoTHub) != 0)
+                                                        {
+                                                            LogError("IoTHubClient_LL_UploadToBlob_step3 failed");
+                                                        }
+                                                    }
+                                                    STRING_delete(failed_response);
+                                                    result = IOTHUB_CLIENT_ERROR;
+                                                }
+                                            }
+                                            else
+                                            {
+                                                /*must make a json*/
+                                                unsigned char * response = BUFFER_u_char(responseToIoTHub);
+                                                STRING_HANDLE req_string;
+                                                req_string = STRING_construct_sprintf(RESPONSE_BODY_FORMAT,
+                                                                                            STRING_c_str(correlationId),
+                                                                                            ((httpResponse < 300) ? "true" : "false"),
+                                                                                            httpResponse, 
+                                                                                            (response == NULL ? (const unsigned char*)"" : response));
+                                                if (req_string == NULL)
+                                                {
+                                                    LogError("Failure constructing string");
+                                                    result = IOTHUB_CLIENT_ERROR;
+                                                }
+                                                else
+                                                {
+                                                    /*do again snprintf*/
+                                                    BUFFER_HANDLE toBeTransmitted = NULL;
+                                                    size_t req_string_len = STRING_length(req_string);
+                                                    const char* required_string = STRING_c_str(req_string);
+                                                    if ((toBeTransmitted = BUFFER_create((const unsigned char*)required_string, req_string_len)) == NULL)
+                                                    {
+                                                        LogError("unable to BUFFER_create");
                                                         result = IOTHUB_CLIENT_ERROR;
                                                     }
                                                     else
                                                     {
-                                                        result = (httpResponse < 300) ? IOTHUB_CLIENT_OK : IOTHUB_CLIENT_ERROR;
+                                                        if (IoTHubClient_LL_UploadToBlob_step3(upload_data, iotHubHttpApiExHandle, requestHttpHeaders, toBeTransmitted) != 0)
+                                                        {
+                                                            LogError("IoTHubClient_LL_UploadToBlob_step3 failed");
+                                                            result = IOTHUB_CLIENT_ERROR;
+                                                        }
+                                                        else
+                                                        {
+                                                            result = (httpResponse < 300) ? IOTHUB_CLIENT_OK : IOTHUB_CLIENT_ERROR;
+                                                        }
+                                                        BUFFER_delete(toBeTransmitted);
                                                     }
-                                                    BUFFER_delete(toBeTransmitted);
+                                                    STRING_delete(req_string);
                                                 }
-                                                STRING_delete(req_string);
                                             }
+                                            BUFFER_delete(responseToIoTHub);
                                         }
-                                        BUFFER_delete(responseToIoTHub);
                                     }
+                                    HTTPHeaders_Free(requestHttpHeaders);
                                 }
-                                HTTPHeaders_Free(requestHttpHeaders);
+                                STRING_delete(sasUri);
+                                STRING_delete(correlationId);
                             }
-                            STRING_delete(sasUri);
-                            STRING_delete(correlationId);
                         }
                     }
                 }

--- a/iothub_client/src/iothub_client_ll_uploadtoblob.c
+++ b/iothub_client/src/iothub_client_ll_uploadtoblob.c
@@ -83,7 +83,7 @@ typedef struct IOTHUB_CLIENT_LL_UPLOADTOBLOB_HANDLE_DATA_TAG
     HTTP_PROXY_OPTIONS http_proxy_options;
     UPOADTOBLOB_CURL_VERBOSITY curl_verbosity_level;
     size_t blob_upload_timeout_secs;
-    const char* curl_interface;
+    const char* networkInterface;
 }IOTHUB_CLIENT_LL_UPLOADTOBLOB_HANDLE_DATA;
 
 typedef struct BLOB_UPLOAD_CONTEXT_TAG
@@ -700,9 +700,9 @@ IOTHUB_CLIENT_RESULT IoTHubClient_LL_UploadMultipleBlocksToBlob_Impl(IOTHUB_CLIE
                 (void)HTTPAPIEX_SetOption(iotHubHttpApiExHandle, OPTION_CURL_VERBOSE, &curl_verbose);
             }
 
-            if (upload_data->curl_interface != NULL)
+            if (upload_data->networkInterface != NULL)
             {
-                (void)HTTPAPIEX_SetOption(iotHubHttpApiExHandle, OPTION_CURL_INTERFACE, upload_data->curl_interface);
+                (void)HTTPAPIEX_SetOption(iotHubHttpApiExHandle, OPTION_CURL_INTERFACE, upload_data->networkInterface);
             }
             /*transmit the x509certificate and x509privatekey*/
             /*Codes_SRS_IOTHUBCLIENT_LL_02_106: [ - x509certificate and x509privatekey saved options shall be passed on the HTTPAPIEX_SetOption ]*/
@@ -791,7 +791,7 @@ IOTHUB_CLIENT_RESULT IoTHubClient_LL_UploadMultipleBlocksToBlob_Impl(IOTHUB_CLIE
                                     else
                                     {
                                         /*Codes_SRS_IOTHUBCLIENT_LL_02_083: [ IoTHubClient_LL_UploadMultipleBlocksToBlob(Ex) shall call Blob_UploadFromSasUri and capture the HTTP return code and HTTP body. ]*/
-                                        BLOB_RESULT uploadMultipleBlocksResult = Blob_UploadMultipleBlocksFromSasUri(STRING_c_str(sasUri), getDataCallbackEx, context, &httpResponse, responseToIoTHub, upload_data->certificates, &(upload_data->http_proxy_options), upload_data->curl_interface);
+                                        BLOB_RESULT uploadMultipleBlocksResult = Blob_UploadMultipleBlocksFromSasUri(STRING_c_str(sasUri), getDataCallbackEx, context, &httpResponse, responseToIoTHub, upload_data->certificates, &(upload_data->http_proxy_options), upload_data->networkInterface);
                                         if (uploadMultipleBlocksResult == BLOB_ABORTED)
                                         {
                                             /*Codes_SRS_IOTHUBCLIENT_LL_99_008: [ If step 2 is aborted by the client, then the HTTP message body shall look like:  ]*/
@@ -991,9 +991,9 @@ void IoTHubClient_LL_UploadToBlob_Destroy(IOTHUB_CLIENT_LL_UPLOADTOBLOB_HANDLE h
         {
             free((char *)upload_data->http_proxy_options.password);
         }
-        if (upload_data->curl_interface != NULL)
+        if (upload_data->networkInterface != NULL)
         {
-            free((char*)upload_data->curl_interface);
+            free((char*)upload_data->networkInterface);
         }
         free(upload_data);
     }
@@ -1175,7 +1175,7 @@ IOTHUB_CLIENT_RESULT IoTHubClient_LL_UploadToBlob_SetOption(IOTHUB_CLIENT_LL_UPL
         {
             if (value == NULL)
             {
-                LogError("NULL is not a valid value for curl_interface option");
+                LogError("NULL is not a valid value for networkInterface option");
                 result = IOTHUB_CLIENT_INVALID_ARG;
             }
             else
@@ -1188,11 +1188,11 @@ IOTHUB_CLIENT_RESULT IoTHubClient_LL_UploadToBlob_SetOption(IOTHUB_CLIENT_LL_UPL
                 }
                 else
                 {
-                    if (upload_data->curl_interface != NULL)
+                    if (upload_data->networkInterface != NULL)
                     {
-                        free((char*)upload_data->curl_interface);
+                        free((char*)upload_data->networkInterface);
                     }
-                    upload_data->curl_interface = tempCopy;
+                    upload_data->networkInterface = tempCopy;
                     result = IOTHUB_CLIENT_OK;
                 }
             }

--- a/iothub_client/src/iothub_client_ll_uploadtoblob.c
+++ b/iothub_client/src/iothub_client_ll_uploadtoblob.c
@@ -81,9 +81,9 @@ typedef struct IOTHUB_CLIENT_LL_UPLOADTOBLOB_HANDLE_DATA_TAG
     
     char* certificates;
     HTTP_PROXY_OPTIONS http_proxy_options;
-    const char* curl_interface;
     UPOADTOBLOB_CURL_VERBOSITY curl_verbosity_level;
     size_t blob_upload_timeout_secs;
+    const char* curl_interface;
 }IOTHUB_CLIENT_LL_UPLOADTOBLOB_HANDLE_DATA;
 
 typedef struct BLOB_UPLOAD_CONTEXT_TAG
@@ -1171,11 +1171,11 @@ IOTHUB_CLIENT_RESULT IoTHubClient_LL_UploadToBlob_SetOption(IOTHUB_CLIENT_LL_UPL
             upload_data->blob_upload_timeout_secs = *(size_t*)value;
             result = IOTHUB_CLIENT_OK;
         }
-        else if (strcmp(optionName, OPTION_CURL_INTERFACE) == 0)
+        else if (strcmp(optionName, OPTION_NETWORK_INTERFACE_UPLOAD_TO_BLOB) == 0)
         {
             if (value == NULL)
             {
-                LogError("NULL is a not a valid value for curl_interface");
+                LogError("NULL is not a valid value for curl_interface option");
                 result = IOTHUB_CLIENT_INVALID_ARG;
             }
             else

--- a/iothub_client/tests/blob_ut/blob_ut.c
+++ b/iothub_client/tests/blob_ut/blob_ut.c
@@ -328,7 +328,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_with_NULL_SasUri_fails)
     ///arrange
 
     ///act
-    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri(NULL, FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL);
+    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri(NULL, FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_INVALID_ARG, result);
@@ -343,7 +343,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_with_NULL_getDataCallBack_and_
     ///arrange
 
     ///act
-    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri(TEST_VALID_SASURI_1, NULL, &context, &httpResponse, testValidBufferHandle, NULL, NULL);
+    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri(TEST_VALID_SASURI_1, NULL, &context, &httpResponse, testValidBufferHandle, NULL, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_INVALID_ARG, result);
@@ -415,7 +415,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_succeeds_when_HTTP_status_code
     set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
 
     ///act
-    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri(TEST_VALID_SASURI_1, FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL);
+    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri(TEST_VALID_SASURI_1, FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_OK, result);
@@ -488,7 +488,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_fails_when_HTTPAPIEX_ExecuteRe
     set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
 
     ///act
-    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri(TEST_VALID_SASURI_1, FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL);
+    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri(TEST_VALID_SASURI_1, FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_HTTP_ERROR, result);
@@ -521,7 +521,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_fails_when_BUFFER_create_fails
     }
 
     ///act
-    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri(TEST_VALID_SASURI_1, FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL);
+    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri(TEST_VALID_SASURI_1, FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -549,7 +549,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_fails_when_HTTPAPIEX_Create_fa
     set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
 
     ///act
-    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri(TEST_VALID_SASURI_1, FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL);
+    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri(TEST_VALID_SASURI_1, FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_ERROR, result);
@@ -574,7 +574,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_fails_when_malloc_fails)
     set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
 
     ///act
-    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri(TEST_VALID_SASURI_1, FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL);
+    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri(TEST_VALID_SASURI_1, FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_ERROR, result);
@@ -595,7 +595,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_when_SasUri_is_wrong_fails_1)
     set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
 
     ///act
-    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https:/h.h/doms", FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL); /*wrong format for protocol, notice it is actually http:\h.h\doms (missing a \ from http)*/
+    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https:/h.h/doms", FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL, NULL); /*wrong format for protocol, notice it is actually http:\h.h\doms (missing a \ from http)*/
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_INVALID_ARG, result);
@@ -616,7 +616,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_when_SasUri_is_wrong_fails_2)
     set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
 
     ///act
-    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h", FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL); /*there's no relative path here*/
+    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h", FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL, NULL); /*there's no relative path here*/
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_INVALID_ARG, result);
@@ -758,7 +758,7 @@ static void Blob_UploadMultipleBlocksFromSasUri_various_sizes_happy_path_Impl(HT
         set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
 
         ///act
-        BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, proxyOptions);
+        BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, proxyOptions, networkInterface);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -941,7 +941,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_various_sizes_with_certificate
         set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
 
         ///act
-        BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, "a", NULL);
+        BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, "a", NULL, NULL);
 
         ///assert
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1079,7 +1079,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_64MB_unhappy_paths)
 
             ///act
             context.toUpload = context.size; /* Reinit context */
-            BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL);
+            BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL, NULL);
 
             ///assert
             ASSERT_ARE_NOT_EQUAL(BLOB_RESULT, BLOB_OK, result, temp_str);
@@ -1219,12 +1219,13 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_64MB_with_certificate_and_netw
         {
 
             umock_c_negative_tests_fail_call(i);
+            const char* interfaceName = "eth0";
             char temp_str[128];
             sprintf(temp_str, "On failed call %lu", (unsigned long)i);
 
             ///act
             context.toUpload = context.size; /* Reinit context */
-            BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, "a", NULL);
+            BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, "a", NULL, interfaceName);
 
             ///assert
             ASSERT_ARE_NOT_EQUAL(BLOB_RESULT, BLOB_OK, result, temp_str);
@@ -1311,7 +1312,7 @@ TEST_FUNCTION(Blob_UploadFromSasUri_when_http_code_is_404_it_immediately_succeed
     set_expected_calls_for_Blob_UploadMultipleBlocksFromSasUri_cleanup();
 
     ///act
-    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL);
+    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetData_Callback, &context, &httpResponse, testValidBufferHandle, NULL, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1334,7 +1335,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_when_blockSize_too_big_fails)
     fakeContext.abortOnBlockNumber = -1;
 
     ///act
-    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetFakeData_Callback, &fakeContext, &httpResponse, testValidBufferHandle, NULL, NULL);
+    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetFakeData_Callback, &fakeContext, &httpResponse, testValidBufferHandle, NULL, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_INVALID_ARG, result);
@@ -1355,7 +1356,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_when_blockSize_is_4MB_succeeds
     fakeContext.abortOnBlockNumber = -1;
 
     ///act
-    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetFakeData_Callback, &fakeContext, &httpResponse, testValidBufferHandle, NULL, NULL);
+    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetFakeData_Callback, &fakeContext, &httpResponse, testValidBufferHandle, NULL, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_OK, result);
@@ -1376,7 +1377,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_when_blockCount_is_maximum_suc
     fakeContext.abortOnBlockNumber = -1;
 
     ///act
-    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetFakeData_Callback, &fakeContext, &httpResponse, testValidBufferHandle, NULL, NULL);
+    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetFakeData_Callback, &fakeContext, &httpResponse, testValidBufferHandle, NULL, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_OK, result);
@@ -1397,7 +1398,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_when_blockCount_is_one_over_ma
     fakeContext.abortOnBlockNumber = -1;
 
     ///act
-    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetFakeData_Callback, &fakeContext, &httpResponse, testValidBufferHandle, NULL, NULL);
+    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetFakeData_Callback, &fakeContext, &httpResponse, testValidBufferHandle, NULL, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_INVALID_ARG, result);
@@ -1418,7 +1419,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_returns_BLOB_ABORTED_when_call
     fakeContext.abortOnBlockNumber = 0;
 
     ///act
-    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetFakeData_Callback, &fakeContext, &httpResponse, testValidBufferHandle, NULL, NULL);
+    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetFakeData_Callback, &fakeContext, &httpResponse, testValidBufferHandle, NULL, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_ABORTED, result);
@@ -1439,7 +1440,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_returns_BLOB_ABORTED_when_call
     fakeContext.abortOnBlockNumber = 5;
 
     ///act
-    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetFakeData_Callback, &fakeContext, &httpResponse, testValidBufferHandle, NULL, NULL);
+    BLOB_RESULT result = Blob_UploadMultipleBlocksFromSasUri("https://h.h/something?a=b", FileUpload_GetFakeData_Callback, &fakeContext, &httpResponse, testValidBufferHandle, NULL, NULL, NULL);
 
     ///assert
     ASSERT_ARE_EQUAL(BLOB_RESULT, BLOB_ABORTED, result);

--- a/iothub_client/tests/blob_ut/blob_ut.c
+++ b/iothub_client/tests/blob_ut/blob_ut.c
@@ -625,7 +625,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_when_SasUri_is_wrong_fails_2)
     ///cleanup
 }
 
-static void Blob_UploadMultipleBlocksFromSasUri_various_sizes_happy_path_Impl(HTTP_PROXY_OPTIONS *proxyOptions)
+static void Blob_UploadMultipleBlocksFromSasUri_various_sizes_happy_path_Impl(HTTP_PROXY_OPTIONS *proxyOptions, const char * networkInterface)
 {
     /*the following sizes have been identified as "important to be tested*/
     /*1B, 4MB-1, 4MB, 4MB+1, 64MB, 64MB+1, 68MB-1, 68MB, 68MB+1*/
@@ -668,6 +668,11 @@ static void Blob_UploadMultipleBlocksFromSasUri_various_sizes_happy_path_Impl(HT
         if (proxyOptions != NULL)
         {
             STRICT_EXPECTED_CALL(HTTPAPIEX_SetOption(IGNORED_PTR_ARG, OPTION_HTTP_PROXY, proxyOptions));
+        }
+
+        if (networkInterface != NULL)
+        {
+            STRICT_EXPECTED_CALL(HTTPAPIEX_SetOption(IGNORED_PTR_ARG, OPTION_CURL_INTERFACE, networkInterface));
         }
         STRICT_EXPECTED_CALL(STRING_construct("<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<BlockList>")); /*this is starting to build the XML used in Put Block List operation*/
 
@@ -778,7 +783,7 @@ static void Blob_UploadMultipleBlocksFromSasUri_various_sizes_happy_path_Impl(HT
 TEST_FUNCTION(Blob_UploadFromSasUri_with_proxy_happy_path)
 {
     HTTP_PROXY_OPTIONS proxyOptions = { "a", 8888, NULL, NULL };
-    Blob_UploadMultipleBlocksFromSasUri_various_sizes_happy_path_Impl(&proxyOptions);
+    Blob_UploadMultipleBlocksFromSasUri_various_sizes_happy_path_Impl(&proxyOptions, NULL);
 }
 
 
@@ -799,10 +804,16 @@ TEST_FUNCTION(Blob_UploadFromSasUri_with_proxy_happy_path)
 /*Tests_SRS_BLOB_02_032: [ Otherwise, Blob_UploadMultipleBlocksFromSasUri shall succeed and return BLOB_OK. ]*/
 TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_various_sizes_happy_path)
 {
-    Blob_UploadMultipleBlocksFromSasUri_various_sizes_happy_path_Impl(NULL);
+    Blob_UploadMultipleBlocksFromSasUri_various_sizes_happy_path_Impl(NULL, NULL);
 }
 
 
+/*Tests_SRS_BLOB_02_033: [ Set network interface for upload to blob ]*/
+TEST_FUNCTION(Blob_UploadFromSasUri_with_network_interface)
+{
+    const char* networkInterface = "eth0";
+    Blob_UploadMultipleBlocksFromSasUri_various_sizes_happy_path_Impl(NULL, networkInterface);
+}
 
 /*Tests_SRS_BLOB_02_037: [ If certificates is non-NULL then Blob_UploadMultipleBlocksFromSasUri shall pass certificates to HTTPAPI_EX_HANDLE by calling HTTPAPIEX_SetOption with the option name "TrustedCerts". ]*/
 TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_various_sizes_with_certificates_happy_path)
@@ -1083,7 +1094,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_64MB_unhappy_paths)
 }
 
 /*Tests_SRS_BLOB_02_038: [ If HTTPAPIEX_SetOption fails then Blob_UploadMultipleBlocksFromSasUri shall fail and return BLOB_ERROR. ]*/
-TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_64MB_with_certificate_unhappy_paths)
+TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_64MB_with_certificate_and_network_interface_unhappy_paths)
 {
     size_t size = 64 * 1024 * 1024;
 
@@ -1109,6 +1120,7 @@ TEST_FUNCTION(Blob_UploadMultipleBlocksFromSasUri_64MB_with_certificate_unhappy_
 
     STRICT_EXPECTED_CALL(HTTPAPIEX_Create("h.h")); /*this is creating the httpapiex handle to storage (it is always the same host)*/
     STRICT_EXPECTED_CALL(HTTPAPIEX_SetOption(IGNORED_PTR_ARG, "TrustedCerts", IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(HTTPAPIEX_SetOption(IGNORED_PTR_ARG, OPTION_CURL_INTERFACE, IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(STRING_construct("<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<BlockList>")); /*this is starting to build the XML used in Put Block List operation*/
 
                                                                                                          /*uploading blocks (Put Block)*/

--- a/iothub_client/tests/iothubclient_ll_u2b_ut/iothub_client_ll_u2b_ut.c
+++ b/iothub_client/tests/iothubclient_ll_u2b_ut/iothub_client_ll_u2b_ut.c
@@ -1316,6 +1316,27 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_SetOption_x509_cert_succeeds)
     IoTHubClient_LL_UploadToBlob_Destroy(h);
 }
 
+TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_SetOption_Network_Interface)
+{
+    //arrange
+    setup_uploadtoblob_create_mocks(IOTHUB_CREDENTIAL_TYPE_X509);
+    IOTHUB_CLIENT_LL_UPLOADTOBLOB_HANDLE h = IoTHubClient_LL_UploadToBlob_Create(&TEST_CONFIG_SAS, TEST_AUTH_HANDLE);
+    umock_c_reset_all_calls();
+
+    STRICT_EXPECTED_CALL(mallocAndStrcpy_s(IGNORED_PTR_ARG, TEST_CERT));
+
+    const char* networkInterface = "eth0";
+    //act
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_LL_UploadToBlob_SetOption(h, OPTION_CURL_INTERFACE, networkInterface);
+
+    //assert
+    ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    //cleanup
+    IoTHubClient_LL_UploadToBlob_Destroy(h);
+}
+
 TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_SetOption_x509_cert_twice_succeeds)
 {
     //arrange

--- a/iothub_client/tests/iothubclient_ll_u2b_ut/iothub_client_ll_u2b_ut.c
+++ b/iothub_client/tests/iothubclient_ll_u2b_ut/iothub_client_ll_u2b_ut.c
@@ -732,7 +732,7 @@ static void setup_Blob_UploadMultipleBlocksFromSasUri_mocks(IOTHUB_CREDENTIAL_TY
     if (BLOB_OK != blob_result)
     {
         status_code = 404;
-        STRICT_EXPECTED_CALL(Blob_UploadMultipleBlocksFromSasUri(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        STRICT_EXPECTED_CALL(Blob_UploadMultipleBlocksFromSasUri(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
             .CopyOutArgumentBuffer_httpStatus(&status_code, sizeof(status_code))
             .SetReturn(blob_result);
         STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG));
@@ -746,7 +746,7 @@ static void setup_Blob_UploadMultipleBlocksFromSasUri_mocks(IOTHUB_CREDENTIAL_TY
     else
     {
         status_code = 200;
-        STRICT_EXPECTED_CALL(Blob_UploadMultipleBlocksFromSasUri(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
+        STRICT_EXPECTED_CALL(Blob_UploadMultipleBlocksFromSasUri(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
             .CopyOutArgumentBuffer_httpStatus(&status_code, sizeof(status_code)).CallCannotFail();
 
         if (null_buffer)
@@ -1323,11 +1323,11 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_SetOption_Network_Interface)
     IOTHUB_CLIENT_LL_UPLOADTOBLOB_HANDLE h = IoTHubClient_LL_UploadToBlob_Create(&TEST_CONFIG_SAS, TEST_AUTH_HANDLE);
     umock_c_reset_all_calls();
 
-    STRICT_EXPECTED_CALL(mallocAndStrcpy_s(IGNORED_PTR_ARG, TEST_CERT));
 
     const char* networkInterface = "eth0";
+    STRICT_EXPECTED_CALL(mallocAndStrcpy_s(IGNORED_PTR_ARG, networkInterface));
     //act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_LL_UploadToBlob_SetOption(h, OPTION_CURL_INTERFACE, networkInterface);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_LL_UploadToBlob_SetOption(h, OPTION_NETWORK_INTERFACE_UPLOAD_TO_BLOB, networkInterface);
 
     //assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);


### PR DESCRIPTION
Currently azure sdk does not support file upload through a specific network interface.
Adding the same as part of this PR.

Note : This PR address fix for following issue.
https://github.com/Azure/azure-iot-sdk-c/issues/1710
