### PR TITLE
Fixing a global buffer overflow in unit tests

### DIFF
--- a/iothub_client/tests/iothubtr_amqp_twin_msgr_ut/iothubtr_amqp_twin_msgr_ut.c
+++ b/iothub_client/tests/iothubtr_amqp_twin_msgr_ut/iothubtr_amqp_twin_msgr_ut.c
@@ -139,8 +139,9 @@ static const char* TWIN_OPERATION_GET = "GET";
 static const char* TWIN_OPERATION_PUT = "PUT";
 static const char* TWIN_OPERATION_DELETE = "DELETE";
 
-static const unsigned char* TWIN_REPORTED_PROPERTIES = (const unsigned char*)"{ \"reportedStateProperty0\": \"reportedStateProperty0\", \"reportedStateProperty1\": \"reportedStateProperty1\" }";
-static int TWIN_REPORTED_PROPERTIES_LENGTH = 117;
+#define TWIN_REPORTED_PROPERTIES_VALUE "{ \"reportedStateProperty0\": \"reportedStateProperty0\", \"reportedStateProperty1\": \"reportedStateProperty1\" }"
+static const unsigned char* TWIN_REPORTED_PROPERTIES = (const unsigned char*)TWIN_REPORTED_PROPERTIES_VALUE;
+static const int TWIN_REPORTED_PROPERTIES_LENGTH = sizeof(TWIN_REPORTED_PROPERTIES_VALUE);
 
 static time_t g_initial_time;
 static time_t g_initial_time_plus_30_secs;


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Description of the problem
Running the Azure IOT C SDK unit tests with [AddressSanitizer](https://docs.microsoft.com/en-us/cpp/sanitizers/asan?view=msvc-160) turned on identified a global buffer overflow error in one of the tests. The cause was a `LENGTH` constant set to a value larger than the actual length of the corresponding string, resulting in copying past the end of the string during a string copy operation.

# Description of the solution
The fix is to use the correct value for the length of the `TWIN_REPORTED_PROPERTIES` string. To avoid future errors if the string is ever modified, the fix makes use of the `sizeof` operator to automatically pick the correct value.