### PR TITLE
provisioning_client: explicitly states function prototypes

### DIFF
--- a/provisioning_client/adapters/hsm_client_data.c
+++ b/provisioning_client/adapters/hsm_client_data.c
@@ -18,7 +18,7 @@
 #include "hsm_client_key.h"
 #endif
 
-int initialize_hsm_system()
+int initialize_hsm_system(void)
 {
     int result = 0;
 #if defined(HSM_TYPE_X509) || defined(HSM_AUTH_TYPE_CUSTOM)
@@ -47,7 +47,7 @@ int initialize_hsm_system()
     return result;
 }
 
-void deinitialize_hsm_system()
+void deinitialize_hsm_system(void)
 {
 #ifdef HSM_TYPE_HTTP_EDGE
     hsm_client_http_edge_deinit();

--- a/provisioning_client/adapters/hsm_client_data.h
+++ b/provisioning_client/adapters/hsm_client_data.h
@@ -13,7 +13,7 @@ extern "C" {
 
 typedef void* HSM_CLIENT_HANDLE;
 
-typedef HSM_CLIENT_HANDLE (*HSM_CLIENT_CREATE)();
+typedef HSM_CLIENT_HANDLE (*HSM_CLIENT_CREATE)(void);
 typedef void (*HSM_CLIENT_DESTROY)(HSM_CLIENT_HANDLE handle);
 
 // TPM
@@ -76,17 +76,17 @@ typedef struct HSM_CLIENT_KEY_INTERFACE_TAG
     HSM_CLIENT_SET_SYMMETRICAL_KEY_INFO hsm_client_set_symm_key_info;
 } HSM_CLIENT_KEY_INTERFACE;
 
-extern int initialize_hsm_system();
-extern void deinitialize_hsm_system();
+extern int initialize_hsm_system(void);
+extern void deinitialize_hsm_system(void);
 
-extern const HSM_CLIENT_TPM_INTERFACE* hsm_client_tpm_interface();
-extern const HSM_CLIENT_X509_INTERFACE* hsm_client_x509_interface();
-extern const HSM_CLIENT_KEY_INTERFACE* hsm_client_key_interface();
+extern const HSM_CLIENT_TPM_INTERFACE* hsm_client_tpm_interface(void);
+extern const HSM_CLIENT_X509_INTERFACE* hsm_client_x509_interface(void);
+extern const HSM_CLIENT_KEY_INTERFACE* hsm_client_key_interface(void);
 
-extern int hsm_client_x509_init();
-extern void hsm_client_x509_deinit();
-extern int hsm_client_tpm_init();
-extern void hsm_client_tpm_deinit();
+extern int hsm_client_x509_init(void);
+extern void hsm_client_x509_deinit(void);
+extern int hsm_client_tpm_init(void);
+extern void hsm_client_tpm_deinit(void);
 
 #ifdef HSM_TYPE_HTTP_EDGE
 extern int hsm_client_http_edge_init();

--- a/provisioning_client/samples/custom_hsm_example/custom_hsm_example.c
+++ b/provisioning_client/samples/custom_hsm_example/custom_hsm_example.c
@@ -40,25 +40,25 @@ typedef struct CUSTOM_HSM_SAMPLE_INFO_TAG
     const char* registration_name;
 } CUSTOM_HSM_SAMPLE_INFO;
 
-int hsm_client_x509_init()
+int hsm_client_x509_init(void)
 {
     return 0;
 }
 
-void hsm_client_x509_deinit()
+void hsm_client_x509_deinit(void)
 {
 }
 
-int hsm_client_tpm_init()
+int hsm_client_tpm_init(void)
 {
     return 0;
 }
 
-void hsm_client_tpm_deinit()
+void hsm_client_tpm_deinit(void)
 {
 }
 
-HSM_CLIENT_HANDLE custom_hsm_create()
+HSM_CLIENT_HANDLE custom_hsm_create(void)
 {
     HSM_CLIENT_HANDLE result;
     CUSTOM_HSM_SAMPLE_INFO* hsm_info = malloc(sizeof(CUSTOM_HSM_SAMPLE_INFO));
@@ -363,19 +363,19 @@ static const HSM_CLIENT_KEY_INTERFACE symm_key_interface =
     custom_hsm_get_registration_name
 };
 
-const HSM_CLIENT_TPM_INTERFACE* hsm_client_tpm_interface()
+const HSM_CLIENT_TPM_INTERFACE* hsm_client_tpm_interface(void)
 {
     // tpm interface pointer
     return &tpm_interface;
 }
 
-const HSM_CLIENT_X509_INTERFACE* hsm_client_x509_interface()
+const HSM_CLIENT_X509_INTERFACE* hsm_client_x509_interface(void)
 {
     // x509 interface pointer
     return &x509_interface;
 }
 
-const HSM_CLIENT_KEY_INTERFACE* hsm_client_key_interface()
+const HSM_CLIENT_KEY_INTERFACE* hsm_client_key_interface(void)
 {
     return &symm_key_interface;
 }

--- a/provisioning_client/tests/common_prov_e2e/prov_hsm/provisioning_hsm.c
+++ b/provisioning_client/tests/common_prov_e2e/prov_hsm/provisioning_hsm.c
@@ -21,37 +21,37 @@ typedef struct IOTHUB_HSM_IMPL_TAG
     SYMM_KEY_INFO_HANDLE key_info;
 } IOTHUB_HSM_IMPL;
 
-int hsm_client_x509_init()
+int hsm_client_x509_init(void)
 {
     int result = 0;
     initialize_device();
     return result;
 }
 
-void hsm_client_x509_deinit()
+void hsm_client_x509_deinit(void)
 {
 }
 
-int hsm_client_tpm_init()
+int hsm_client_tpm_init(void)
 {
     return 0;
 }
 
-void hsm_client_tpm_deinit()
+void hsm_client_tpm_deinit(void)
 {
 }
 
-int hsm_client_key_init()
+int hsm_client_key_init(void)
 {
     initialize_symm_key();
     return 0;
 }
 
-void hsm_client_key_deinit()
+void hsm_client_key_deinit(void)
 {
 }
 
-HSM_CLIENT_HANDLE iothub_hsm_x509_create()
+HSM_CLIENT_HANDLE iothub_hsm_x509_create(void)
 {
     IOTHUB_HSM_IMPL* result;
     result = malloc(sizeof(IOTHUB_HSM_IMPL));
@@ -70,7 +70,7 @@ HSM_CLIENT_HANDLE iothub_hsm_x509_create()
     return (HSM_CLIENT_HANDLE)result;
 }
 
-HSM_CLIENT_HANDLE iothub_hsm_tpm_create()
+HSM_CLIENT_HANDLE iothub_hsm_tpm_create(void)
 {
     IOTHUB_HSM_IMPL* result;
     result = malloc(sizeof(IOTHUB_HSM_IMPL));
@@ -92,7 +92,7 @@ HSM_CLIENT_HANDLE iothub_hsm_tpm_create()
     return (HSM_CLIENT_HANDLE)result;
 }
 
-HSM_CLIENT_HANDLE iothub_hsm_key_create()
+HSM_CLIENT_HANDLE iothub_hsm_key_create(void)
 {
     IOTHUB_HSM_IMPL* result;
     result = malloc(sizeof(IOTHUB_HSM_IMPL));
@@ -412,7 +412,7 @@ static const HSM_CLIENT_X509_INTERFACE x509_interface =
     iothub_hsm_get_common_name
 };
 
-const HSM_CLIENT_X509_INTERFACE* hsm_client_x509_interface()
+const HSM_CLIENT_X509_INTERFACE* hsm_client_x509_interface(void)
 {
     return &x509_interface;
 }
@@ -427,7 +427,7 @@ static const HSM_CLIENT_TPM_INTERFACE tpm_interface =
     iothub_tpm_hsm_sign_with_identity
 };
 
-const HSM_CLIENT_TPM_INTERFACE* hsm_client_tpm_interface()
+const HSM_CLIENT_TPM_INTERFACE* hsm_client_tpm_interface(void)
 {
     // tpm interface pointer
     return &tpm_interface;
@@ -441,7 +441,7 @@ static const HSM_CLIENT_KEY_INTERFACE key_interface =
     iothub_hsm_get_registry_id
 };
 
-const HSM_CLIENT_KEY_INTERFACE* hsm_client_key_interface()
+const HSM_CLIENT_KEY_INTERFACE* hsm_client_key_interface(void)
 {
     // tpm interface pointer
     return &key_interface;

--- a/provisioning_client/tests/common_prov_e2e/prov_hsm/symm_key.c
+++ b/provisioning_client/tests/common_prov_e2e/prov_hsm/symm_key.c
@@ -20,12 +20,12 @@ typedef struct SYMM_KEY_INFO_TAG
     char reg_id[128];
 } SYMM_KEY_INFO;
 
-void initialize_symm_key()
+void initialize_symm_key(void)
 {
     // Generate crypto key
 }
 
-SYMM_KEY_INFO_HANDLE symm_key_info_create()
+SYMM_KEY_INFO_HANDLE symm_key_info_create(void)
 {
     SYMM_KEY_INFO* result;
     /* Codes_SRS_HSM_CLIENT_TPM_07_002: [ On success hsm_client_tpm_create shall allocate a new instance of the secure device tpm interface. ] */

--- a/provisioning_client/tests/common_prov_e2e/prov_hsm/symm_key.h
+++ b/provisioning_client/tests/common_prov_e2e/prov_hsm/symm_key.h
@@ -13,9 +13,9 @@ extern "C" {
 
     typedef struct SYMM_KEY_INFO_TAG* SYMM_KEY_INFO_HANDLE;
 
-    extern void initialize_symm_key();
+    extern void initialize_symm_key(void);
 
-    extern SYMM_KEY_INFO_HANDLE symm_key_info_create();
+    extern SYMM_KEY_INFO_HANDLE symm_key_info_create(void);
     extern void symm_key_info_destroy(SYMM_KEY_INFO_HANDLE handle);
     extern const char* symm_key_info_get_key(SYMM_KEY_INFO_HANDLE handle);
     extern const char* symm_key_info_get_reg_id(SYMM_KEY_INFO_HANDLE handle);

--- a/provisioning_client/tests/common_prov_e2e/prov_hsm/tpm_msr.c
+++ b/provisioning_client/tests/common_prov_e2e/prov_hsm/tpm_msr.c
@@ -40,7 +40,7 @@ static TPMS_RSA_PARMS  RsaStorageParams = {
 0                                       // UINT32               exponent
 };
 
-static TPM2B_PUBLIC* GetEkTemplate ()
+static TPM2B_PUBLIC* GetEkTemplate (void)
 {
     static TPM2B_PUBLIC EkTemplate = { 0,   // size will be computed during marshaling
     {
@@ -62,7 +62,7 @@ static TPM2B_PUBLIC* GetEkTemplate ()
     return &EkTemplate;
 }
 
-static TPM2B_PUBLIC* GetSrkTemplate()
+static TPM2B_PUBLIC* GetSrkTemplate(void)
 {
     static TPM2B_PUBLIC SrkTemplate = { 0,  // size will be computed during marshaling
     {
@@ -268,7 +268,7 @@ static int initialize_tpm(TPM_INFO* tpm_info)
     return result;
 }
 
-TPM_INFO_HANDLE tpm_msr_create()
+TPM_INFO_HANDLE tpm_msr_create(void)
 {
     TPM_INFO* result;
     result = (TPM_INFO*)malloc(sizeof(TPM_INFO));

--- a/provisioning_client/tests/common_prov_e2e/prov_hsm/tpm_msr.h
+++ b/provisioning_client/tests/common_prov_e2e/prov_hsm/tpm_msr.h
@@ -13,7 +13,7 @@ extern "C" {
 
 typedef struct TPM_INFO_TAG* TPM_INFO_HANDLE;
 
-extern TPM_INFO_HANDLE tpm_msr_create();
+extern TPM_INFO_HANDLE tpm_msr_create(void);
 extern void tpm_msr_destroy(TPM_INFO_HANDLE handle);
 
 extern int tpm_msr_get_ek(TPM_INFO_HANDLE handle, unsigned char* data_pos, size_t* key_len);

--- a/provisioning_client/tests/common_prov_e2e/prov_hsm/x509_info.h
+++ b/provisioning_client/tests/common_prov_e2e/prov_hsm/x509_info.h
@@ -13,8 +13,8 @@
 
     typedef struct X509_CERT_INFO_TAG* X509_INFO_HANDLE;
 
-    extern void initialize_device();
-    extern X509_INFO_HANDLE x509_info_create();
+    extern void initialize_device(void);
+    extern X509_INFO_HANDLE x509_info_create(void);
     extern void x509_info_destroy(X509_INFO_HANDLE handle);
     extern const char* x509_info_get_cert(X509_INFO_HANDLE handle);
     extern const char* x509_info_get_key(X509_INFO_HANDLE handle);

--- a/provisioning_client/tests/common_prov_e2e/prov_hsm/x509_msr.c
+++ b/provisioning_client/tests/common_prov_e2e/prov_hsm/x509_msr.c
@@ -407,7 +407,7 @@ static int process_riot_key_info(X509_CERT_INFO* x509_info)
     return result;
 }
 
-static void generate_subject_name()
+static void generate_subject_name(void)
 {
     char device_guid[DEVICE_GUID_SIZE];
     if (UniqueId_Generate(device_guid, DEVICE_GUID_SIZE) != UNIQUEID_OK)
@@ -438,7 +438,7 @@ static void generate_subject_name()
     }
 }
 
-static void generate_keys()
+static void generate_keys(void)
 {
     if (g_digest_initialized == 0)
     {
@@ -461,13 +461,13 @@ static void generate_keys()
     }
 }
 
-void initialize_device()
+void initialize_device(void)
 {
     generate_keys();
     generate_subject_name();
 }
 
-X509_INFO_HANDLE x509_info_create()
+X509_INFO_HANDLE x509_info_create(void)
 {
     X509_CERT_INFO* result;
     /* Codes_SRS_HSM_CLIENT_TPM_07_002: [ On success hsm_client_tpm_create shall allocate a new instance of the secure device tpm interface. ] */


### PR DESCRIPTION
When building with `-Wstrict-prototypes` flag enabled, functions with no
explicit prototype are reported (i.e. `()` instead of `(void)`).

Replacing the empty parenthesis with the correct form of declaring a
function without arguments fixes the issue.

Signed-off-by: Francesco Giancane <francesco.giancane@accenture.com>

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] ~~I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).~~
- ~~If this is a modification that impacts the behavior of a public API~~
  - [ ] ~~I edited the corresponding document in the `devdoc` folder and added or modified requirements.~~
- I submitted this PR against the correct branch: 
  - [X] This pull-request is submitted against the `master` branch. 
  - [X] I have merged the latest `master` branch prior to submission and re-merged as needed after I took any feedback.
  - [X] I have squashed my changes into one with a clear description of the change.

# Description of the problem
When building the library on systems where `-Wstrict-prototypes` flag is asserted, a warning is emitted stating that each and every function prototype in this PR is not correct.

# Description of the solution
function with missing arguments `()` are signaled via that warning flag. Replacing the empty parenthesis with a correct empty argument function signature `(void)` solved the issue.