### PR TITLE
Provisioning client with AMQP-WS uses an incorrect port when proxy is configured

### DIFF
--- a/provisioning_client/src/prov_transport_amqp_ws_client.c
+++ b/provisioning_client/src/prov_transport_amqp_ws_client.c
@@ -54,7 +54,7 @@ static PROV_TRANSPORT_IO_INFO* amqp_transport_ws_io(const char* fqdn, SASL_MECHA
         {
             /* Codes_PROV_TRANSPORT_AMQP_WS_CLIENT_07_012: [ If proxy_info is not NULL, amqp_transport_ws_io shall construct a HTTP_PROXY_IO_CONFIG object and assign it to TLSIO_CONFIG underlying_io_parameters ] */
             proxy_config.hostname = tls_io_config.hostname;
-            proxy_config.port = proxy_info->port;
+            proxy_config.port = PROV_AMQP_WS_PORT_NUM;
             proxy_config.proxy_hostname = proxy_info->host_address;
             proxy_config.proxy_port = proxy_info->port;
             proxy_config.username = proxy_info->username;


### PR DESCRIPTION

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `master` branch. 
  - [x] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 