### PR TITLE
update the uamqp linking

### DIFF
--- a/iothub_client/CMakeLists.txt
+++ b/iothub_client/CMakeLists.txt
@@ -306,6 +306,7 @@ if(${use_amqp})
     )
     setSdkTargetBuildProperties(iothub_client_amqp_transport)
     linkSharedUtil(iothub_client_amqp_transport)
+    linkUAMQP(iothub_client_amqp_transport)
     set(iothub_client_libs
         ${iothub_client_libs}
         iothub_client_amqp_transport
@@ -318,6 +319,7 @@ if(${use_amqp})
     )
     setSdkTargetBuildProperties(iothub_client_amqp_ws_transport)
     linkSharedUtil(iothub_client_amqp_ws_transport)
+    linkUAMQP(iothub_client_amqp_ws_transport)
     set(iothub_client_libs
         ${iothub_client_libs}
         iothub_client_amqp_ws_transport
@@ -331,8 +333,6 @@ if(${use_amqp})
         set(iothub_transport_source ${iothub_transport_source}
             ${iothub_client_amqp_ws_transport_c_files}
             ${iothub_client_amqp_ws_transport_h_files})
-
-        set(iothub_client_libs ${iothub_client_libs} uamqp)
     endif(build_as_dynamic)
 endif()
 


### PR DESCRIPTION
Works to help [this part of this GH issue](https://github.com/Azure/azure-iot-sdk-c/issues/1839#issuecomment-777585600).

What's happening here? This uamqp lib is getting added to the list of libs for the iothub client. Which is fine for linking but not great for installing the libs since this lib isn't getting built here. This change makes the uamqp section parallel the mqtt section of the build:

build as dynamic for mqtt:
https://github.com/Azure/azure-iot-sdk-c/blob/e3f8f378b54c2d7ee2183c781a2a8ef0c66e1c86/iothub_client/CMakeLists.txt#L366-L374

linking the umqtt lib to the transport:
https://github.com/Azure/azure-iot-sdk-c/blob/e3f8f378b54c2d7ee2183c781a2a8ef0c66e1c86/iothub_client/CMakeLists.txt#L342-L348