### PR TITLE
Fix order CMakelists.txt adds dependencies for unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,10 +240,6 @@ if (NOT ${use_installed_dependencies})
     if (NOT TARGET azure_macro_utils_c AND EXISTS "${CMAKE_CURRENT_LIST_DIR}/deps/azure-macro-utils-c/CMakeLists.txt")
         add_subdirectory(deps/azure-macro-utils-c)
     endif()
-    if (NOT TARGET umock_c)
-        # Get the repo if it's not there
-        add_subdirectory(deps/umock-c)
-    endif()
 
     if (${original_run_e2e_tests} OR ${original_run_unittests} OR ${run_sfc_tests})
         if (NOT TARGET testrunnerswitcher)
@@ -255,6 +251,13 @@ if (NOT ${use_installed_dependencies})
         endif()
         enable_testing()
     endif()
+
+
+    if (NOT TARGET umock_c)
+        # Get the repo if it's not there
+        add_subdirectory(deps/umock-c)
+    endif()
+
 else()
     if (NOT azure_macro_utils_cFOUND)
         find_package(azure_macro_utils_c REQUIRED CONFIG)


### PR DESCRIPTION
By adding umock before ctest and testrunner it makes umock to look
into its own submodules. If --recursive is not used on git clone or
git submodule update, then the following error occurs:

```cmake
-- Detecting CXX compile features - done
-- IoT Client SDK Version = 1.6.0
CMake Warning (dev) at deps/umock-c/CMakeLists.txt:13 (option):
  Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
  --help-policy CMP0077" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  For compatibility with older versions of CMake, option is clearing the
  normal variable 'use_cppunittest'.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Error at deps/umock-c/CMakeLists.txt:63 (add_subdirectory):
  The source directory

    /home/ewertons/code/azure-iot-sdk-c-2/deps/umock-c/deps/testrunner

  does not contain a CMakeLists.txt file.

CMake Error at deps/umock-c/CMakeLists.txt:66 (add_subdirectory):
  The source directory

    /home/ewertons/code/azure-iot-sdk-c-2/deps/umock-c/deps/ctest

  does not contain a CMakeLists.txt file.

-- Looking for include file stdint.h
```

Changing the order on C SDK CMakelists.txt causes ctest and testrunner
to be include from the C SDK deps, preventing umock of trying to adds
its own.

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 