### PR TITLE
Add simple thermostat sample for new PnP API

### DIFF
--- a/iothub_client/samples/pnp/common/pnp_sample_config.c
+++ b/iothub_client/samples/pnp/common/pnp_sample_config.c
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// This file implements the logic to retrieve the PnP sample's configuration via the environment.
+
+#include <stdlib.h>
+
+#include "azure_c_shared_utility/xlogging.h"
+#include "pnp_sample_config.h"
+
+// Environment variable used to specify how app connects to hub and the two possible values.
+static const char g_securityTypeEnvironmentVariable[] = "IOTHUB_DEVICE_SECURITY_TYPE";
+static const char g_securityTypeConnectionStringValue[] = "connectionString";
+static const char g_securityTypeDpsValue[] = "DPS";
+
+// Environment variable used to specify this application's connection string.
+static const char g_connectionStringEnvironmentVariable[] = "IOTHUB_DEVICE_CONNECTION_STRING";
+
+#ifdef USE_PROV_MODULE_FULL
+// Environment variable used to specify this application's DPS id scope.
+static const char g_dpsIdScopeEnvironmentVariable[] = "IOTHUB_DEVICE_DPS_ID_SCOPE";
+
+// Environment variable used to specify this application's DPS device id.
+static const char g_dpsDeviceIdEnvironmentVariable[] = "IOTHUB_DEVICE_DPS_DEVICE_ID";
+
+// Environment variable used to specify this application's DPS device key.
+static const char g_dpsDeviceKeyEnvironmentVariable[] = "IOTHUB_DEVICE_DPS_DEVICE_KEY";
+
+// Environment variable used to optionally specify this application's DPS id scope.
+static const char g_dpsEndpointEnvironmentVariable[] = "IOTHUB_DEVICE_DPS_ENDPOINT";
+
+// Global provisioning endpoint for DPS if one is not specified via the environment.
+static const char g_dps_DefaultGlobalProvUri[] = "global.azure-devices-provisioning.net";
+#endif
+
+//
+// GetConnectionStringFromEnvironment retrieves the connection string based on environment variable.
+//
+static bool GetConnectionStringFromEnvironment(PNP_DEVICE_CONFIGURATION* pnpDeviceConfiguration)
+{
+    bool result;
+
+    if ((pnpDeviceConfiguration->u.connectionString = getenv(g_connectionStringEnvironmentVariable)) == NULL)
+    {
+        LogError("Cannot read environment variable=%s", g_connectionStringEnvironmentVariable);
+        result = false;
+    }
+    else
+    {
+        pnpDeviceConfiguration->securityType = PNP_CONNECTION_SECURITY_TYPE_CONNECTION_STRING;
+        result = true;    
+    }
+
+    return result;
+}
+
+//
+// GetDpsFromEnvironment retrieves DPS configuration for a symmetric key based connection
+// from environment variables.
+//
+static bool GetDpsFromEnvironment(PNP_DEVICE_CONFIGURATION* pnpDeviceConfiguration)
+{
+#ifndef USE_PROV_MODULE_FULL
+    // Explain to user misconfiguration.  The "run_e2e_tests" must be set to OFF because otherwise
+    // the e2e's test HSM layer and symmetric key logic will conflict.
+    LogError("DPS based authentication was requested via environment variables, but DPS is not enabled.");
+    LogError("DPS is an optional component of the Azure IoT C SDK.  It is enabled with symmetric keys at cmake time by");
+    LogError("passing <-Duse_prov_client=ON -Dhsm_type_symm_key=ON -Drun_e2e_tests=OFF> to cmake's command line");
+    return false;
+#else
+    bool result;
+
+    if ((pnpDeviceConfiguration->u.dpsConnectionAuth.endpoint = getenv(g_dpsEndpointEnvironmentVariable)) == NULL)
+    {
+        // We will fall back to standard endpoint if one is not specified
+        pnpDeviceConfiguration->u.dpsConnectionAuth.endpoint = g_dps_DefaultGlobalProvUri;
+    }
+
+    if ((pnpDeviceConfiguration->u.dpsConnectionAuth.idScope = getenv(g_dpsIdScopeEnvironmentVariable)) == NULL)
+    {
+        LogError("Cannot read environment variable=%s", g_dpsIdScopeEnvironmentVariable);
+        result = false;
+    }
+    else if ((pnpDeviceConfiguration->u.dpsConnectionAuth.deviceId = getenv(g_dpsDeviceIdEnvironmentVariable)) == NULL)
+    {
+        LogError("Cannot read environment variable=%s", g_dpsDeviceIdEnvironmentVariable);
+        result = false;
+    }
+    else if ((pnpDeviceConfiguration->u.dpsConnectionAuth.deviceKey = getenv(g_dpsDeviceKeyEnvironmentVariable)) == NULL)
+    {
+        LogError("Cannot read environment variable=%s", g_dpsDeviceKeyEnvironmentVariable);
+        result = false;
+    }
+    else
+    {
+        pnpDeviceConfiguration->securityType = PNP_CONNECTION_SECURITY_TYPE_DPS;
+        result = true;    
+    }
+
+    return result;
+#endif // USE_PROV_MODULE_FULL
+}
+
+bool GetConnectionSettingsFromEnvironment(PNP_DEVICE_CONFIGURATION* pnpDeviceConfiguration)
+{
+    const char* securityTypeString;
+    bool result;
+
+    if ((securityTypeString = getenv(g_securityTypeEnvironmentVariable)) == NULL)
+    {
+        LogError("Cannot read environment variable=%s", g_securityTypeEnvironmentVariable);
+        result = false;
+    }
+    else
+    {
+        if (strcmp(securityTypeString, g_securityTypeConnectionStringValue) == 0)
+        {
+            result = GetConnectionStringFromEnvironment(pnpDeviceConfiguration);
+        }
+        else if (strcmp(securityTypeString, g_securityTypeDpsValue) == 0)
+        {
+            result = GetDpsFromEnvironment(pnpDeviceConfiguration);
+        }
+        else
+        {
+            LogError("Environment variable %s must be either %s or %s", g_securityTypeEnvironmentVariable, g_securityTypeConnectionStringValue, g_securityTypeDpsValue);
+            result = false;
+        }
+    }
+
+    return result;    
+}

--- a/iothub_client/samples/pnp/common/pnp_sample_config.h
+++ b/iothub_client/samples/pnp/common/pnp_sample_config.h
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef PNP_SAMPLE_CONFIG
+#define PNP_SAMPLE_CONFIG
+
+#include <stdbool.h>
+
+//
+// Whether we're using a connection string or DPS provisioning for device credentials
+//
+typedef enum PNP_CONNECTION_SECURITY_TYPE_TAG
+{
+    PNP_CONNECTION_SECURITY_TYPE_CONNECTION_STRING,
+    PNP_CONNECTION_SECURITY_TYPE_DPS
+} PNP_CONNECTION_SECURITY_TYPE;
+
+#ifdef USE_PROV_MODULE_FULL
+//
+// PNP_DPS_CONNECTION_AUTH is used to configure the DPS device client
+//
+typedef struct PNP_DPS_CONFIGURATION_TAG
+{
+    const char* endpoint;
+    const char* idScope;
+    const char* deviceId;
+    const char* deviceKey;
+} PNP_DPS_CONNECTION_AUTH;
+#endif /* USE_PROV_MODULE_FULL */
+
+//
+// PNP_DEVICE_CONFIGURATION is used to setup the IOTHUB_DEVICE_CLIENT_LL_HANDLE
+//
+typedef struct PNP_DEVICE_CONFIGURATION_TAG
+{
+    // Whether we're using connection string or DPS
+    PNP_CONNECTION_SECURITY_TYPE securityType;
+    // The connection string or DPS security information
+    union {
+        char* connectionString;
+#ifdef USE_PROV_MODULE_FULL
+        PNP_DPS_CONNECTION_AUTH dpsConnectionAuth;
+#endif
+    } u;
+    // ModelId of this PnP device
+    const char* modelId;
+    // Whether more verbose tracing is enabled for the IoT Hub client
+    bool enableTracing;
+} PNP_DEVICE_CONFIGURATION;
+
+//
+// GetConfigurationFromEnvironment determines how to connect to the IoT Hub (using 
+// either a connection string or a DPS symmetric key) from the environment.
+//
+bool GetConnectionSettingsFromEnvironment(PNP_DEVICE_CONFIGURATION* pnpDeviceConfiguration);
+
+#endif /* PNP_SAMPLE_CONFIG */

--- a/iothub_client/samples/pnp/common/pnp_status_values.h
+++ b/iothub_client/samples/pnp/common/pnp_status_values.h
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef PNP_STATUS_VALUES
+#define PNP_STATUS_VALUES
+
+// By convention, PnP uses HTTP status codes to indicate success and error states even for 
+// non-HTTP based protocols.  The codes below are the ones the sample uses, but applications
+// may use additional ones.
+
+#define PNP_STATUS_SUCCESS 200
+#define PNP_STATUS_BAD_FORMAT 400
+#define PNP_STATUS_NOT_FOUND 404
+#define PNP_STATUS_INTERNAL_ERROR 500
+
+#endif /* PNP_STATUS_VALUES */
+


### PR DESCRIPTION
Adds simple thermostat.

Note that there was pre-existing code using the "sample" API before which is being changed in place.  It's also being substantially cleaned up.  Some is because it's needed to fix up, and also bringing this implementation more inline with the thermostat component as part of more complex temp sensor.

For the ./common directory, we either:
* Deprecated stuff we really don't want to use anymore, like the pnp_protocol, is clearly deprecated both in files and in readme.md.
* Add a few more files for helpers.
* Update the DPS implementation, which should remain common, but needed cleaning up.

Checkin flow:
* Stage1 Checked in the public header files.
* Stage2a **This checkin** adds the updated samples for simple thermostat.
* Stage2b will add the updated samples for more complex temperature sensor.
* Stage3 will add code implementation.
* Stage4 will add unit tests.  
