### PR TITLE
[longhaul] filter twin desired messages that was lost from network disconnect

### DIFF
--- a/iothub_client/tests/common_longhaul/iothub_client_statistics.c
+++ b/iothub_client/tests/common_longhaul/iothub_client_statistics.c
@@ -1314,7 +1314,7 @@ int iothub_client_statistics_get_device_twin_desired_summary(IOTHUB_CLIENT_STATI
                     if (singlylinkedlist_find(stats->connection_status_history, compare_message_time_to_connection_time, &device_twin_info->time_updated))
                     {
                         summary->updates_sent--;
-                        LogInfo("Removing twin desired update id (%u) because of network error", device_twin_info->update_id);
+                        LogInfo("Removing twin desired update id (%d) because of network error", (int)device_twin_info->update_id);
                     }
                 }
             }

--- a/testtools/iothub_test/src/iothubtest.c
+++ b/testtools/iothub_test/src/iothubtest.c
@@ -949,6 +949,8 @@ static AMQP_VALUE create_link_source(char* receive_address, filter_set filter_se
 
 static void on_connection_state_changed(void* context, CONNECTION_STATE new_connection_state, CONNECTION_STATE previous_connection_state)
 {
+    LogInfo("AMQP connection state changed. new_connection_state: %d, previous_connection_state %d", new_connection_state, previous_connection_state);
+
     IOTHUB_VALIDATION_INFO* devhubValInfo = (IOTHUB_VALIDATION_INFO*)context;
     if (devhubValInfo->isEventListenerConnected && 
         (new_connection_state == CONNECTION_STATE_END || new_connection_state == CONNECTION_STATE_ERROR) &&


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 