### PR TITLE
Cleanup initial readme and dev box setup

### DIFF
--- a/doc/connection_and_messaging_reliability.md
+++ b/doc/connection_and_messaging_reliability.md
@@ -66,7 +66,7 @@ The design of the Azure IoT C SDK is composed of layers, each of them assigned s
 | Azure IoT C Low Level SDK | [iothub\_client\_ll](https://github.com/Azure/azure-iot-sdk-c/blob/master/iothub_client/inc/iothub_client_ll.h)     | Main surface of the Azure IoT device client API (single-threaded)                                                                                                                                                                                                                                        |
 | Protocol Transport        | [iothubtransport\*](https://github.com/Azure/azure-iot-sdk-c/tree/master/iothub_client/inc)                         | Provides an interface between the specific protocol API (e.g., [uamqp](https://github.com/Azure/azure-uamqp-c), [umqtt](https://github.com/Azure/azure-umqtt-c)) and the upper client SDK. It is responsible for part of the business logic, the message queueing and timeout control, options handling. |
 | Protocol API              | [uamqp](https://github.com/Azure/azure-uamqp-c), [umqtt](https://github.com/Azure/azure-umqtt-c) or native HTTP API | Implements the specific application protocol (either AMQP, MQTT or HTTP, respectivelly)                                                                                                                                                                                                                  |
-| TLS                       | [tlsio\_\*](https://github.com/Azure/azure-c-shared-utility/tree/master/adapters)                                   | Provides a wrapper over the specific TLS API (schannel, openssl, wolfssl, mbedtls), using the [xio](https://github.com/Azure/azure-c-shared-utility/blob/master/inc/azure_c_shared_utility/xio.h) interface that the device client SDK uses                                                              |
+| TLS                       | [tlsio\_\*](https://github.com/Azure/azure-c-shared-utility/tree/master/adapters)                                   | Provides a wrapper over the specific TLS API (Schannel, openssl, wolfssl, mbedtls), using the [xio](https://github.com/Azure/azure-c-shared-utility/blob/master/inc/azure_c_shared_utility/xio.h) interface that the device client SDK uses                                                              |
 | Socket                    | [socketio\_\*](https://github.com/Azure/azure-c-shared-utility/tree/master/adapters)                                | Provides a wrapper over the specific socket API ([win32, berkeley, mbed](https://github.com/Azure/azure-c-shared-utility/tree/master/adapters)), using the [xio](https://github.com/Azure/azure-c-shared-utility/blob/master/inc/azure_c_shared_utility/xio.h) interface that the device client SDK uses |
 
 When an Azure IoT device client instance is created, this is the typical\* sequence within the SDK:
@@ -77,7 +77,7 @@ When an Azure IoT device client instance is created, this is the typical\* seque
 
 3. The transport protocol then creates:
 
-    - A tlsio\_\* instance based on the system where it is running (by default schannel on Windows and openssl on Linux), and
+    - A tlsio\_\* instance based on the system where it is running (by default Schannel on Windows and openssl on Linux), and
 
     - An instance of the application protocol specific API (uamqp, [umqtt](https://github.com/Azure/azure-umqtt-c), httpapi), passing as argument the tlsio\_\* instance created above.
 

--- a/doc/devbox_setup.md
+++ b/doc/devbox_setup.md
@@ -109,7 +109,7 @@ By default all samples are built to handle a variety of server root CA certifica
 
 > Note: Any samples you build will not work until you configure them with a valid IoT Hub device connection string. For more information, see the [samples section](#samplecode) below.
 
-It is possible to use OpenSSL as your TLS stack instead of the default schannel when running on Windows, although this is *highly* discouraged.  See [this document][windows-and-openssl] for more.
+It is possible to use OpenSSL as your TLS stack instead of the default Schannel when running on Windows, although this is *highly* discouraged.  See [this document][windows-and-openssl] for more.
 
 <a name="linux"></a>
 

--- a/doc/devbox_setup.md
+++ b/doc/devbox_setup.md
@@ -109,7 +109,7 @@ By default all samples are built to handle a variety of server root CA certifica
 
 > Note: Any samples you build will not work until you configure them with a valid IoT Hub device connection string. For more information, see the [samples section](#samplecode) below.
 
-It is possible to use OpenSSL as your TLS stack instead of the default schannel when running on Windows, although this is *highly* discouraged.  See [this document](#windows-and-openssl) for more.
+It is possible to use OpenSSL as your TLS stack instead of the default schannel when running on Windows, although this is *highly* discouraged.  See [this document](windows-and-openssl) for more.
 
 <a name="linux"></a>
 

--- a/doc/devbox_setup.md
+++ b/doc/devbox_setup.md
@@ -1,6 +1,6 @@
 # Prepare your development environment
 
-This document describes how to prepare your development environment to use the **Microsoft Azure IoT device SDK for C**. It describes preparing a development environment in Windows using Visual Studio and in Linux.
+This document describes how to prepare your development environment to use the **Microsoft Azure IoT device SDK for C**.
 
 - [Set up a Windows development environment](#windows)
 - [Set up a Linux development environment](#linux)

--- a/doc/devbox_setup.md
+++ b/doc/devbox_setup.md
@@ -109,7 +109,7 @@ By default all samples are built to handle a variety of server root CA certifica
 
 > Note: Any samples you build will not work until you configure them with a valid IoT Hub device connection string. For more information, see the [samples section](#samplecode) below.
 
-It is possible to use OpenSSL as your TLS stack instead of the default schannel when running on Windows, although this is *highly* discouraged.  See [this document](windows-and-openssl) for more.
+It is possible to use OpenSSL as your TLS stack instead of the default schannel when running on Windows, although this is *highly* discouraged.  See [this document][windows-and-openssl] for more.
 
 <a name="linux"></a>
 

--- a/doc/devbox_setup.md
+++ b/doc/devbox_setup.md
@@ -31,7 +31,7 @@ cd azure-iot-sdk-c
 git submodule update --init
 ```
 
->If you are using a release before 2019-04-15 then you will need to use the `--recursive` argument.  Otherwise it is highly recommended NOT to use `--recursive` as this results in poor git performance.
+>If you are using a release before 2019-04-15 then you will need to use the `--recursive` argument for `git submodule`.  Otherwise it is highly recommended NOT to use `--recursive` as this results in poor git performance.
 
 ### Building sample applications using vcpkg to build the SDK
 
@@ -109,42 +109,7 @@ By default all samples are built to handle a variety of server root CA certifica
 
 > Note: Any samples you build will not work until you configure them with a valid IoT Hub device connection string. For more information, see the [samples section](#samplecode) below.
 
-### Using OpenSSL in the SDK
-
-For TLS operations, by default the C-SDK uses Schannel on Windows Platforms.  You can use OpenSSL instead on Windows if you desire.  **NOTE:  this configuration presently receives only basic manual testing and does not have gated e2e tests.**
-
-**IMPORTANT SECURITY NOTE WHEN USING OPENSSL ON WINDOWS**
-You are responsible for updating your OpenSSL dependencies as security fixes for it become available.  Schannel on Windows is a system component automatically serviced by Windows Update.  OpenSSL on Linux is updated by Linux packaging mechanisms, such as apt-get on Debian based distributions.  Shipping the C-SDK on Windows using OpenSSL means you are responsible for getting updated versions of it to your devices.
-
-[OpenSSL] binaries that the C-SDK depends on are **ssleay32** and **libeay32**. To enable OpenSSL to be used on Windows, you need to
-
-- Obtain OpenSSL binaries.  There are many ways to do this, but one of the easier ways is to:
-
-- Open the appropriate developer command prompt you plan on building the C-SDK from.
-
-- Install [vcpkg], a Microsoft tool that helps you manage C and C++ libraries.
-
-- Run `.\vcpkg install openssl` to obtain the required OpenSSL binaries.
-
-- Make note of the directory that OpenSSL has been installed to by vcpkg, e.g. `C:\vcpkgRoot\vcpkg\packages\openssl_x86-windows`.
-
-* Make the C-SDK link against these OpenSSL binaries instead of the default Schannel.
-  * Regardless of how you obtained OpenSSL binaries, set environment variables to point at its root directory.  *Be careful there are no leading spaces between the `=` and directory name as cmake's errors are not always obvious.*
-      ```Shell
-       set OpenSSLDir=C:\vcpkgRoot\vcpkg\packages\openssl_x86-windows
-       set OPENSSL_ROOT_DIR=C:\vcpkgRoot\vcpkg\packages\openssl_x86-windows
-       ```
-  * Build the SDK to include OpenSSL.  The key difference from the typical flow is the inclusion of the `-Duse_openssl:BOOL=ON` option when invoking cmake.
-
-     ```Shell
-     cd azure-iot-sdk-c
-     mkdir cmake
-     cd cmake
-     cmake -Duse_openssl:BOOL=ON ..
-     cmake --build . -- /m /p:Configuration=Release
-     ```
-
-Building samples and your application should be the same as using the default Schannel at this point.
+It is possible to use OpenSSL as your TLS stack instead of the default schannel when running on Windows, although this is *highly* discouraged.  See [this document](#windows-and-openssl) for more.
 
 <a name="linux"></a>
 
@@ -185,7 +150,7 @@ This section describes how to set up a development environment for the C SDK on 
   git submodule update --init
   ```
 
-  >If you are using a release before 2019-04-15 then you will need to use the `--recursive` argument.  Otherwise it is highly recommended NOT to use `--recursive` as this results in poor git performance.
+  >If you are using a release before 2019-04-15 then you will need to use the `--recursive` argument for `git submodule`.  Otherwise it is highly recommended NOT to use `--recursive` as this results in poor git performance.
 
 ### Build the C SDK on Linux
 
@@ -268,7 +233,7 @@ We've tested the device SDK for C on macOS High Sierra, with XCode version 9.2.
   git submodule update --init
   ```
 
-  >If you are using a release before 2019-04-15 then you will need to use the `--recursive` argument.  Otherwise it is highly recommended NOT to use `--recursive` as this results in poor git performance.
+  >If you are using a release before 2019-04-15 then you will need to use the `--recursive` argument for `git submodule`.  Otherwise it is highly recommended NOT to use `--recursive` as this results in poor git performance.
 
 #### Upgrade CURL on Mac OS
 
@@ -415,9 +380,6 @@ make
 [git]:http://www.git-scm.com
 [CMake]:https://cmake.org/
 [MSBuild]:https://msdn.microsoft.com/en-us/library/0k6kkbsd.aspx
-[OpenSSL]:https://www.openssl.org/
-[OpenSSL Github Repository]: https://github.com/openssl/openssl
-[OpenSSL Installation]:https://github.com/openssl/openssl/blob/master/INSTALL
 [Compilation and Installation]:https://wiki.openssl.org/index.php/Compilation_and_Installation#Windows
 [Ubuntu]:http://www.ubuntu.com/desktop
 [gcc]:https://gcc.gnu.org/
@@ -430,3 +392,4 @@ make
 [latest-release]:https://github.com/Azure/azure-iot-sdk-c/releases/latest
 [Windows 10 IoT Core]:https://docs.microsoft.com/en-us/windows/iot-core/develop-your-app/buildingappsforiotcore
 [vcpkg]:https://github.com/Microsoft/vcpkg
+[windows-and-openssl]:./windows_and_openssl.md

--- a/doc/devbox_setup.md
+++ b/doc/devbox_setup.md
@@ -5,7 +5,6 @@ This document describes how to prepare your development environment to use the *
 - [Set up a Windows development environment](#windows)
 - [Set up a Linux development environment](#linux)
 - [Set up a macOS (Mac OS X) development environment](#macos)
-- [Set up a Windows Embedded Compact 2013 development environment](#windowsce)
 - [Sample applications](#samplecode)
 
 <a name="windows"></a>
@@ -18,7 +17,7 @@ This document describes how to prepare your development environment to use the *
 
 - Install [git]. Confirm git is in your PATH by typing `git version` from a command prompt.
 
-- Install [CMake]. Make sure it is in your PATH by typing `cmake -version` from a command prompt. CMake will be used to create Visual Studio projects to build libraries and samples.
+- Install CMake, either by including it in your Visual Studio 2019 install or installing directly from [CMake.org][CMake]. Make sure it is in your PATH by typing `cmake -version` from a command prompt. CMake will be used to create Visual Studio projects to build libraries and samples.
 
 - Locate the tag name for the [latest release][latest-release] of the SDK.
 
@@ -32,11 +31,11 @@ cd azure-iot-sdk-c
 git submodule update --init
 ```
 
->If you are using a release before 2019-04-15 then you will need to use the `--recursive` argument to instructs git to clone other GitHub repos this SDK depends on. Dependencies are listed [here](https://github.com/Azure/azure-iot-sdk-c/blob/master/.gitmodules).
+>If you are using a release before 2019-04-15 then you will need to use the `--recursive` argument.  Otherwise it is highly recommended NOT to use `--recursive` as this results in poor git performance.
 
 ### Building sample applications using vcpkg to build the SDK
 
-The sample applications can be build with the help of the C SDK libraries and headers built with vcpkg (vcpkg is a package manager that facilitates building C and C++ libraries). To install the vcpkg C SDK libraries and headers, follow these steps [Setup C SDK vcpkg for Windows development environment](https://github.com/Azure/azure-iot-sdk-c/blob/master/doc/setting_up_vcpkg.md#setup-c-sdk-vcpkg-for-windows-development-environment).
+The sample applications can be build with the help of the C SDK libraries and headers built with vcpkg.  vcpkg is a package manager that facilitates building C and C++ libraries. To install the vcpkg C SDK libraries and headers, follow these steps [Setup C SDK vcpkg for Windows development environment](.doc/setting_up_vcpkg.md#setup-c-sdk-vcpkg-for-windows-development-environment).
 
 Note: vcpkg manager creates a directory with all the headers and generates the C SDK .lib files on your machine. If you are using Visual Studio (from 2017) the command 'vcpkg integrate install' lets Visual Studio knows where the vcpkg headers and lib directories are located. If you're using other IDEs, just add the vcpkg directories to your compiler/linker include paths.
 
@@ -45,7 +44,7 @@ To quickly build one of the sample applications, open the corresponding Visual S
 
 In the sample's main source file, find the line similar to this:
 
-```Shell
+```C
 static const char* connectionString = "[device connection string]";
 ```
 
@@ -56,7 +55,7 @@ Build the sample project.
 
 ### Building the C SDK with CMake on Windows
 
-In some cases, you may want to build the SDK locally for development and testing purposes (without using vcpkg manager). First, take the following steps to generate project files:
+In some cases, you may want to build the SDK locally for development and testing purposes (without using vcpkg). First, take the following steps to generate project files:
 
 - Open a "Developer Command Prompt for VS2017" or "Developer Command Prompt for VS2019".
 
@@ -100,7 +99,9 @@ ctest -C "debug" -V
 
 ### Build a sample that uses different protocols, including over WebSockets
 
-By default the C-SDK will have web sockets enabled for AMQP and MQTT.  The sample **iothub_client\samples\iothub_ll_telemetry_sample** lets you specify the `protocol` variable.
+By default the C-SDK will have web sockets enabled for AMQP and MQTT.  The sample **iothub_client\samples\iothub_ll_telemetry_sample** lets you specify the `protocol` variable.  
+
+Unless you have a reason otherwise, we recommend you use MQTT as your protocol.
 
 ### Build a sample using a specific server root certificate
 
@@ -167,19 +168,11 @@ This section describes how to set up a development environment for the C SDK on 
   cmake --version
   ```
 
-  > For information about how to upgrade your version of CMake to 3.x on Ubuntu 14.04, read [How to install CMake 3.2 on Ubuntu 14.04?](http://askubuntu.com/questions/610291/how-to-install-cmake-3-2-on-ubuntu-14-04).
-
 - Verify that gcc is at least version **4.4.7**:
 
   ```Shell
   gcc --version
   ```
-
-  > For information about how to upgrade your version of gcc on Ubuntu 14.04, read [How do I use the latest GCC 4.9 on Ubuntu 14.04?](http://askubuntu.com/questions/466651/how-do-i-use-the-latest-gcc-4-9-on-ubuntu-14-04).
-
-- Patch CURL to the latest version available.
-  > The minimum version of curl required is 7.56, as recent previous versions [presented critical failures](https://github.com/Azure/azure-iot-sdk-c/issues/308).
-  > To upgrade see "Upgrade CURL on Mac OS" steps below.
 
 - Locate the tag name for the [latest release][latest-release] of the SDK.
   > Our release tag names are date values in `lts_mm_yyyy` format.
@@ -192,7 +185,7 @@ This section describes how to set up a development environment for the C SDK on 
   git submodule update --init
   ```
 
-  > If you are using a release before 2019-04-15 then you will need to use the `--recursive` argument to instructs git to clone other GitHub repos this SDK depends on. Dependencies are listed [here](https://github.com/Azure/azure-iot-sdk-c/blob/master/.gitmodules).
+  >If you are using a release before 2019-04-15 then you will need to use the `--recursive` argument.  Otherwise it is highly recommended NOT to use `--recursive` as this results in poor git performance.
 
 ### Build the C SDK on Linux
 
@@ -229,6 +222,8 @@ ctest -C "debug" -V
 ### Build a sample that uses different protocols, including over WebSockets
 
 By default the C-SDK will have web sockets enabled for AMQP and MQTT.  The sample **iothub_client\samples\iothub_ll_telemetry_sample** lets you specify the `protocol` variable.
+
+Unless you have a reason otherwise, we recommend you use MQTT as your protocol.
 
 ### Build a sample using a specific server root certificate
 
@@ -273,7 +268,7 @@ We've tested the device SDK for C on macOS High Sierra, with XCode version 9.2.
   git submodule update --init
   ```
 
-  > If you are using a release before 2019-04-15 then you will need to use the `--recursive` argument to instructs git to clone other GitHub repos this SDK depends on. Dependencies are listed [here](https://github.com/Azure/azure-iot-sdk-c/blob/master/.gitmodules).
+  >If you are using a release before 2019-04-15 then you will need to use the `--recursive` argument.  Otherwise it is highly recommended NOT to use `--recursive` as this results in poor git performance.
 
 #### Upgrade CURL on Mac OS
 
@@ -353,6 +348,8 @@ Also, you can build and run unit tests:
 
 By default the C-SDK will have web sockets enabled for AMQP and MQTT.  The sample **iothub_client\samples\iothub_ll_telemetry_sample** lets you specify the `protocol` variable.
 
+Unless you have a reason otherwise, we recommend you use MQTT as your protocol.
+
 ### Build a sample using a specific server root certificate
 
 By default all samples are built to handle a variety of server root CA certificates during TLS negotiation. If you would like to decrease the size of the sample, select the appropriate root certificate option during the cmake step. Follow the instructions [here](https://github.com/Azure/azure-iot-sdk-c/certs).
@@ -389,9 +386,7 @@ The example above assumes curl 7.58 has been compiled and saved into `/usr/local
 
 This repository contains various C sample applications that illustrate how to use the Azure IoT device SDK for C:
 
--[Simple samples for the device SDK][simple_samples]
-
--[Samples using the serializer library][serializer_samples]
+-[Samples for the device SDK][device_samples]
 
 Once the SDK is building successfully you can run any of the available samples using the following (example given for a linux system):
 
@@ -431,8 +426,7 @@ make
 [XCode]:https://developer.apple.com/xcode/
 [Homebrew]:http://brew.sh/
 [clang]:https://clang.llvm.org/
-[simple_samples]: ../iothub_client/samples/
-[serializer_samples]: ../serializer/samples/
+[device_samples]: ../iothub_client/samples/
 [latest-release]:https://github.com/Azure/azure-iot-sdk-c/releases/latest
 [Windows 10 IoT Core]:https://docs.microsoft.com/en-us/windows/iot-core/develop-your-app/buildingappsforiotcore
 [vcpkg]:https://github.com/Microsoft/vcpkg

--- a/doc/windows_and_openssl.md
+++ b/doc/windows_and_openssl.md
@@ -1,9 +1,9 @@
 # Using OpenSSL on IoT SDK on Windows
 
-This document is only relevant if you are using the IoT C-SDK on Windows and you wish to use OpenSSL instead of schannel for your TLS stack.
+This document is only relevant if you are using the IoT C-SDK on Windows and you wish to use OpenSSL instead of Schannel for your TLS stack.
 
 ## Using OpenSSL on Windows is highly discouraged
-By default you should use the SDK's default settings for Windows, which is to use schannel.  You should avoid OpenSSL on Windows for the C-SDK because:
+By default you should use the SDK's default settings for Windows, which is to use Schannel.  You should avoid OpenSSL on Windows for the C-SDK because:
 
 * OpenSSL/Windows combination for the SDK receives only basic testing and is not part of checkin gates.
 

--- a/doc/windows_and_openssl.md
+++ b/doc/windows_and_openssl.md
@@ -1,0 +1,47 @@
+# Using OpenSSL on IoT SDK on Windows
+
+This document is only relevant if you are using the IoT C-SDK on Windows and you wish to use OpenSSL instead of schannel for your TLS stack.
+
+## Using OpenSSL on Windows is highly discouraged
+By default you should use the SDK's default settings for Windows, which is to use schannel.  You should avoid OpenSSL on Windows for the C-SDK because:
+
+* OpenSSL/Windows combination for the SDK receives only basic testing and is not part of checkin gates.
+
+* You are responsible for updating your OpenSSL dependencies as security fixes for it become available.  Schannel on Windows is a system component automatically serviced by Windows Update.  OpenSSL on Linux is updated by Linux packaging mechanisms, such as apt-get on Debian based distributions.  Shipping the C-SDK on Windows using OpenSSL means you are responsible for getting updated versions of it to your devices.
+
+This document is kept primarily for archival purposes for customers who may be on OpenSSL/Windows and are not able to change.
+
+## Setup instructions
+
+[OpenSSL] binaries that the C-SDK depends on are **ssleay32** and **libeay32**. To enable OpenSSL to be used on Windows, you need to
+
+- Obtain OpenSSL binaries.  There are many ways to do this, but one of the easier ways is to:
+
+- Open the appropriate developer command prompt you plan on building the C-SDK from.
+
+- Install [vcpkg], a Microsoft tool that helps you manage C and C++ libraries.
+
+- Run `.\vcpkg install openssl` to obtain the required OpenSSL binaries.
+
+- Make note of the directory that OpenSSL has been installed to by vcpkg, e.g. `C:\vcpkgRoot\vcpkg\packages\openssl_x86-windows`.
+
+* Make the C-SDK link against these OpenSSL binaries instead of the default Schannel.
+  * Regardless of how you obtained OpenSSL binaries, set environment variables to point at its root directory.  *Be careful there are no leading spaces between the `=` and directory name as cmake's errors are not always obvious.*
+      ```Shell
+       set OpenSSLDir=C:\vcpkgRoot\vcpkg\packages\openssl_x86-windows
+       set OPENSSL_ROOT_DIR=C:\vcpkgRoot\vcpkg\packages\openssl_x86-windows
+       ```
+  * Build the SDK to include OpenSSL.  The key difference from the typical flow is the inclusion of the `-Duse_openssl:BOOL=ON` option when invoking cmake.
+
+     ```Shell
+     cd azure-iot-sdk-c
+     mkdir cmake
+     cd cmake
+     cmake -Duse_openssl:BOOL=ON ..
+     cmake --build . -- /m /p:Configuration=Release
+     ```
+
+## Samples and usage
+Building samples and your application should be the same as using the default Schannel at this point.
+
+[OpenSSL]:https://www.openssl.org/

--- a/provisioning_service_client/readme.md
+++ b/provisioning_service_client/readme.md
@@ -1,0 +1,11 @@
+# Microsoft Azure IoT Device Provisioning Service SDK for C
+
+## End of active development for service SDK
+
+The Azure IoT Device Provisioning Service SDK for C is no longer under active development.
+
+We will continue to fix critical bugs such as crashes, data corruption, and security vulnerabilities.  We will **NOT** add any new feature or fix bugs that are not critical, however.
+
+Azure IoT Service SDK support is available in higher-level languages ([C#](https://github.com/Azure/azure-iot-sdk-csharp), [Java](https://github.com/Azure/azure-iot-sdk-java), [Node](https://github.com/Azure/azure-iot-sdk-node), [Python](https://github.com/Azure/azure-iot-sdk-python)).
+
+The rest of this repo - for instance the [the provisioning code that runs on devices themselves](../provisioning_client) for deploying code to devices - continues to be under active development.  This ending of new features only applies to code under this subfolder.

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 [![Build Status](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_apis/build/status/c/integrate-into-repo-C)](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/latest?definitionId=85)
 
 
-The Azure IOT Hub Device SDK allows applications written in C99 (or later) or C++ to communicate easily with [Azure IoT Hub](https://azure.microsoft.com/en-us/services/iot-hub/), [Azure IoT Central][Azure-IoT-Central] and to 
+The Azure IOT Hub Device SDK allows applications written in C99 or later or C++ to communicate easily with [Azure IoT Hub](https://azure.microsoft.com/en-us/services/iot-hub/), [Azure IoT Central][Azure-IoT-Central] and to 
  [Azure IoT Device Provisioning][Azure-IoT-Device-Provisioning].  This repo includes the source code for the libraries, setup instructions, and samples demonstrating use scenarios.
 
 For constained devices - where memory is managed in kilobytes and not megabytes - there are even lighter weight SDK options available.  See [Other Azure IoT SDKs](#other-azure-iot-sdks) for more.
@@ -31,7 +31,7 @@ For constained devices - where memory is managed in kilobytes and not megabytes 
   - [Schedule<sup>1</sup>](#schedulesup1sup)
     - [Planned Release Schedule](#planned-release-schedule)
 
-## Getting the  SDK
+## Getting the SDK
   The simplest way to get started with the Azure IoT SDKs is to use the following packages and libraries:
   * mbed:                                      [Device SDK library on MBED](./iothub_client/readme.md#mbed)
   * Arduino:                                   [Device SDK library in the Arduino IDE](./iothub_client/readme.md#arduino)
@@ -80,7 +80,7 @@ IoT Hub supports multiple protocols for the device to connect with : MQTT, AMQP,
 | Retry policies                                                                                                   | :heavy_check_mark:* | :heavy_check_mark:* | :heavy_check_mark:*      | :heavy_check_mark:*      | :heavy_multiplication_x: | Retry policy for unsuccessful device-to-cloud messages have two options: no try, exponential backoff with jitter (default).   *Custom retry policy is in progress.                                                                                                                                              |
 | Devices multiplexing over single connection                                                                      | :heavy_minus_sign:  | :heavy_minus_sign:  | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark:       |                                                                                                                                                                                                                                                                                                                   |
 | Connection Pooling - Specifying number of connections                                                            | :heavy_minus_sign:  | :heavy_minus_sign:  | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: |                                                                                                                                                                                                                                                                                                                   |
-| Azure IoT Plug and Play Support                                                            | :heavy_multiplication_x:  | :heavy_check_mark:  | :heavy_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: |Ability to build [Azure IoT Plug and Play devices][iot-plug-and-play].|                                                                                                                                                                                                                                                                                                                   |
+| Azure IoT Plug and Play Support                                                            | :heavy_check_mark:  | :heavy_check_mark:  | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |Ability to build [Azure IoT Plug and Play devices][iot-plug-and-play].|                                                                                                                                                                                                                                                                                                                   |
 
 This SDK also contains options you can set and platform specific features.  You can find detail list in this [document](./doc/Iothub_sdk_options.md).
 
@@ -140,7 +140,6 @@ If you encounter any bugs, have suggestions for new features or if you would lik
 * [Azure IoT device SDK for C tutorial][c-sdk-intro]
 * [How to port the C libraries to other OS platforms](https://github.com/Azure/azure-c-shared-utility/blob/master/devdoc/porting_guide.md)
 * [Cross compilation example][c-cross-compile]
-* [C SDKs API reference][c-api-reference]
 
 ## SDK Folder Structure
 

--- a/readme.md
+++ b/readme.md
@@ -3,10 +3,10 @@
 [![Build Status](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_apis/build/status/c/integrate-into-repo-C)](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/latest?definitionId=85)
 
 
-The Azure IOT Hub Device SDK allows applications written in C99 (or later) or C++ to communicate easily with [Azure IoT Hub](https://azure.microsoft.com/en-us/services/iot-hub/) and to 
- [Azure IoT Device Provisioning](https://docs.microsoft.com/azure/iot-dps/).  This repo includes the source code for the libraries, setup instructions, and samples demonstrating use scenarios.
+The Azure IOT Hub Device SDK allows applications written in C99 (or later) or C++ to communicate easily with [Azure IoT Hub](https://azure.microsoft.com/en-us/services/iot-hub/), [Azure IoT Central][Azure-IoT-Central] and to 
+ [Azure IoT Device Provisioning][Azure-IoT-Device-Provisioning].  This repo includes the source code for the libraries, setup instructions, and samples demonstrating use scenarios.
 
-For constained devices - where memory is managed in kilobytes and not megabytes - there are even lighter weight SDK options available.  See [Other Azure IoT SDKs](#-other-azure-iot-sdks) for more.
+For constained devices - where memory is managed in kilobytes and not megabytes - there are even lighter weight SDK options available.  See [Other Azure IoT SDKs](#other-azure-iot-sdks) for more.
 
 
 ## Table of Contents
@@ -50,7 +50,7 @@ The API reference documentation for the C SDKs can be found [here][c-api-referen
 
 ## Other Azure IoT SDKs
 
-To find Azure IoT SDKs in other languages, please refer to the [about-iot-sdks][about-iot-sdks].
+To find Azure IoT SDKs in other languages, please refer to the [guidance here][about-iot-sdks].
 
 **Note on constrained devices**: The `Embedded C SDK` is an alternative for constrained devices which enables the BYO (bring your own) network approach: IoT developers have the freedom of choice to bring an MQTT client, TLS and Socket of their choice to create a device solution. Find more information about the Embedded C SDK [here](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/iot).
 
@@ -80,7 +80,7 @@ IoT Hub supports multiple protocols for the device to use : MQTT, AMQP, and HTTP
 | Retry policies                                                                                                   | :heavy_check_mark:* | :heavy_check_mark:* | :heavy_check_mark:*      | :heavy_check_mark:*      | :heavy_multiplication_x: | Retry policy for unsuccessful device-to-cloud messages have two options: no try, exponential backoff with jitter (default).   *Custom retry policy is in progress.                                                                                                                                              |
 | Devices multiplexing over single connection                                                                      | :heavy_minus_sign:  | :heavy_minus_sign:  | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark:       |                                                                                                                                                                                                                                                                                                                   |
 | Connection Pooling - Specifying number of connections                                                            | :heavy_minus_sign:  | :heavy_minus_sign:  | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: |                                                                                                                                                                                                                                                                                                                   |
-| Azure IoT Plug and Play Support                                                            | :heavy_multiplication_x:  | :heavy_multiplication_x:  | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |                                                                                                                                                                                                                                                                                                                   |
+| Azure IoT Plug and Play Support                                                            | :heavy_multiplication_x:  | :heavy_check_mark:  | :heavy_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: Ability to build [Azure IoT Plug and Play devices][iot-plug-and-play].|                                                                                                                                                                                                                                                                                                                   |
 
 This SDK also contains options you can set and platform specific features.  You can find detail list in this [document](./doc/Iothub_sdk_options.md).
 
@@ -247,3 +247,6 @@ Microsoft collects performance and usage information which may be used to provid
 [c-cross-compile]: doc/SDK_cross_compile_example.md
 [c-api-reference]: https://docs.microsoft.com/azure/iot-hub/iot-c-sdk-ref/
 [about-iot-sdks]:https://docs.microsoft.com/en-us/azure/iot-develop/about-iot-sdks
+[Azure-IoT-Central]: https://docs.microsoft.com/en-us/azure/iot-central/
+[Azure-IoT-Device-Provisioning]: https://docs.microsoft.com/azure/iot-dps/
+[iot-plug-and-play]: https://docs.microsoft.com/en-us/azure/iot-pnp/overview-iot-plug-and-play

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 The Azure IOT Hub Device SDK allows applications written in C99 or later or C++ to communicate easily with [Azure IoT Hub](https://azure.microsoft.com/en-us/services/iot-hub/), [Azure IoT Central][Azure-IoT-Central] and to 
  [Azure IoT Device Provisioning][Azure-IoT-Device-Provisioning].  This repo includes the source code for the libraries, setup instructions, and samples demonstrating use scenarios.
 
-For constained devices - where memory is managed in kilobytes and not megabytes - there are even lighter weight SDK options available.  See [Other Azure IoT SDKs](#other-azure-iot-sdks) for more.
+For constained devices - where memory is measured in kilobytes and not megabytes - there are even lighter weight SDK options available.  See [Other Azure IoT SDKs](#other-azure-iot-sdks) for more.
 
 
 ## Table of Contents
@@ -32,14 +32,13 @@ For constained devices - where memory is managed in kilobytes and not megabytes 
     - [Planned Release Schedule](#planned-release-schedule)
 
 ## Getting the SDK
-  The simplest way to get started with the Azure IoT SDKs is to use the following packages and libraries:
+  The simplest way to get started with the Azure IoT SDKs on supported platforms is to use the following packages and libraries:
   * mbed:                                      [Device SDK library on MBED](./iothub_client/readme.md#mbed)
   * Arduino:                                   [Device SDK library in the Arduino IDE](./iothub_client/readme.md#arduino)
   * Windows:                                   [Device SDK on Vcpkg](./doc/setting_up_vcpkg.md#setup-c-sdk-vcpkg-for-windows-development-environment)
   * iOS:                                       [Device SDK on CocoaPod](https://cocoapods.org/pods/AzureIoTHubClient)
 
-You can alternately clone and build the SDK directly.  Instructions can be found [here](./iothub_client/readme.md#compile).
-  
+For other platforms - including Linux - you need to clone and build the SDK directly.  You may also build it directly for the platforms above.  Instructions can be found [here](./iothub_client/readme.md#compile).
 
 ## Samples
 There are many samples available for the SDK.  More information can be found [here](./samples/readme.md).
@@ -80,7 +79,7 @@ IoT Hub supports multiple protocols for the device to connect with : MQTT, AMQP,
 | Retry policies                                                                                                   | :heavy_check_mark:* | :heavy_check_mark:* | :heavy_check_mark:*      | :heavy_check_mark:*      | :heavy_multiplication_x: | Retry policy for unsuccessful device-to-cloud messages have two options: no try, exponential backoff with jitter (default).   *Custom retry policy is in progress.                                                                                                                                              |
 | Devices multiplexing over single connection                                                                      | :heavy_minus_sign:  | :heavy_minus_sign:  | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark:       |                                                                                                                                                                                                                                                                                                                   |
 | Connection Pooling - Specifying number of connections                                                            | :heavy_minus_sign:  | :heavy_minus_sign:  | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: |                                                                                                                                                                                                                                                                                                                   |
-| Azure IoT Plug and Play Support                                                            | :heavy_check_mark:  | :heavy_check_mark:  | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |Ability to build [Azure IoT Plug and Play devices][iot-plug-and-play].|                                                                                                                                                                                                                                                                                                                   |
+| [Azure IoT Plug and Play Support][iot-plug-and-play]                                                            | :heavy_check_mark:  | :heavy_check_mark:  | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |Ability to build Azure IoT Plug and Play devices.|                                                                                                                                                                                                                                                                                                                   |
 
 This SDK also contains options you can set and platform specific features.  You can find detail list in this [document](./doc/Iothub_sdk_options.md).
 

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ To learn more about building Azure IoT Applications, you can visit the [Azure Io
 
 ### Device Client SDK
 
-IoT Hub supports multiple protocols for the device to use : MQTT, AMQP, and HTTPS.  MQTT and AMQP can optionally run over WebSockets.  The Device Client SDK allows the protocol to be chosen at connection creation time.
+IoT Hub supports multiple protocols for the device to connect with : MQTT, AMQP, and HTTPS.  MQTT and AMQP can optionally run over WebSockets.  The Device Client SDK allows the protocol to be chosen at connection creation time.
 
 **If you're not sure which protocol to use, you should use MQTT or MQTT-WS.**  MQTT requires considerably fewer resources than AMQP and supports considerably more IoT Hub functionality than HTTPS.  Neither AMQP nor HTTPS are guaranteed to have Device Client SDK implementations for new features going forward, such as Azure IoT Plug and Play.
 
@@ -80,7 +80,7 @@ IoT Hub supports multiple protocols for the device to use : MQTT, AMQP, and HTTP
 | Retry policies                                                                                                   | :heavy_check_mark:* | :heavy_check_mark:* | :heavy_check_mark:*      | :heavy_check_mark:*      | :heavy_multiplication_x: | Retry policy for unsuccessful device-to-cloud messages have two options: no try, exponential backoff with jitter (default).   *Custom retry policy is in progress.                                                                                                                                              |
 | Devices multiplexing over single connection                                                                      | :heavy_minus_sign:  | :heavy_minus_sign:  | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark:       |                                                                                                                                                                                                                                                                                                                   |
 | Connection Pooling - Specifying number of connections                                                            | :heavy_minus_sign:  | :heavy_minus_sign:  | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: |                                                                                                                                                                                                                                                                                                                   |
-| Azure IoT Plug and Play Support                                                            | :heavy_multiplication_x:  | :heavy_check_mark:  | :heavy_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: Ability to build [Azure IoT Plug and Play devices][iot-plug-and-play].|                                                                                                                                                                                                                                                                                                                   |
+| Azure IoT Plug and Play Support                                                            | :heavy_multiplication_x:  | :heavy_check_mark:  | :heavy_check_mark: | :heavy_minus_sign: | :heavy_minus_sign: |Ability to build [Azure IoT Plug and Play devices][iot-plug-and-play].|                                                                                                                                                                                                                                                                                                                   |
 
 This SDK also contains options you can set and platform specific features.  You can find detail list in this [document](./doc/Iothub_sdk_options.md).
 
@@ -130,7 +130,7 @@ If you encounter any bugs, have suggestions for new features or if you would lik
 * Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
 * Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag "azure-iot-hub".
 * Need Support? Every customer with an active Azure subscription has access to [support](https://docs.microsoft.com/en-us/azure/azure-supportability/how-to-create-azure-support-request) with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
-* Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub ([C](https://github.com/Azure/azure-iot-sdk-c), [Java](https://github.com/Azure/azure-iot-sdk-java), [.NET](https://github.com/Azure/azure-iot-sdk-csharp), [Node.js](https://github.com/Azure/azure-iot-sdk-node), [Python](https://github.com/Azure/azure-iot-sdk-python)).
+* Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on [our GitHub issues][c-github-issues].
 
 ## Read more
 
@@ -153,10 +153,6 @@ These are git submodules that contain code, such as adapters and protocol implem
 
 Build and checkin gate related folders.
 
-`/provisioning_client`
-
-This folder contains client library for device provisioning client.
-
 `/certs`
 
 Contains certificates needed to communicate with Azure IoT Hub.
@@ -175,6 +171,10 @@ Contains Azure IoT Hub client components that provide the raw messaging capabili
    * src: client libraries source files.
    * samples: contains simple samples.
    * tests: unit and end-to-end tests for source code.
+
+`/provisioning_client`
+
+This folder contains client library for device provisioning client.
 
 `/samples`
 
@@ -250,3 +250,4 @@ Microsoft collects performance and usage information which may be used to provid
 [Azure-IoT-Central]: https://docs.microsoft.com/en-us/azure/iot-central/
 [Azure-IoT-Device-Provisioning]: https://docs.microsoft.com/azure/iot-dps/
 [iot-plug-and-play]: https://docs.microsoft.com/en-us/azure/iot-pnp/overview-iot-plug-and-play
+[c-github-issues]: https://github.com/Azure/azure-iot-sdk-c/issues

--- a/readme.md
+++ b/readme.md
@@ -2,65 +2,47 @@
 
 [![Build Status](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_apis/build/status/c/integrate-into-repo-C)](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/latest?definitionId=85)
 
-This repository contains the following:
-* **Azure IoT Hub Device C SDK** to connect devices running C code to Azure IoT Hub.
-* **Azure IoT Hub Device Provisioning Service Client SDK** for enrolling devices with [Azure IoT Device Provisioning Services](https://docs.microsoft.com/azure/iot-dps/) and managing enrollments lists.
-* **Azure IoT Hub Service C SDK** to interface with an Azure IoT Hub service instance from a server-side C application.
-* **Serializer Library for C** to help serialize and deserialize data on your device.
+
+The Azure IOT Hub Device SDK allows applications written in C99 (or later) or C++ to communicate easily with [Azure IoT Hub](https://azure.microsoft.com/en-us/services/iot-hub/) and to 
+ [Azure IoT Device Provisioning](https://docs.microsoft.com/azure/iot-dps/).  This repo includes the source code for the libraries, setup instructions, and samples demonstrating use scenarios.
+
+For constained devices - where memory is managed in kilobytes and not megabytes - there are even lighter weight SDK options available.  See [Other Azure IoT SDKs](#-other-azure-iot-sdks) for more.
+
 
 ## Table of Contents
 - [Azure IoT C SDKs and Libraries](#azure-iot-c-sdks-and-libraries)
   - [Table of Contents](#table-of-contents)
-  - [Packages and Libraries](#packages-and-libraries)
-  - [Samples](#samples)
+  - [Getting the  SDK](#getting-the-sdk)
   - [Compile the SDK](#compile-the-sdk)
+  - [Samples](#samples)
   - [SDK API Reference Documentation](#sdk-api-reference-documentation)
   - [Other Azure IoT SDKs](#other-azure-iot-sdks)
   - [Developing Azure IoT Applications](#developing-azure-iot-applications)
-  - [Key Features and Roadmap](#key-features-and-roadmap)
+  - [Key Features](#key-features)
     - [Device Client SDK](#device-client-sdk)
-    - [Service Client SDK](#service-client-sdk)
     - [Provisioning client SDK](#provisioning-client-sdk)
-    - [Provisioning Service SDK](#provisioning-service-sdk)
   - [OS Platforms and Hardware Compatibility](#os-platforms-and-hardware-compatibility)
   - [Porting the Azure IoT Device Client SDK for C to New Devices](#porting-the-azure-iot-device-client-sdk-for-c-to-new-devices)
   - [Contribution, Feedback and Issues](#contribution-feedback-and-issues)
   - [Support](#support)
   - [Read more](#read-more)
   - [SDK Folder Structure](#sdk-folder-structure)
-    - [/c-utility, /uamqp, /umqtt, /parson](#c-utility-uamqp-umqtt-parson)
-    - [/blob](#blob)
-    - [/dps_client](#dps_client)
-    - [/certs](#certs)
-    - [/doc](#doc)
-    - [/build_all](#build_all)
-    - [/iothub_client](#iothub_client)
-    - [/serializer](#serializer)
-    - [/iothub_service_client](#iothub_service_client)
-    - [/testtools](#testtools)
-    - [/tools](#tools)
 - [Long Term Support](#long-term-support)
   - [Schedule<sup>1</sup>](#schedulesup1sup)
     - [Planned Release Schedule](#planned-release-schedule)
 
-## Packages and Libraries
+## Getting the  SDK
   The simplest way to get started with the Azure IoT SDKs is to use the following packages and libraries:
   * mbed:                                      [Device SDK library on MBED](./iothub_client/readme.md#mbed)
   * Arduino:                                   [Device SDK library in the Arduino IDE](./iothub_client/readme.md#arduino)
   * Windows:                                   [Device SDK on Vcpkg](./doc/setting_up_vcpkg.md#setup-c-sdk-vcpkg-for-windows-development-environment)
   * iOS:                                       [Device SDK on CocoaPod](https://cocoapods.org/pods/AzureIoTHubClient)
 
+You can alternately clone and build the SDK directly.  Instructions can be found [here](./iothub_client/readme.md#compile).
+  
+
 ## Samples
-  Here are a set of simple samples that will help you get started:
-  * [Device SDK Samples](./iothub_client/samples/)
-  * [Service SDK Samples](./iothub_service_client/samples/)
-  * [Serializer Library Samples](./serializer/samples/)
-
-## Compile the SDK
-
-When no package or library is available for your platform or if you want to modify the SDK code, or port the SDK to a new platform, then you can leverage the build environment provided in the repository.
-  * [Device SDK](./iothub_client/readme.md#compile)
-  * [Service SDK](./iothub_service_client/readme.md#compile)
+There are many samples available for the SDK.  More information can be found [here](./samples/readme.md).
 
 ## SDK API Reference Documentation
 
@@ -68,7 +50,7 @@ The API reference documentation for the C SDKs can be found [here][c-api-referen
 
 ## Other Azure IoT SDKs
 
-To find Azure IoT SDKs in other languages, please refer to the [azure-iot-sdks][azure-iot-sdks] repository.
+To find Azure IoT SDKs in other languages, please refer to the [about-iot-sdks][about-iot-sdks].
 
 **Note on constrained devices**: The `Embedded C SDK` is an alternative for constrained devices which enables the BYO (bring your own) network approach: IoT developers have the freedom of choice to bring an MQTT client, TLS and Socket of their choice to create a device solution. Find more information about the Embedded C SDK [here](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/iot).
 
@@ -76,9 +58,14 @@ To find Azure IoT SDKs in other languages, please refer to the [azure-iot-sdks][
 
 To learn more about building Azure IoT Applications, you can visit the [Azure IoT Dev Center][iot-dev-center].
 
-## Key Features and Roadmap
+## Key Features
 
 ### Device Client SDK
+
+IoT Hub supports multiple protocols for the device to use : MQTT, AMQP, and HTTPS.  MQTT and AMQP can optionally run over WebSockets.  The Device Client SDK allows the protocol to be chosen at connection creation time.
+
+**If you're not sure which protocol to use, you should use MQTT or MQTT-WS.**  MQTT requires considerably fewer resources than AMQP and supports considerably more IoT Hub functionality than HTTPS.  Neither AMQP nor HTTPS are guaranteed to have Device Client SDK implementations for new features going forward, such as Azure IoT Plug and Play.
+
 :heavy_check_mark: feature available  :heavy_multiplication_x: feature planned but not supported  :heavy_minus_sign: no support planned
 
 | Features                                                                                                         | mqtt                | mqtt-ws             | amqp                     | amqp-ws                  | https                    | Description                                                                                                                                                                                                                                                                                                       |
@@ -93,23 +80,11 @@ To learn more about building Azure IoT Applications, you can visit the [Azure Io
 | Retry policies                                                                                                   | :heavy_check_mark:* | :heavy_check_mark:* | :heavy_check_mark:*      | :heavy_check_mark:*      | :heavy_multiplication_x: | Retry policy for unsuccessful device-to-cloud messages have two options: no try, exponential backoff with jitter (default).   *Custom retry policy is in progress.                                                                                                                                              |
 | Devices multiplexing over single connection                                                                      | :heavy_minus_sign:  | :heavy_minus_sign:  | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark:       |                                                                                                                                                                                                                                                                                                                   |
 | Connection Pooling - Specifying number of connections                                                            | :heavy_minus_sign:  | :heavy_minus_sign:  | :heavy_multiplication_x: | :heavy_multiplication_x: | :heavy_multiplication_x: |                                                                                                                                                                                                                                                                                                                   |
-
+| Azure IoT Plug and Play Support                                                            | :heavy_multiplication_x:  | :heavy_multiplication_x:  | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: |                                                                                                                                                                                                                                                                                                                   |
 
 This SDK also contains options you can set and platform specific features.  You can find detail list in this [document](./doc/Iothub_sdk_options.md).
 
 
-### Service Client SDK
-:heavy_check_mark: feature available  :heavy_multiplication_x: feature planned but not supported  :heavy_minus_sign: no support planned
-
-| Features                                                                                                      | C                  | Description                                                                                                                        |
-|---------------------------------------------------------------------------------------------------------------|--------------------|------------------------------------------------------------------------------------------------------------------------------------|
-| [Identity registry (CRUD)](https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry) | :heavy_check_mark:*                | Use your backend app to perform CRUD operation for individual device or in bulk.  This SDK supports CRUD operation on individual device with create device from ID/Key pair only.                                                    |
-| [Cloud-to-device messaging](https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-c2d)     | :heavy_check_mark: | Use your backend app to send cloud-to-device messages in AMQP and AMQP-WS, and set up cloud-to-device message receivers.           |
-| [Direct Methods operations](https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-direct-methods)   | :heavy_check_mark: | Use your backend app to invoke direct method on device.                                                                            |
-| [Device Twins operations](https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins)       | :heavy_check_mark:* | Use your backend app to perform device twin operations.  *Twin reported property update callback and replace twin are in progress. |
-| [Query](https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language)                       | :heavy_multiplication_x: | Use your backend app to perform query for information.                                                                             |
-| [Jobs](https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-jobs)                                  | :heavy_multiplication_x:                | Use your backend app to perform job operation.                                                                                     |
-| [File Upload](https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-file-upload)                    | :heavy_multiplication_x:                | Set up your backend app to send file upload notification receiver.                                                                 |
 
 ### Provisioning client SDK
 This repository contains [provisioning client SDK](./provisioning_client) for the [Device Provisioning Service](https://docs.microsoft.com/azure/iot-dps/).
@@ -121,18 +96,7 @@ This repository contains [provisioning client SDK](./provisioning_client) for th
 |-----------------------------|--------------------|--------------------|--------------------|--------------------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | TPM Individual Enrollment   | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | This SDK supports connecting your device to the Device Provisioning Service via [individual enrollment](https://docs.microsoft.com/azure/iot-dps/concepts-service#enrollment) using [Trusted Platform Module](https://docs.microsoft.com/azure/iot-dps/concepts-security#trusted-platform-module-tpm).  This [quickstart](https://docs.microsoft.com/azure/iot-dps/quick-create-simulated-device) reviews how to create a simulated device for individual enrollment with TPM. TPM over MQTT is currently not supported by the Device Provisioning Service.                                                                                                                                                                                                               |
 | X.509 Individual Enrollment | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | This SDK supports connecting your device to the Device Provisioning Service via [individual enrollment](https://docs.microsoft.com/azure/iot-dps/concepts-service#enrollment) using [X.509 leaf certificate](https://docs.microsoft.com/azure/iot-dps/concepts-security#leaf-certificate).  This [quickstart](https://docs.microsoft.com/azure/iot-dps/quick-create-simulated-device-x509) reviews how to create a simulated device for individual enrollment with X.509. |
-| X.509 Enrollment Group      | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | This SDK supports connecting your device to the Device Provisioning Service via [enrollment group](https://docs.microsoft.com/azure/iot-dps/concepts-service#enrollment) using [X.509 root certificate](https://docs.microsoft.com/azure/iot-dps/concepts-security#root-certificate).                                                                                                                                                                                         |
-
-### Provisioning Service SDK
-This repository contains [provisioning service client SDK](./provisioning_service_client/) for the Device Provisioning Service to [programmatically enroll devices](https://docs.microsoft.com/en-us/azure/iot-dps/how-to-manage-enrollments-sdks).
-
-| Feature                                            | Support            | Description                                                                                                                                                                                                                                            |
-|----------------------------------------------------|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| CRUD Operation with TPM Individual Enrollment      | :heavy_check_mark: | Programmatically manage device enrollment using TPM with the service SDK.  Please visit the [samples folder](./provisioning_service_client/samples/) to learn more about this feature. |
-| Bulk CRUD Operation with TPM Individual Enrollment | :heavy_check_mark: | Programmatically bulk manage device enrollment using TPM with the service SDK.  Please visit the [samples folder](./provisioning_service_client/samples/) to learn more about this feature. |
-| CRUD Operation with X.509 Individual Enrollment    | :heavy_check_mark: | Programmatically manage device enrollment using X.509 individual enrollment with the service SDK.  Please visit the [samples folder](./provisioning_service_client/samples/) to learn more about this feature. |
-| CRUD Operation with X.509 Group Enrollment         | :heavy_check_mark: | Programmatically manage device enrollment using X.509 group enrollment with the service SDK.  Please visit the [samples folder](./provisioning_service_client/samples/) to learn more about this feature. |
-| Query enrollments                                  | :heavy_check_mark: | Programmatically query registration states with the service SDK.  Please visit the [samples folder](./provisioning_service_client/samples/) to learn more about this feature.                                                                            |
+| X.509 Enrollment Group      | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | This SDK supports connecting your device to the Device Provisioning Service via [enrollment group](https://docs.microsoft.com/azure/iot-dps/concepts-service#enrollment) using [X.509 root certificate](https://docs.microsoft.com/azure/iot-dps/concepts-security#root-certificate).
 
 ## OS Platforms and Hardware Compatibility
 
@@ -180,31 +144,28 @@ If you encounter any bugs, have suggestions for new features or if you would lik
 
 ## SDK Folder Structure
 
-### /c-utility, /uamqp, /umqtt, /parson
+`/c-utility, /deps, /umqtt, /uamqp` - 
 
-These are git submodules that contain code, such as adapters and protocol implementations, shared with other projects. Note that some of them contain nested submodules.
+These are git submodules that contain code, such as adapters and protocol implementations, shared with other projects.
 
-### /blob
 
-This folder contains client components that enable access to Azure blob storage.
+`/build, /build_all`
 
-### /dps_client
+Build and checkin gate related folders.
 
-This folder contains client library for device provisioning service.
+`/provisioning_client`
 
-### /certs
+This folder contains client library for device provisioning client.
+
+`/certs`
 
 Contains certificates needed to communicate with Azure IoT Hub.
 
-### /doc
+`/doc`
 
 This folder contains application development guides and device setup instructions.
 
-### /build_all
-
-This folder contains platform-specific build scripts for the client libraries and dependent components.
-
-### /iothub_client
+`/iothub_client`
 
 Contains Azure IoT Hub client components that provide the raw messaging capabilities of the library. Refer to the API documentation and samples for information on how to use it.
 
@@ -215,28 +176,34 @@ Contains Azure IoT Hub client components that provide the raw messaging capabili
    * samples: contains simple samples.
    * tests: unit and end-to-end tests for source code.
 
-### /serializer
+`/samples`
 
-Contains libraries that provide modeling and JSON serialization capabilities on top of the raw messaging library. These libraries facilitate uploading structured data and command and control for use with Azure IoT services. Refer to the API documentation and samples for information on how to use it.
+Contains samples demonstrating more complex E2E scenarios using SDK.
 
-   * build: has one subfolder for each platform (e.g. Windows, Linux, Mbed). Contains makefiles, batch files, and solutions that are used to generate the library binaries.
-   * devdoc: contains requirements, designs notes, manuals.
-   * inc: public include files.
-   * src: client libraries source files.
-   * samples: contains simple samples.
-   * tests: unit tests and end-to-end tests for source code.
+`/testtools`
 
-### /iothub_service_client
+Contains tools that are used in testing the libraries.
+
+`/tools`
+
+Miscellaneous tools.
+
+
+### Deprecated folders
+The following folders are deprecated.
+
+`/iothub_service_client`
 
 Contains libraries that enable interactions with the IoT Hub service to perform operations such as sending messages to devices and managing the device identity registry.
 
-### /testtools
+`/provisioning_service_client`
 
-Contains tools that are currently used in testing the client libraries: Mocking Framework (micromock), Generic Test Runner (CTest), Unit Test Project Template, etc.
+Contains libraries that enable interactions with the Device Proviosining service to perform operations such as setting policy around the enrollments.
 
-### /tools
+`/serializer`
 
-Miscellaneous tools: compilembed, mbed_build, traceabilitytool (checks spec requirements vs code implementation).
+Contains libraries that provide modeling and JSON serialization capabilities on top of the raw messaging library.
+
 
 # Long Term Support
 
@@ -279,4 +246,4 @@ Microsoft collects performance and usage information which may be used to provid
 [c-porting-guide]: https://github.com/Azure/azure-c-shared-utility/blob/master/devdoc/porting_guide.md
 [c-cross-compile]: doc/SDK_cross_compile_example.md
 [c-api-reference]: https://docs.microsoft.com/azure/iot-hub/iot-c-sdk-ref/
-[azure-iot-sdks]:https://github.com/azure/azure-iot-sdks
+[about-iot-sdks]:https://docs.microsoft.com/en-us/azure/iot-develop/about-iot-sdks


### PR DESCRIPTION
Tactical fixes for the ./readme.md at home directory and dev box setup instructions.

Rough sense of changes:
* Better motivation for SDK up-front.
* Since we don't want folks using service SDKs for C (should be other languages), don't reference as much on 1st page.
* Reference provisioning_service_client is the same level of support as iothub_service_client.
* Fix broken links.
* Push MQTT as preferred transport at this level (in docs I've edited, more work needed).
* Simplify/cleanup folder-structure documentation.
* Move OpenSSL on Windows to a new document and out of the main devbox setup, since this isn't a common scenario and we actually want to discourage this.
* Lots of wordsmithing.
