### PR TITLE
[FuzzAMQP] heap-use-after-free on_cbs_put_token_complete_callback() iothubtransport_amqp_cbs_auth.c:173

### DIFF
--- a/iothub_client/src/iothubtransport_amqp_cbs_auth.c
+++ b/iothub_client/src/iothubtransport_amqp_cbs_auth.c
@@ -463,6 +463,12 @@ int authentication_stop(AUTHENTICATION_HANDLE authentication_handle)
         }
         else
         {
+            // stop pending the cbs operations using this authentication handle 
+            if (instance->state == AUTHENTICATION_STATE_STARTING && instance->cbs_handle != NULL)
+            {
+                cbs_stop(instance->cbs_handle, authentication_handle);
+            }
+
             // Codes_SRS_IOTHUBTRANSPORT_AMQP_AUTH_09_033: [`instance->cbs_handle` shall be set to NULL]
             instance->cbs_handle = NULL;
 

--- a/iothub_client/src/iothubtransport_amqp_device.c
+++ b/iothub_client/src/iothubtransport_amqp_device.c
@@ -564,12 +564,6 @@ static void internal_destroy_device(AMQP_DEVICE_INSTANCE* instance)
             twin_messenger_destroy(instance->twin_messenger_handle);
         }
 
-        // close the cbs before destroying the authentication handle 
-        if (instance->cbs_handle != NULL)
-        {
-            cbs_close(instance->cbs_handle);
-        }
-
         if (instance->authentication_handle != NULL)
         {
             authentication_destroy(instance->authentication_handle);

--- a/iothub_client/src/iothubtransport_amqp_device.c
+++ b/iothub_client/src/iothubtransport_amqp_device.c
@@ -564,6 +564,12 @@ static void internal_destroy_device(AMQP_DEVICE_INSTANCE* instance)
             twin_messenger_destroy(instance->twin_messenger_handle);
         }
 
+        // close the cbs before destroying the authentication handle 
+        if (instance->cbs_handle != NULL)
+        {
+            cbs_close(instance->cbs_handle);
+        }
+
         if (instance->authentication_handle != NULL)
         {
             authentication_destroy(instance->authentication_handle);

--- a/iothub_client/tests/iothubtransport_amqp_device_ut/iothubtransport_amqp_device_ut.c
+++ b/iothub_client/tests/iothubtransport_amqp_device_ut/iothubtransport_amqp_device_ut.c
@@ -652,6 +652,7 @@ static void set_expected_calls_for_device_destroy(AMQP_DEVICE_HANDLE handle, AMQ
 
     if (config->authentication_mode == DEVICE_AUTH_MODE_CBS && auth_state != AUTHENTICATION_STATE_STOPPED)
     {
+        STRICT_EXPECTED_CALL(cbs_close(TEST_CBS_HANDLE));
         STRICT_EXPECTED_CALL(authentication_destroy(TEST_AUTHENTICATION_HANDLE));
     }
 


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 