### PR TITLE
Set device method travel time back to 300

### DIFF
--- a/iothub_client/tests/common_longhaul/iothub_client_common_longhaul.c
+++ b/iothub_client/tests/common_longhaul/iothub_client_common_longhaul.c
@@ -1497,7 +1497,7 @@ static int invoke_device_method(const void* context)
                     iotHubLonghaul->deviceInfo->deviceId,
                     LONGHAUL_DEVICE_METHOD_NAME,
                     message,
-                    MAX_DEVICE_METHOD_TRAVEL_TIME_SECS,
+                    300,
                     &responseStatus, &responsePayload, &responseSize);
 
                 if (device_method_info.method_result == IOTHUB_DEVICE_METHOD_OK)


### PR DESCRIPTION
Set device method travel time back to 300

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 
  - [ ] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 