### PR TITLE
Have multiple PnP component sample use official PnP API

### DIFF
--- a/iothub_client/samples/pnp/common/pnp_dps_ll.c
+++ b/iothub_client/samples/pnp/common/pnp_dps_ll.c
@@ -53,7 +53,7 @@ static char* g_dpsDeviceId;
 // maximum number of characters for an ID is 128.  We reserve extra space for the JSON envelope.
 #define PNP_DPS_REGISTRATION_MAX_PAYLOAD_SIZE (128 + 16)
 // snprintf style format for building the payload for Prov_Device_LL_Set_Provisioning_Payload() call.
-static const char PNP_DPS_REGISTRATION_FMT[] =  "{\"modelId\":\"%s\"}";
+static const char PNP_DPS_REGISTRATION_FMT[] = "{\"modelId\":\"%s\"}";
 
 //
 // provisioningRegisterCallback is called by the DPS client when the DPS server has either succeeded or failed the DPS
@@ -98,12 +98,7 @@ IOTHUB_DEVICE_CLIENT_LL_HANDLE PnP_CreateDeviceClientLLHandle_ViaDps(const PNP_D
     g_pnpDpsRegistrationStatus = PNP_DPS_REGISTRATION_NOT_COMPLETE;
 
     // Initial DPS setup and handle creation.
-    if (snprintf(modelIdPayload, sizeof(modelIdPayload), PNP_DPS_REGISTRATION_FMT, pnpDeviceConfiguration->modelId) < 0)
-    {
-        LogError("building modelId payload unsuccessful");
-        result = false;
-    }
-    else if ((prov_dev_set_symmetric_key_info(pnpDeviceConfiguration->u.dpsConnectionAuth.deviceId, pnpDeviceConfiguration->u.dpsConnectionAuth.deviceKey) != 0))
+    if ((prov_dev_set_symmetric_key_info(pnpDeviceConfiguration->u.dpsConnectionAuth.deviceId, pnpDeviceConfiguration->u.dpsConnectionAuth.deviceKey) != 0))
     {
         LogError("prov_dev_set_symmetric_key_info failed.");
         result = false;
@@ -121,6 +116,11 @@ IOTHUB_DEVICE_CLIENT_LL_HANDLE PnP_CreateDeviceClientLLHandle_ViaDps(const PNP_D
     else if ((provDeviceResult = Prov_Device_LL_SetOption(provDeviceClient, PROV_OPTION_LOG_TRACE, &pnpDeviceConfiguration->enableTracing)) != PROV_DEVICE_RESULT_OK)
     {
         LogError("Setting provisioning tracing on failed, error=%d", provDeviceResult);
+        result = false;
+    }
+    else if (snprintf(modelIdPayload, sizeof(modelIdPayload), PNP_DPS_REGISTRATION_FMT, pnpDeviceConfiguration->modelId) < 0)
+    {
+        LogError("building modelId payload unsuccessful");
         result = false;
     }
     else if ((provDeviceResult = Prov_Device_LL_Set_Provisioning_Payload(provDeviceClient, modelIdPayload)) != PROV_DEVICE_RESULT_OK)

--- a/iothub_client/samples/pnp/pnp_simple_thermostat/CMakeLists.txt
+++ b/iothub_client/samples/pnp/pnp_simple_thermostat/CMakeLists.txt
@@ -7,6 +7,7 @@ compileAsC99()
 
 set(pnp_simple_thermostat_c_files
     pnp_simple_thermostat.c
+    ../common/pnp_sample_config.c
 )
 
 IF(WIN32)
@@ -15,8 +16,7 @@ IF(WIN32)
 ENDIF(WIN32)
 
 if(${use_prov_client})
-    set(pnp_simple_thermostat_c_files ${pnp_simple_thermostat_c_files} ../common/pnp_dps_ll.c ../common/pnp_sample_config.c)
-    include_directories(../common)
+    set(pnp_simple_thermostat_c_files ${pnp_simple_thermostat_c_files} ../common/pnp_dps_ll.c)
 endif()
 
 #Conditionally use the SDK trusted certs in the samples
@@ -26,7 +26,7 @@ if(${use_sample_trusted_cert})
     set(pnp_simple_thermostat_c_files ${pnp_simple_thermostat_c_files} ${PROJECT_SOURCE_DIR}/certs/certs.c)
 endif()
 
-include_directories(. ${PROJECT_SOURCE_DIR}/deps/parson)
+include_directories(. ${PROJECT_SOURCE_DIR}/deps/parson ../common)
 
 add_executable(pnp_simple_thermostat ${pnp_simple_thermostat_c_files})
 

--- a/iothub_client/samples/pnp/pnp_simple_thermostat/pnp_simple_thermostat.c
+++ b/iothub_client/samples/pnp/pnp_simple_thermostat/pnp_simple_thermostat.c
@@ -67,7 +67,7 @@ static const char g_targetTemperaturePropertyName[] = "targetTemperature";
 static const char g_maxTempSinceLastRebootPropertyName[] = "maxTempSinceLastReboot";
 
 // Name of command this component supports to get report information
-static const char g_getMaxMinReport[] = "getMaxMinReport";
+static const char g_getMaxMinReportCommandName[] = "getMaxMinReport";
 
 // An empty JSON body for PnP command responses.
 static const char g_JSONEmpty[] = "{}";
@@ -262,7 +262,7 @@ static int Thermostat_CommandCallback(const char* componentName, const char* com
         LogError("This model only supports root components, but component %s was specified in command", componentName);
         result = PNP_STATUS_NOT_FOUND;
     }
-    else if (strcmp(commandName, g_getMaxMinReport) != 0)
+    else if (strcmp(commandName, g_getMaxMinReportCommandName) != 0)
     {
         LogError("Command name %s is not supported on this component", commandName);
         result = PNP_STATUS_NOT_FOUND;

--- a/iothub_client/samples/pnp/pnp_simple_thermostat/pnp_simple_thermostat.c
+++ b/iothub_client/samples/pnp/pnp_simple_thermostat/pnp_simple_thermostat.c
@@ -412,7 +412,7 @@ static void SendMaxTemperatureSinceReboot(IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceC
 static void Thermostat_ProcessTargetTemperature(IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient, IOTHUB_CLIENT_DESERIALIZED_PROPERTY* property, int propertiesVersion)
 {
     char* next;
-    double targetTemperature = strtol(property->value.str, &next, 10);
+    double targetTemperature = strtod(property->value.str, &next);
     if ((property->value.str == next) || (targetTemperature == LONG_MAX) || (targetTemperature == LONG_MIN))
     {
         LogError("Property %s is not a valid integer", property->value.str);

--- a/iothub_client/samples/pnp/pnp_simple_thermostat/pnp_simple_thermostat.c
+++ b/iothub_client/samples/pnp/pnp_simple_thermostat/pnp_simple_thermostat.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <limits.h>
 
 // JSON parser library.
 #include "parson.h"
@@ -19,9 +20,9 @@
 // IoT Hub device client and IoT core utility related header files.
 #include "iothub.h"
 #include "iothub_device_client_ll.h"
-#include "iothub_message.h"
 #include "iothub_client_options.h"
 #include "iothubtransportmqtt.h"
+#include "iothub_message.h"
 #include "iothub_client_properties.h"
 #include "azure_c_shared_utility/threadapi.h"
 #include "azure_c_shared_utility/xlogging.h"
@@ -438,7 +439,7 @@ static void Thermostat_ProcessTargetTemperature(IOTHUB_DEVICE_CLIENT_LL_HANDLE d
 //
 // Thermostat_PropertiesCallback is invoked when properties arrive from the server.
 //
-static int Thermostat_PropertiesCallback(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE payloadType,  const unsigned char* payload, size_t payloadLength, void* userContextCallback)
+static void Thermostat_PropertiesCallback(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE payloadType,  const unsigned char* payload, size_t payloadLength, void* userContextCallback)
 {
     IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient = (IOTHUB_DEVICE_CLIENT_LL_HANDLE)userContextCallback;
     IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE propertyIterator = NULL;
@@ -502,7 +503,6 @@ static int Thermostat_PropertiesCallback(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE pay
     }
 
     IoTHubClient_Deserialize_Properties_DestroyIterator(propertyIterator);
-    return 0;
 }
 
 //

--- a/iothub_client/samples/pnp/pnp_temperature_controller/CMakeLists.txt
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/CMakeLists.txt
@@ -9,6 +9,7 @@ set(pnp_temperature_controller_c_files
     pnp_temperature_controller.c
     pnp_thermostat_component.c
     pnp_deviceinfo_component.c
+    ../common/pnp_sample_config.c
 )
 
 IF(WIN32)
@@ -17,7 +18,7 @@ IF(WIN32)
 ENDIF(WIN32)
 
 if(${use_prov_client})
-    set(pnp_temperature_controller_c_files ${pnp_temperature_controller_c_files} ../common/pnp_dps_ll.c ../common/pnp_sample_config.c)
+    set(pnp_temperature_controller_c_files ${pnp_temperature_controller_c_files} ../common/pnp_dps_ll.c)
 endif()
 
 #Conditionally use the SDK trusted certs in the samples

--- a/iothub_client/samples/pnp/pnp_temperature_controller/CMakeLists.txt
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/CMakeLists.txt
@@ -9,8 +9,6 @@ set(pnp_temperature_controller_c_files
     pnp_temperature_controller.c
     pnp_thermostat_component.c
     pnp_deviceinfo_component.c
-    ../common/pnp_device_client_ll.c
-    ../common/pnp_protocol.c
 )
 
 IF(WIN32)
@@ -19,7 +17,7 @@ IF(WIN32)
 ENDIF(WIN32)
 
 if(${use_prov_client})
-    set(pnp_temperature_controller_c_files ${pnp_temperature_controller_c_files} ../common/pnp_dps_ll.c)
+    set(pnp_temperature_controller_c_files ${pnp_temperature_controller_c_files} ../common/pnp_dps_ll.c ../common/pnp_sample_config.c)
 endif()
 
 #Conditionally use the SDK trusted certs in the samples

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_deviceinfo_component.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_deviceinfo_component.c
@@ -44,7 +44,7 @@ void PnP_DeviceInfoComponent_Report_All_Properties(const char* componentName, IO
     IOTHUB_CLIENT_RESULT iothubClientResult;
     unsigned char* propertiesSerialized = NULL;
     size_t propertiesSerializedLength;
-    IOTHUB_CLIENT_REPORTED_PROPERTY properties[8] =  {
+    IOTHUB_CLIENT_REPORTED_PROPERTY properties[] =  {
         {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_SoftwareVersionPropertyName, PnPDeviceInfo_SoftwareVersionPropertyValue},
         {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_ManufacturerPropertyName, PnPDeviceInfo_ManufacturerPropertyValue},
         {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_ModelPropertyName, PnPDeviceInfo_ModelPropertyValue},

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_deviceinfo_component.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_deviceinfo_component.c
@@ -55,7 +55,7 @@ void PnP_DeviceInfoComponent_Report_All_Properties(const char* componentName, IO
         {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_TotalMemoryPropertyName, PnPDeviceInfo_TotalMemoryPropertyValue}
     };
 
-    const int numProperties = sizeof(properties) / sizeof(properties[0]);
+    const size_t numProperties = sizeof(properties) / sizeof(properties[0]);
 
     // The first step of reporting properties is to serialize IOTHUB_CLIENT_REPORTED_PROPERTY into JSON for sending.
     if ((iothubClientResult = IoTHubClient_Serialize_ReportedProperties(properties, numProperties, componentName, &propertiesSerialized, &propertiesSerializedLength)) != IOTHUB_CLIENT_OK)

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_deviceinfo_component.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_deviceinfo_component.c
@@ -5,14 +5,13 @@
 
 // PnP routines
 #include "pnp_deviceinfo_component.h"
-#include "pnp_protocol.h"
+#include "iothub_client_properties.h"
 
 // Core IoT SDK utilities
 #include "azure_c_shared_utility/xlogging.h"
 
 // Property names along with their simulated values.  
 // NOTE: the property values must be legal JSON values.  Strings specifically must be enclosed with an extra set of quotes to be legal json string values.
-// The property names in this sample do not hard-code the extra quotes because the underlying PnP sample adds this to names automatically.
 #define PNP_ENCODE_STRING_FOR_JSON(str) #str
 
 static const char PnPDeviceInfo_SoftwareVersionPropertyName[] = "swVersion";
@@ -40,47 +39,34 @@ static const char PnPDeviceInfo_TotalStoragePropertyValue[] = "10000";
 static const char PnPDeviceInfo_TotalMemoryPropertyName[] = "totalMemory";
 static const char PnPDeviceInfo_TotalMemoryPropertyValue[] = "200";
 
-//
-// SendReportedPropertyForDeviceInformation sends a property as part of DeviceInfo component.
-//
-static void SendReportedPropertyForDeviceInformation(IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClientLL, const char* componentName, const char* propertyName, const char* propertyValue)
+void PnP_DeviceInfoComponent_Report_All_Properties(const char* componentName, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient)
 {
     IOTHUB_CLIENT_RESULT iothubClientResult;
-    STRING_HANDLE jsonToSend = NULL;
+    unsigned char* propertiesSerialized = NULL;
+    size_t propertiesSerializedLength;
+    IOTHUB_CLIENT_REPORTED_PROPERTY properties[8] =  {
+        {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_SoftwareVersionPropertyName, PnPDeviceInfo_SoftwareVersionPropertyValue},
+        {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_ManufacturerPropertyName, PnPDeviceInfo_ManufacturerPropertyValue},
+        {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_ModelPropertyName, PnPDeviceInfo_ModelPropertyValue},
+        {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_OsNamePropertyName, PnPDeviceInfo_OsNamePropertyValue},
+        {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_ProcessorArchitecturePropertyName, PnPDeviceInfo_ProcessorArchitecturePropertyValue},
+        {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_ProcessorManufacturerPropertyName, PnPDeviceInfo_ProcessorManufacturerPropertyValue},
+        {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_TotalStoragePropertyName, PnPDeviceInfo_TotalStoragePropertyValue},
+        {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_TotalMemoryPropertyName, PnPDeviceInfo_TotalMemoryPropertyValue}
+    };
 
-    if ((jsonToSend = PnP_CreateReportedProperty(componentName, propertyName, propertyValue)) == NULL)
+    const int numProperties = sizeof(properties) / sizeof(properties[0]);
+
+    // The first step of reporting properties is to serialize IOTHUB_CLIENT_REPORTED_PROPERTY into JSON for sending.
+    if ((iothubClientResult = IoTHubClient_Serialize_ReportedProperties(properties, numProperties, componentName, &propertiesSerialized, &propertiesSerializedLength)) != IOTHUB_CLIENT_OK)
     {
-        LogError("Unable to build reported property response for propertyName=%s, propertyValue=%s", propertyName, propertyValue);
+        LogError("Unable to serialize reported state, error=%d", iothubClientResult);
     }
-    else
+    // The output of IoTHubClient_Serialize_ReportedProperties is sent to IoTHubDeviceClient_LL_SendPropertiesAsync to perform network I/O.
+    else if ((iothubClientResult = IoTHubDeviceClient_LL_SendPropertiesAsync(deviceClient, propertiesSerialized, propertiesSerializedLength, NULL, NULL)) != IOTHUB_CLIENT_OK)
     {
-        const char* jsonToSendStr = STRING_c_str(jsonToSend);
-        size_t jsonToSendStrLen = strlen(jsonToSendStr);
-
-        if ((iothubClientResult = IoTHubDeviceClient_LL_SendReportedState(deviceClientLL, (const unsigned char*)jsonToSendStr, jsonToSendStrLen, NULL, NULL)) != IOTHUB_CLIENT_OK)
-        {
-            LogError("Unable to send reported state for property=%s, error=%d", propertyName, iothubClientResult);
-        }
-        else
-        {
-            LogInfo("Sending device information property to IoTHub.  propertyName=%s, propertyValue=%s", propertyName, propertyValue);
-        }
+        LogError("Unable to send reported state, error=%d", iothubClientResult);
     }
 
-    STRING_delete(jsonToSend);
-}
-
-void PnP_DeviceInfoComponent_Report_All_Properties(const char* componentName, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClientLL)
-{
-    // NOTE: It is possible to put multiple property updates into a single JSON and IoTHubDeviceClient_LL_SendReportedState invocation.
-    // This sample does not do so for clarity, though production devices should seriously consider such property update batching to
-    // save bandwidth.  PnP_CreateReportedProperty does not currently accept arrays.
-    SendReportedPropertyForDeviceInformation(deviceClientLL, componentName, PnPDeviceInfo_SoftwareVersionPropertyName, PnPDeviceInfo_SoftwareVersionPropertyValue);
-    SendReportedPropertyForDeviceInformation(deviceClientLL, componentName, PnPDeviceInfo_ManufacturerPropertyName, PnPDeviceInfo_ManufacturerPropertyValue);
-    SendReportedPropertyForDeviceInformation(deviceClientLL, componentName, PnPDeviceInfo_ModelPropertyName, PnPDeviceInfo_ModelPropertyValue);
-    SendReportedPropertyForDeviceInformation(deviceClientLL, componentName, PnPDeviceInfo_OsNamePropertyName, PnPDeviceInfo_OsNamePropertyValue);
-    SendReportedPropertyForDeviceInformation(deviceClientLL, componentName, PnPDeviceInfo_ProcessorArchitecturePropertyName, PnPDeviceInfo_ProcessorArchitecturePropertyValue);
-    SendReportedPropertyForDeviceInformation(deviceClientLL, componentName, PnPDeviceInfo_ProcessorManufacturerPropertyName, PnPDeviceInfo_ProcessorManufacturerPropertyValue);
-    SendReportedPropertyForDeviceInformation(deviceClientLL, componentName, PnPDeviceInfo_TotalStoragePropertyName, PnPDeviceInfo_TotalStoragePropertyValue);
-    SendReportedPropertyForDeviceInformation(deviceClientLL, componentName, PnPDeviceInfo_TotalMemoryPropertyName, PnPDeviceInfo_TotalMemoryPropertyValue);
+    IoTHubClient_Serialize_Properties_Destroy(propertiesSerialized);
 }

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_deviceinfo_component.h
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_deviceinfo_component.h
@@ -13,8 +13,8 @@
 #include "iothub_device_client_ll.h"
 
 //
-// PnP_DeviceInfoComponent_Report_All_Properties sends properties corresponding to the DeviceInfo interface to the cloud.
+// PnP_DeviceInfoComponent_Report_All_Properties sends properties corresponding to the DeviceInfo interface to IoT Hub.
 //
-void PnP_DeviceInfoComponent_Report_All_Properties(const char* componentName, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClientLL);
+void PnP_DeviceInfoComponent_Report_All_Properties(const char* componentName, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient);
 
 #endif /* PNP_DEVICEINFO_COMPONENT_H */

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_temperature_controller.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_temperature_controller.c
@@ -55,7 +55,7 @@ static unsigned int g_sleepBetweenPollsMs = 100;
 // So we will send telemetry every (g_sendTelemetryPollInterval * g_sleepBetweenPollsMs) milliseconds; 60 seconds as currently configured.
 static const int g_sendTelemetryPollInterval = 600;
 
-// Whether tracing at the IoTHub client is enabled or not.
+// Whether tracing at the IoT Hub client is enabled or not.
 static bool g_hubClientTraceEnabled = true;
 
 // DTMI indicating this device's model identifier.
@@ -169,7 +169,8 @@ static int PnP_TempControlComponent_InvokeRebootCommand(JSON_Value* rootValue)
 //
 // PnP_TempControlComponent_CommandCallback is invoked by IoT SDK when a command arrives.
 //
-static int PnP_TempControlComponent_CommandCallback(const char* componentName, const char* commandName, const unsigned char* payload, size_t size, const char* payloadContentType, unsigned char** response, size_t* responseSize, void* userContextCallback)
+static int PnP_TempControlComponent_CommandCallback(const char* componentName, const char* commandName, const unsigned char* payload, size_t size, const char* payloadContentType,
+                                                    unsigned char** response, size_t* responseSize, void* userContextCallback)
 {
     (void)userContextCallback;
     // payloadContentType is guaranteed to be "application/json".  Future versions of the IoT Hub SDK might enable additional
@@ -386,7 +387,7 @@ static void PnP_TempControlComponent_ReportSerialNumber_Property(IOTHUB_DEVICE_C
 }
 
 //
-// CreateDeviceClientLLHandle does the creates the IOTHUB_DEVICE_CLIENT_LL_HANDLE based on environment configuration.
+// CreateDeviceClientLLHandle creates the IOTHUB_DEVICE_CLIENT_LL_HANDLE based on environment configuration.
 // If PNP_CONNECTION_SECURITY_TYPE_DPS is used, the call will block until DPS provisions the device.
 //
 static IOTHUB_DEVICE_CLIENT_LL_HANDLE CreateDeviceClientLLHandle(void)
@@ -397,7 +398,7 @@ static IOTHUB_DEVICE_CLIENT_LL_HANDLE CreateDeviceClientLLHandle(void)
     {
         if ((deviceClient = IoTHubDeviceClient_LL_CreateFromConnectionString(g_pnpDeviceConfiguration.u.connectionString, MQTT_Protocol)) == NULL)
         {
-            LogError("Failure creating IotHub client.  Hint: Check your connection string");
+            LogError("Failure creating Iot Hub client.  Hint: Check your connection string");
         }
     }
 #ifdef USE_PROV_MODULE_FULL
@@ -422,7 +423,7 @@ static IOTHUB_DEVICE_CLIENT_LL_HANDLE CreateAndConfigureDeviceClientHandleForPnP
     int iothubInitResult;
     bool result;
 
-    // Before invoking any IoTHub Device SDK functionality, IoTHub_Init must be invoked.
+    // Before invoking any IoT Hub Device SDK functionality, IoTHub_Init must be invoked.
     if ((iothubInitResult = IoTHub_Init()) != 0)
     {
         LogError("Failure to initialize client, error=%d", iothubInitResult);
@@ -431,7 +432,7 @@ static IOTHUB_DEVICE_CLIENT_LL_HANDLE CreateAndConfigureDeviceClientHandleForPnP
     // Create the deviceClient.
     else if ((deviceClient = CreateDeviceClientLLHandle()) == NULL)
     {
-        LogError("Failure creating IotHub client.  Hint: Check your connection string or DPS configuration");
+        LogError("Failure creating Iot Hub client.  Hint: Check your connection string or DPS configuration");
         result = false;
     }
     // Sets verbosity level.
@@ -483,11 +484,11 @@ static IOTHUB_DEVICE_CLIENT_LL_HANDLE CreateAndConfigureDeviceClientHandleForPnP
     {
         IoTHubDeviceClient_LL_Destroy(deviceClient);
         deviceClient = NULL;
-    }
 
-    if ((result == false) &&  (iothubInitResult == 0))
-    {
-        IoTHub_Deinit();
+        if (iothubInitResult == 0)
+        {
+            IoTHub_Deinit();
+        }
     }
 
     return deviceClient;
@@ -550,7 +551,9 @@ int main(void)
     // for extended periods of time when using DPS.
     else if ((deviceClient = CreateAndConfigureDeviceClientHandleForPnP()) == NULL)
     {
-        LogError("Failure creating IotHub device client");
+        LogError("Failure creating Iot Hub device client");
+        PnP_ThermostatComponent_Destroy(g_thermostatHandle1);
+        PnP_ThermostatComponent_Destroy(g_thermostatHandle2);
     }
     else
     {
@@ -581,7 +584,7 @@ int main(void)
         }
 
         // The remainder of the code is used for cleaning up our allocated resources. It won't be executed in this 
-        // sample (because the loop above is infinite and // is only broken out of by Control-C of the program), but 
+        // sample (because the loop above is infinite and is only broken out of by Control-C of the program), but 
         // it is included for reference.
 
         // Free the memory allocated to track simulated thermostat.

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_temperature_controller.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_temperature_controller.c
@@ -5,57 +5,48 @@
 // model in that the model has properties, commands, and telemetry off of the root component
 // as well as subcomponents.
 
-// The DTDL for component is https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json
+// The Digital Twin Definition Language (DTDLv2) document describing the device implemented in this sample
+// is available at https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json
 
-// Standard C header files
+// Standard C header files.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-// IoTHub Device Client and IoT core utility related header files
+// JSON parser library.
+#include "parson.h"
+
+// IoT Hub device client and IoT core utility related header files.
 #include "iothub.h"
 #include "iothub_device_client_ll.h"
 #include "iothub_client_options.h"
+#include "iothubtransportmqtt.h"
 #include "iothub_message.h"
+#include "iothub_client_properties.h"
 #include "azure_c_shared_utility/strings.h"
 #include "azure_c_shared_utility/threadapi.h"
 #include "azure_c_shared_utility/xlogging.h"
 
-// PnP utilities.
-#include "pnp_device_client_ll.h"
-#include "pnp_protocol.h"
+#include "pnp_status_values.h"
+
+#ifdef SET_TRUSTED_CERT_IN_SAMPLES
+// For devices that do not have (or want) an OS level trusted certificate store,
+// but instead bring in default trusted certificates from the Azure IoT C SDK.
+#include "azure_c_shared_utility/shared_util_options.h"
+#include "certs.h"
+#endif // SET_TRUSTED_CERT_IN_SAMPLES
+
+#include "pnp_sample_config.h"
+
+#ifdef USE_PROV_MODULE_FULL
+#include "pnp_dps_ll.h"
+#endif // USE_PROV_MODULE_FULL
 
 // Headers that provide implementation for subcomponents (the two thermostat components and DeviceInfo)
 #include "pnp_thermostat_component.h"
 #include "pnp_deviceinfo_component.h"
 
-// Environment variable used to specify how app connects to hub and the two possible values
-static const char g_securityTypeEnvironmentVariable[] = "IOTHUB_DEVICE_SECURITY_TYPE";
-static const char g_securityTypeConnectionStringValue[] = "connectionString";
-static const char g_securityTypeDpsValue[] = "DPS";
-
-// Environment variable used to specify this application's connection string
-static const char g_connectionStringEnvironmentVariable[] = "IOTHUB_DEVICE_CONNECTION_STRING";
-
-// Values of connection / security settings read from environment variables and/or DPS runtime
-PNP_DEVICE_CONFIGURATION g_pnpDeviceConfiguration;
-
-#ifdef USE_PROV_MODULE_FULL
-// Environment variable used to specify this application's DPS id scope
-static const char g_dpsIdScopeEnvironmentVariable[] = "IOTHUB_DEVICE_DPS_ID_SCOPE";
-
-// Environment variable used to specify this application's DPS device id
-static const char g_dpsDeviceIdEnvironmentVariable[] = "IOTHUB_DEVICE_DPS_DEVICE_ID";
-
-// Environment variable used to specify this application's DPS device key
-static const char g_dpsDeviceKeyEnvironmentVariable[] = "IOTHUB_DEVICE_DPS_DEVICE_KEY";
-
-// Environment variable used to optionally specify this application's DPS id scope
-static const char g_dpsEndpointEnvironmentVariable[] = "IOTHUB_DEVICE_DPS_ENDPOINT";
-
-// Global provisioning endpoint for DPS if one is not specified via the environment
-static const char g_dps_DefaultGlobalProvUri[] = "global.azure-devices-provisioning.net";
-#endif
+#define CURRENT_WORKING_SET_BUFFER_SIZE 64
 
 // Amount of time to sleep between polling hub, in milliseconds.  Set to wake up every 100 milliseconds.
 static unsigned int g_sleepBetweenPollsMs = 100;
@@ -67,8 +58,12 @@ static const int g_sendTelemetryPollInterval = 600;
 // Whether tracing at the IoTHub client is enabled or not. 
 static bool g_hubClientTraceEnabled = true;
 
-// DTMI indicating this device's ModelId.
+// DTMI indicating this device's model identifier.
 static const char g_temperatureControllerModelId[] = "dtmi:com:example:TemperatureController;1";
+
+// Metadata to add to telemetry messages.
+static const char g_jsonContentType[] = "application/json";
+static const char g_utf8EncodingType[] = "utf8";
 
 // PNP_THERMOSTAT_COMPONENT_HANDLE represent the thermostat components that are sub-components of the temperature controller.
 // Note that we do NOT have an analogous DeviceInfo component handle because there is only DeviceInfo subcomponent and its
@@ -78,35 +73,62 @@ PNP_THERMOSTAT_COMPONENT_HANDLE g_thermostatHandle2;
 
 // Name of subcomponents that TemmperatureController implements.
 static const char g_thermostatComponent1Name[] = "thermostat1";
-static const size_t g_thermostatComponent1Size = sizeof(g_thermostatComponent1Name) - 1;
 static const char g_thermostatComponent2Name[] = "thermostat2";
-static const size_t g_thermostatComponent2Size = sizeof(g_thermostatComponent2Name) - 1;
 static const char g_deviceInfoComponentName[] = "deviceInformation";
 
+// All components modeled by this device.
 static const char* g_modeledComponents[] = {g_thermostatComponent1Name, g_thermostatComponent2Name, g_deviceInfoComponentName};
 static const size_t g_numModeledComponents = sizeof(g_modeledComponents) / sizeof(g_modeledComponents[0]);
 
 // Command implemented by the TemperatureControl component itself to implement reboot.
 static const char g_rebootCommand[] = "reboot";
 
-// An empty JSON body for PnP command responses
+// An empty JSON body for PnP command responses.
 static const char g_JSONEmpty[] = "{}";
 static const size_t g_JSONEmptySize = sizeof(g_JSONEmpty) - 1;
 
-// Minimum value we will return for working set, + some random number
+// Minimum value we will return for working set, + some random number.
 static const int g_workingSetMinimum = 1000;
-// Random number for working set will range between the g_workingSetMinimum and (g_workingSetMinimum+g_workingSetRandomModulo)
+// Random number for working set will range between the g_workingSetMinimum and (g_workingSetMinimum+g_workingSetRandomModulo).
 static const int g_workingSetRandomModulo = 500;
 // Format string for sending a telemetry message with the working set.
 static const char g_workingSetTelemetryFormat[] = "{\"workingSet\":%d}";
 
-// Name of the serial number property as defined in this component's DTML
+// Name of the serial number property.
 static const char g_serialNumberPropertyName[] = "serialNumber";
-// Value of the serial number.  NOTE: This must be a legal JSON string which requires value to be in "..."
+// Value of the serial number.  NOTE: This must be a legal JSON string which requires value to be in "...".
 static const char g_serialNumberPropertyValue[] = "\"serial-no-123-abc\"";
 
+// Values of connection / security settings read from environment variables and/or DPS runtime.
+PNP_DEVICE_CONFIGURATION g_pnpDeviceConfiguration;
+
 //
-// PnP_TempControlComponent_InvokeRebootCommand processes the reboot command on the root interface
+// CreateDeviceClientLLHandle does the creates the IOTHUB_DEVICE_CLIENT_LL_HANDLE based on environment configuration.
+// If PNP_CONNECTION_SECURITY_TYPE_DPS is used, the call will block until DPS provisions the device.
+//
+static IOTHUB_DEVICE_CLIENT_LL_HANDLE CreateDeviceClientLLHandle(void)
+{
+    IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient = NULL;
+
+    if (g_pnpDeviceConfiguration.securityType == PNP_CONNECTION_SECURITY_TYPE_CONNECTION_STRING)
+    {
+        if ((deviceClient = IoTHubDeviceClient_LL_CreateFromConnectionString(g_pnpDeviceConfiguration.u.connectionString, MQTT_Protocol)) == NULL)
+        {
+            LogError("Failure creating IotHub client.  Hint: Check your connection string");
+        }
+    }
+#ifdef USE_PROV_MODULE_FULL
+    else if ((deviceClient = PnP_CreateDeviceClientLLHandle_ViaDps(&g_pnpDeviceConfiguration)) == NULL)
+    {
+        LogError("Cannot retrieve IoT Hub connection information from DPS client");
+    }
+#endif /* USE_PROV_MODULE_FULL */
+
+    return deviceClient;
+}
+
+//
+// PnP_TempControlComponent_InvokeRebootCommand processes the reboot command on the root component.
 //
 static int PnP_TempControlComponent_InvokeRebootCommand(JSON_Value* rootValue)
 {
@@ -121,7 +143,7 @@ static int PnP_TempControlComponent_InvokeRebootCommand(JSON_Value* rootValue)
     {
         // See caveats section in ../readme.md; we don't actually respect the delay value to keep the sample simple.
         int delayInSeconds = (int)json_value_get_number(rootValue);
-        LogInfo("Temperature controller 'reboot' command invoked with delay=%d seconds", delayInSeconds);
+        LogInfo("Temperature controller 'reboot' command invoked with delay %d seconds", delayInSeconds);
         result = PNP_STATUS_SUCCESS;
     }
     
@@ -148,65 +170,86 @@ static void SetEmptyCommandResponse(unsigned char** response, size_t* responseSi
 }
 
 //
-// PnP_TempControlComponent_DeviceMethodCallback is invoked by IoT SDK when a device method arrives.
+// CopyPayloadToString creates a null-terminated string from the payload buffer.
+// payload is not guaranteed to be null-terminated by the IoT Hub device SDK.
 //
-static int PnP_TempControlComponent_DeviceMethodCallback(const char* methodName, const unsigned char* payload, size_t size, unsigned char** response, size_t* responseSize, void* userContextCallback)
+static char* CopyPayloadToString(const unsigned char* payload, size_t size)
+{
+    char* jsonStr;
+    size_t sizeToAllocate = size + 1;
+
+    if ((jsonStr = (char*)malloc(sizeToAllocate)) == NULL)
+    {
+        LogError("Unable to allocate %lu size buffer", (unsigned long)(sizeToAllocate));
+    }
+    else
+    {
+        memcpy(jsonStr, payload, size);
+        jsonStr[size] = '\0';
+    }
+
+    return jsonStr;
+}
+
+//
+// PnP_TempControlComponent_CommandCallback is invoked by IoT SDK when a command arrives.
+//
+static int PnP_TempControlComponent_CommandCallback(const char* componentName, const char* commandName, const unsigned char* payload, size_t size, const char* payloadContentType, unsigned char** response, size_t* responseSize, void* userContextCallback)
 {
     (void)userContextCallback;
+    // payloadContentType is guaranteed to be "application/json".  Future versions of the IoT Hub SDK might enable additional
+    // values, but it will require explicit opt-in from the application.
+    (void)payloadContentType; 
 
     char* jsonStr = NULL;
     JSON_Value* rootValue = NULL;
     int result;
-    unsigned const char *componentName;
-    size_t componentNameSize;
-    const char *pnpCommandName;
+
+    LogInfo("Device command %s arrived for component %s", commandName, (componentName == NULL) ? "" : componentName);
 
     *response = NULL;
     *responseSize = 0;
 
-    // Parse the methodName into its PnP (optional) componentName and pnpCommandName.
-    PnP_ParseCommandName(methodName, &componentName, &componentNameSize, &pnpCommandName);
-
-    // Parse the JSON of the payload request.
-    if ((jsonStr = PnP_CopyPayloadToString(payload, size)) == NULL)
+    // Because the payload isn't null-terminated, create one here so parson can process it.
+    if ((jsonStr = CopyPayloadToString(payload, size)) == NULL)
     {
-        LogError("Unable to allocate twin buffer");
+        LogError("Unable to allocate buffer");
         result = PNP_STATUS_INTERNAL_ERROR;
     }
     else if ((rootValue = json_parse_string(jsonStr)) == NULL)
     {
-        LogError("Unable to parse twin JSON");
+        LogError("Unable to parse JSON");
         result = PNP_STATUS_INTERNAL_ERROR;
     }
     else
     {
+        // Route the incoming command to the appropriate component to process it.
         if (componentName != NULL)
         {
-            LogInfo("Received PnP command for component=%.*s, command=%s", (int)componentNameSize, componentName, pnpCommandName);
-            if (strncmp((const char*)componentName, g_thermostatComponent1Name, g_thermostatComponent1Size) == 0)
+            if (strcmp(componentName, g_thermostatComponent1Name) == 0)
             {
-                result = PnP_ThermostatComponent_ProcessCommand(g_thermostatHandle1, pnpCommandName, rootValue, response, responseSize);
+                result = PnP_ThermostatComponent_ProcessCommand(g_thermostatHandle1, commandName, rootValue, response, responseSize);
             }
-            else if (strncmp((const char*)componentName, g_thermostatComponent2Name, g_thermostatComponent2Size) == 0)
+            else if (strcmp(componentName, g_thermostatComponent2Name) == 0)
             {
-                result = PnP_ThermostatComponent_ProcessCommand(g_thermostatHandle2, pnpCommandName, rootValue, response, responseSize);
+                result = PnP_ThermostatComponent_ProcessCommand(g_thermostatHandle2, commandName, rootValue, response, responseSize);
             }
             else
             {
-                LogError("PnP component=%.*s is not supported by TemperatureController", (int)componentNameSize, componentName);
+                LogError("Component %s is not supported by TemperatureController", componentName);
                 result = PNP_STATUS_NOT_FOUND;
             }
         }
         else
         {
-            LogInfo("Received PnP command for TemperatureController component, command=%s", pnpCommandName);
-            if (strcmp(pnpCommandName, g_rebootCommand) == 0)
+            // Command has arrived on the root component
+            if (strcmp(commandName, g_rebootCommand) == 0)
             {
                 result = PnP_TempControlComponent_InvokeRebootCommand(rootValue);
             }
             else
             {
-                LogError("PnP command=s%s is not supported by TemperatureController", pnpCommandName);
+                LogError("Command %s is not supported by TemperatureController", commandName);
                 result = PNP_STATUS_NOT_FOUND;
             }
         }
@@ -223,49 +266,75 @@ static int PnP_TempControlComponent_DeviceMethodCallback(const char* methodName,
     return result;
 }
 
-//
-// PnP_TempControlComponent_ApplicationPropertyCallback is the callback function is invoked when PnP_ProcessTwinData() visits each property.
-//
-static void PnP_TempControlComponent_ApplicationPropertyCallback(const char* componentName, const char* propertyName, JSON_Value* propertyValue, int version, void* userContextCallback)
+int PnP_TempControlComponent_UpdatedPropertyCallback(
+    IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE payloadType, 
+    const unsigned char* payload,
+    size_t payloadLength,
+    void* userContextCallback)
 {
-    // This sample uses the pnp_device_client.h/.c to create the IOTHUB_DEVICE_CLIENT_LL_HANDLE as well as initialize callbacks.
-    // The convention used is that IOTHUB_DEVICE_CLIENT_LL_HANDLE is passed as the userContextCallback on the initial twin callback.
-    // The pnp_protocol.h/.c pass this userContextCallback down to this visitor function.
     IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient = (IOTHUB_DEVICE_CLIENT_LL_HANDLE)userContextCallback;
+    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE propertyIterator = NULL;
+    IOTHUB_CLIENT_DESERIALIZED_PROPERTY property;
+    int propertiesVersion;
+    IOTHUB_CLIENT_RESULT clientResult;
 
-    if (componentName == NULL)
+    // The properties arrive as a raw JSON buffer (which is not null-terminated).  IoTHubClient_Deserialize_Properties_CreateIterator parses 
+    // this into a more convenient form to allow property-by-property enumeration over the updated properties.
+    if ((clientResult = IoTHubClient_Deserialize_Properties_CreateIterator(payloadType, payload, payloadLength, g_modeledComponents, g_numModeledComponents, &propertyIterator)) != IOTHUB_CLIENT_OK)
     {
-        // The PnP protocol does not define a mechanism to report errors such as this to IoTHub, so 
-        // the best we can do here is to log for diagnostics purposes.
-        LogError("Property=%s arrived for TemperatureControl component itself.  This does not support writeable properties on it (all properties are on subcomponents)", propertyName);
+        LogError("IoTHubClient_Deserialize_Properties failed, error=%d", clientResult);
     }
-    else if (strcmp(componentName, g_thermostatComponent1Name) == 0)
+    else if ((clientResult = IoTHubClient_Deserialize_Properties_GetVersion(propertyIterator, &propertiesVersion)) != IOTHUB_CLIENT_OK)
     {
-        PnP_ThermostatComponent_ProcessPropertyUpdate(g_thermostatHandle1, deviceClient, propertyName, propertyValue, version);
-    }
-    else if (strcmp(componentName, g_thermostatComponent2Name) == 0)
-    {
-        PnP_ThermostatComponent_ProcessPropertyUpdate(g_thermostatHandle2, deviceClient, propertyName, propertyValue, version);
+        LogError("IoTHubClient_Deserialize_Properties_GetVersion failed, error=%d", clientResult);
     }
     else
     {
-        LogError("Component=%s is not implemented by the TemperatureController", componentName);
-    }
-}
+        bool propertySpecified;
+        property.structVersion = IOTHUB_CLIENT_DESERIALIZED_PROPERTY_STRUCT_VERSION_1;
 
-//
-// PnP_TempControlComponent_DeviceTwinCallback is invoked by IoT SDK when a twin - either full twin or a PATCH update - arrives.
-//
-static void PnP_TempControlComponent_DeviceTwinCallback(DEVICE_TWIN_UPDATE_STATE updateState, const unsigned char* payload, size_t size, void* userContextCallback)
-{
-    // Invoke PnP_ProcessTwinData to actualy process the data.  PnP_ProcessTwinData uses a visitor pattern to parse
-    // the JSON and then visit each property, invoking PnP_TempControlComponent_ApplicationPropertyCallback on each element.
-    if (PnP_ProcessTwinData(updateState, payload, size, g_modeledComponents, g_numModeledComponents, PnP_TempControlComponent_ApplicationPropertyCallback, userContextCallback) == false)
-    {
-        // If we're unable to parse the JSON for any reason (typically because the JSON is malformed or we ran out of memory)
-        // there is no action we can take beyond logging.
-        LogError("Unable to process twin json.  Ignoring any desired property update requests");
+        while ((clientResult = IoTHubClient_Deserialize_Properties_GetNextProperty(propertyIterator, &property, &propertySpecified)) == IOTHUB_CLIENT_OK)
+        {
+            if (propertySpecified == false)
+            {
+                break;
+            }
+
+            if (property.propertyType == IOTHUB_CLIENT_PROPERTY_TYPE_REPORTED_FROM_DEVICE)
+            {
+                // We are iterating over a property that the device has previously sent to IoT Hub; 
+                // this shows what IoT Hub has recorded the reported property as.
+                //
+                // There are scenarios where a device may use this, such as knowing whether the
+                // given property has changed on the device and needs to be re-reported.
+                //
+                // This sample doesn't do anything with this, so we'll continue on when we hit reported properties.
+                continue;
+            }
+            
+            if (property.componentName == NULL) 
+            {   
+                LogError("Property %s arrived for TemperatureControl component itself.  This does not support properties on it (all properties are on subcomponents)", property.componentName);
+            }
+            else if (strcmp(property.componentName, g_thermostatComponent1Name) == 0)
+            {
+                PnP_ThermostatComponent_ProcessPropertyUpdate(g_thermostatHandle1, deviceClient, property.name, property.value.str, propertiesVersion);
+            }
+            else if (strcmp(property.componentName, g_thermostatComponent2Name) == 0)
+            {
+                PnP_ThermostatComponent_ProcessPropertyUpdate(g_thermostatHandle2, deviceClient, property.name, property.value.str, propertiesVersion);
+            }
+            else
+            {
+                LogError("Component %s is not implemented by the TemperatureController", property.componentName);
+            }
+            
+            IoTHubClient_Deserialize_Properties_DestroyProperty(&property);
+        }
     }
+
+    IoTHubClient_Deserialize_Properties_DestroyIterator(propertyIterator);
+    return 0;
 }
 
 //
@@ -276,184 +345,159 @@ static void PnP_TempControlComponent_DeviceTwinCallback(DEVICE_TWIN_UPDATE_STATE
 void PnP_TempControlComponent_SendWorkingSet(IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient) 
 {
     IOTHUB_MESSAGE_HANDLE messageHandle = NULL;
-    IOTHUB_CLIENT_RESULT iothubResult;
-    char workingSetTelemetryPayload[64];
+    IOTHUB_MESSAGE_RESULT messageResult;
+    IOTHUB_CLIENT_RESULT iothubClientResult;
+    char workingSetTelemetryPayload[CURRENT_WORKING_SET_BUFFER_SIZE];
 
     int workingSet = g_workingSetMinimum + (rand() % g_workingSetRandomModulo);
 
+    // Create the telemetry message body to send.
     if (snprintf(workingSetTelemetryPayload, sizeof(workingSetTelemetryPayload), g_workingSetTelemetryFormat, workingSet) < 0)
     {
         LogError("Unable to create a workingSet telemetry payload string");
     }
-    else if ((messageHandle = PnP_CreateTelemetryMessageHandle(NULL, workingSetTelemetryPayload)) == NULL)
+    // Create the message handle and specify its metadata.
+    else if ((messageHandle = IoTHubMessage_CreateFromString(workingSetTelemetryPayload)) == NULL)
     {
-        LogError("Unable to create telemetry message");
+        LogError("IoTHubMessage_CreateFromString failed");
     }
-    else if ((iothubResult = IoTHubDeviceClient_LL_SendEventAsync(deviceClient, messageHandle, NULL, NULL)) != IOTHUB_CLIENT_OK)
+    else if ((messageResult = IoTHubMessage_SetContentTypeSystemProperty(messageHandle, g_jsonContentType)) != IOTHUB_MESSAGE_OK)
     {
-        LogError("Unable to send telemetry message, error=%d", iothubResult);
+        LogError("IoTHubMessage_SetContentTypeSystemProperty failed, error=%d", messageResult);
+    }
+    else if ((messageResult = IoTHubMessage_SetContentEncodingSystemProperty(messageHandle, g_utf8EncodingType)) != IOTHUB_MESSAGE_OK)
+    {
+        LogError("IoTHubMessage_SetContentEncodingSystemProperty failed, error=%d", messageResult);
+    }
+    // Send the telemetry message.
+    else if ((iothubClientResult = IoTHubDeviceClient_LL_SendTelemetryAsync(deviceClient, messageHandle, NULL, NULL)) != IOTHUB_CLIENT_OK)
+    {
+        LogError("Unable to send telemetry message, error=%d", iothubClientResult);
     }
 
     IoTHubMessage_Destroy(messageHandle);
 }
 
 //
-// PnP_TempControlComponent_ReportSerialNumber_Property sends the "serialNumber" property to IoTHub
+// PnP_TempControlComponent_ReportSerialNumber_Property sends the "serialNumber" property to IoT Hub.
 //
 static void PnP_TempControlComponent_ReportSerialNumber_Property(IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient)
 {
-    IOTHUB_CLIENT_RESULT iothubClientResult;
-    STRING_HANDLE jsonToSend = NULL;
+    IOTHUB_CLIENT_RESULT clientResult;
+    IOTHUB_CLIENT_REPORTED_PROPERTY property = { IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, g_serialNumberPropertyName, g_serialNumberPropertyValue };
+    unsigned char* serializedProperties = NULL;
+    size_t serializedPropertiesLength;
 
-    if ((jsonToSend = PnP_CreateReportedProperty(NULL, g_serialNumberPropertyName, g_serialNumberPropertyValue)) == NULL)
+    // The first step of reporting properties is to serialize it into an IoT Hub friendly format.  You can do this by either
+    // implementing the PnP convention for building up the correct JSON or more simply to use IoTHubClient_Serialize_ReportedProperties.
+    if ((clientResult = IoTHubClient_Serialize_ReportedProperties(&property, 1, NULL, &serializedProperties, &serializedPropertiesLength)) != IOTHUB_CLIENT_OK)
     {
-        LogError("Unable to build serial number property");
+        LogError("Unable to serialize reported state, error=%d", clientResult);
     }
-    else
+    // The output of IoTHubClient_Serialize_ReportedProperties is sent to IoTHubDeviceClient_LL_SendPropertiesAsync to perform network I/O.
+    else if ((clientResult = IoTHubDeviceClient_LL_SendPropertiesAsync(deviceClient, serializedProperties, serializedPropertiesLength, NULL, NULL)) != IOTHUB_CLIENT_OK)
     {
-        const char* jsonToSendStr = STRING_c_str(jsonToSend);
-        size_t jsonToSendStrLen = strlen(jsonToSendStr);
-
-        if ((iothubClientResult = IoTHubDeviceClient_LL_SendReportedState(deviceClient, (const unsigned char*)jsonToSendStr, jsonToSendStrLen, NULL, NULL)) != IOTHUB_CLIENT_OK)
-        {
-            LogError("Unable to send reported state, error=%d", iothubClientResult);
-        }
-        else
-        {
-            LogInfo("Sending serialNumber property to IoTHub");
-        }
+        LogError("Unable to send reported state, error=%d", clientResult);
     }
 
-    STRING_delete(jsonToSend);
+    IoTHubClient_Serialize_Properties_Destroy(serializedProperties);
 }
 
 //
-// GetConnectionStringFromEnvironment retrieves the connection string based on environment variable
+// CreateAndConfigureDeviceClientHandleForPnP creates a IOTHUB_DEVICE_CLIENT_LL_HANDLE for this application, setting its
+// ModelId along with various callbacks.
 //
-static bool GetConnectionStringFromEnvironment()
-{
-    bool result;
-
-    if ((g_pnpDeviceConfiguration.u.connectionString = getenv(g_connectionStringEnvironmentVariable)) == NULL)
-    {
-        LogError("Cannot read environment variable=%s", g_connectionStringEnvironmentVariable);
-        result = false;
-    }
-    else
-    {
-        g_pnpDeviceConfiguration.securityType = PNP_CONNECTION_SECURITY_TYPE_CONNECTION_STRING;
-        result = true;    
-    }
-
-    return result;
-}
-
-//
-// GetDpsFromEnvironment retrieves DPS configuration for a symmetric key based connection
-// from environment variables
-//
-static bool GetDpsFromEnvironment()
-{
-#ifndef USE_PROV_MODULE_FULL
-    // Explain to user misconfiguration.  The "run_e2e_tests" must be set to OFF because otherwise
-    // the e2e's test HSM layer and symmetric key logic will conflict.
-    LogError("DPS based authentication was requested via environment variables, but DPS is not enabled.");
-    LogError("DPS is an optional component of the Azure IoT C SDK.  It is enabled with symmetric keys at cmake time by");
-    LogError("passing <-Duse_prov_client=ON -Dhsm_type_symm_key=ON -Drun_e2e_tests=OFF> to cmake's command line");
-    return false;
-#else
-    bool result;
-
-    if ((g_pnpDeviceConfiguration.u.dpsConnectionAuth.endpoint = getenv(g_dpsEndpointEnvironmentVariable)) == NULL)
-    {
-        // We will fall back to standard endpoint if one is not specified
-        g_pnpDeviceConfiguration.u.dpsConnectionAuth.endpoint = g_dps_DefaultGlobalProvUri;
-    }
-
-    if ((g_pnpDeviceConfiguration.u.dpsConnectionAuth.idScope = getenv(g_dpsIdScopeEnvironmentVariable)) == NULL)
-    {
-        LogError("Cannot read environment variable=%s", g_dpsIdScopeEnvironmentVariable);
-        result = false;
-    }
-    else if ((g_pnpDeviceConfiguration.u.dpsConnectionAuth.deviceId = getenv(g_dpsDeviceIdEnvironmentVariable)) == NULL)
-    {
-        LogError("Cannot read environment variable=%s", g_dpsDeviceIdEnvironmentVariable);
-        result = false;
-    }
-    else if ((g_pnpDeviceConfiguration.u.dpsConnectionAuth.deviceKey = getenv(g_dpsDeviceKeyEnvironmentVariable)) == NULL)
-    {
-        LogError("Cannot read environment variable=%s", g_dpsDeviceKeyEnvironmentVariable);
-        result = false;
-    }
-    else
-    {
-        g_pnpDeviceConfiguration.securityType = PNP_CONNECTION_SECURITY_TYPE_DPS;
-        result = true;    
-    }
-
-    return result;
-#endif // USE_PROV_MODULE_FULL
-}
-
-
-//
-// GetConfigurationFromEnvironment reads how to connect to the IoT Hub (using 
-// either a connection string or a DPS symmetric key) from the environment.
-//
-static bool GetConnectionSettingsFromEnvironment()
-{
-    const char* securityTypeString;
-    bool result;
-
-    if ((securityTypeString = getenv(g_securityTypeEnvironmentVariable)) == NULL)
-    {
-        LogError("Cannot read environment variable=%s", g_securityTypeEnvironmentVariable);
-        result = false;
-    }
-    else
-    {
-        if (strcmp(securityTypeString, g_securityTypeConnectionStringValue) == 0)
-        {
-            result = GetConnectionStringFromEnvironment();
-        }
-        else if (strcmp(securityTypeString, g_securityTypeDpsValue) == 0)
-        {
-            result = GetDpsFromEnvironment();
-        }
-        else
-        {
-            LogError("Environment variable %s must be either %s or %s", g_securityTypeEnvironmentVariable, g_securityTypeConnectionStringValue, g_securityTypeDpsValue);
-            result = false;
-        }
-    }
-
-    return result;    
-}
-
-//
-// CreateDeviceClientAndAllocateComponents allocates the IOTHUB_DEVICE_CLIENT_LL_HANDLE the application will use along with thermostat components
-// 
-static IOTHUB_DEVICE_CLIENT_LL_HANDLE CreateDeviceClientAndAllocateComponents(void)
+static IOTHUB_DEVICE_CLIENT_LL_HANDLE CreateAndConfigureDeviceClientHandleForPnP(void)
 {
     IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient = NULL;
+    IOTHUB_CLIENT_RESULT iothubClientResult;
+    bool urlAutoEncodeDecode = true;
+    int iothubInitResult;
     bool result;
 
-    g_pnpDeviceConfiguration.deviceMethodCallback = PnP_TempControlComponent_DeviceMethodCallback;
-    g_pnpDeviceConfiguration.deviceTwinCallback = PnP_TempControlComponent_DeviceTwinCallback;
-    g_pnpDeviceConfiguration.enableTracing = g_hubClientTraceEnabled;
-    g_pnpDeviceConfiguration.modelId = g_temperatureControllerModelId;
+    // Before invoking any IoTHub Device SDK functionality, IoTHub_Init must be invoked.
+    if ((iothubInitResult = IoTHub_Init()) != 0)
+    {
+        LogError("Failure to initialize client.  Error=%d", iothubInitResult);
+        result = false;
+    }
+    // Create the deviceClient.
+    else if ((deviceClient = CreateDeviceClientLLHandle()) == NULL)
+    {
+        LogError("Failure creating IotHub client.  Hint: Check your connection string or DPS configuration");
+        result = false;
+    }
+    // Sets verbosity level.
+    else if ((iothubClientResult = IoTHubDeviceClient_LL_SetOption(deviceClient, OPTION_LOG_TRACE, &g_hubClientTraceEnabled)) != IOTHUB_CLIENT_OK)
+    {
+        LogError("Unable to set logging option, error=%d", iothubClientResult);
+        result = false;
+    }
+    // Sets the name of ModelId for this PnP device.
+    // This *MUST* be set before the client is connected to IoTHub.  We do not automatically connect when the 
+    // handle is created, but will implicitly connect to subscribe for command and property callbacks below.
+    else if ((iothubClientResult = IoTHubDeviceClient_LL_SetOption(deviceClient, OPTION_MODEL_ID, g_temperatureControllerModelId)) != IOTHUB_CLIENT_OK)
+    {
+        LogError("Unable to set the ModelID, error=%d", iothubClientResult);
+        result = false;
+    }
+    // Enabling auto url encode will have the underlying SDK perform URL encoding operations automatically for telemetry message properties.
+    else if ((iothubClientResult = IoTHubDeviceClient_LL_SetOption(deviceClient, OPTION_AUTO_URL_ENCODE_DECODE, &urlAutoEncodeDecode)) != IOTHUB_CLIENT_OK)
+    {
+        LogError("Unable to set auto Url encode option, error=%d", iothubClientResult);
+        result = false;
+    }
+#ifdef SET_TRUSTED_CERT_IN_SAMPLES
+    // Setting the Trusted Certificate.  This is only necessary on systems without built in certificate stores.
+    else if ((iothubClientResult = IoTHubDeviceClient_LL_SetOption(deviceClient, OPTION_TRUSTED_CERT, certificates)) != IOTHUB_CLIENT_OK)
+    {
+        LogError("Unable to set the trusted cert, error=%d", iothubClientResult);
+        result = false;
+    }
+#endif // SET_TRUSTED_CERT_IN_SAMPLES
+    // Sets the callback function that processes incoming commands.  Note that this will implicitly initiate a connection to IoT Hub.
+    else if ((iothubClientResult = IoTHubDeviceClient_LL_SubscribeToCommands(deviceClient, PnP_TempControlComponent_CommandCallback, NULL)) != IOTHUB_CLIENT_OK)
+    {
+        LogError("Unable to subscribe for commands, error=%d", iothubClientResult);
+        result = false;
+    }
+    // Retrieve all properties for the device and also subscribe for any future writable property update changes.
+    else if ((iothubClientResult = IoTHubDeviceClient_LL_GetPropertiesAndSubscribeToUpdatesAsync(deviceClient, PnP_TempControlComponent_UpdatedPropertyCallback, (void*)deviceClient)) != IOTHUB_CLIENT_OK)
+    {
+        LogError("Unable to subscribe and get properties, error=%d", iothubClientResult);
+        result = false;
+    }
+    else
+    {
+        result = true;
+    }
 
-    if (GetConnectionSettingsFromEnvironment() == false)
+    if (result == false)
     {
-        LogError("Cannot read required environment variable(s)");
-        result = false;
+        IoTHubDeviceClient_LL_Destroy(deviceClient);
+        deviceClient = NULL;
     }
-    else if ((deviceClient = PnP_CreateDeviceClientLLHandle(&g_pnpDeviceConfiguration)) == NULL)
+
+    if ((result == false) &&  (iothubInitResult == 0))
     {
-        LogError("Failure creating IotHub device client");
-        result = false;
+        IoTHub_Deinit();
     }
-    else if ((g_thermostatHandle1 = PnP_ThermostatComponent_CreateHandle(g_thermostatComponent1Name)) == NULL)
+
+    return deviceClient;
+}
+
+//
+// AllocateThermostatComponents allocates subcomponents of this module.  These are implemented in separate .c 
+// files and the thermostat components have handles to simulate how a more complex PnP device might be composed.
+// 
+static bool AllocateThermostatComponents(void)
+{
+    bool result;
+
+    // PnP_ThermostatComponent_CreateHandle creates handles to process the subcomponents of Temperature Controller (namely
+    // thermostat1 and thermostat2) that require state and need to process callbacks from IoT Hub.  The other component,
+    // deviceInfo, is so simple (one time send of data) as to not need a handle.
+    if ((g_thermostatHandle1 = PnP_ThermostatComponent_CreateHandle(g_thermostatComponent1Name)) == NULL)
     {
         LogError("Unable to create component handle for %s", g_thermostatComponent1Name);
         result = false;
@@ -470,24 +514,34 @@ static IOTHUB_DEVICE_CLIENT_LL_HANDLE CreateDeviceClientAndAllocateComponents(vo
 
     if (result == false)
     {
-        PnP_ThermostatComponent_Destroy(g_thermostatHandle2);
         PnP_ThermostatComponent_Destroy(g_thermostatHandle1);
-        if (deviceClient != NULL)
-        {
-            IoTHubDeviceClient_LL_Destroy(deviceClient);
-            IoTHub_Deinit();
-            deviceClient = NULL;
-        }
+        PnP_ThermostatComponent_Destroy(g_thermostatHandle2);
     }
 
-    return deviceClient;
+    return result;
 }
 
 int main(void)
 {
     IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient = NULL;
 
-    if ((deviceClient = CreateDeviceClientAndAllocateComponents()) == NULL)
+    g_pnpDeviceConfiguration.enableTracing = g_hubClientTraceEnabled;
+    g_pnpDeviceConfiguration.modelId = g_temperatureControllerModelId;
+
+    // First determine the IoT Hub / credentials / device to use.
+    if (GetConnectionSettingsFromEnvironment(&g_pnpDeviceConfiguration) == false)
+    {
+        LogError("Cannot read required environment variable(s)");
+    }
+    // Creates the thermostat subcomponents defined by this model.  Since everything
+    // is simulated, this setup stage just creates simulated objects in memory.
+    else if (AllocateThermostatComponents() == false)
+    {
+        LogError("Failure allocating thermostat components");
+    }
+    // Create a handle to device client handle.  Note that this call may block
+    // for extended periods of time when using DPS.
+    else if ((deviceClient = CreateAndConfigureDeviceClientHandleForPnP()) == NULL)
     {
         LogError("Failure creating IotHub device client");
     }
@@ -497,7 +551,7 @@ int main(void)
 
         int numberOfIterations = 0;
 
-        // During startup, send the non-"writeable" properties.
+        // During startup, send what DTDLv2 calls "read-only properties" to indicate initial device state.
         PnP_TempControlComponent_ReportSerialNumber_Property(deviceClient);
         PnP_DeviceInfoComponent_Report_All_Properties(g_deviceInfoComponentName, deviceClient);
         PnP_TempControlComponent_Report_MaxTempSinceLastReboot_Property(g_thermostatHandle1, deviceClient);
@@ -510,8 +564,8 @@ int main(void)
             if ((numberOfIterations % g_sendTelemetryPollInterval) == 0)
             {
                 PnP_TempControlComponent_SendWorkingSet(deviceClient);
-                PnP_ThermostatComponent_SendTelemetry(g_thermostatHandle1, deviceClient);
-                PnP_ThermostatComponent_SendTelemetry(g_thermostatHandle2, deviceClient);
+                PnP_ThermostatComponent_SendCurrentTemperature(g_thermostatHandle1, deviceClient);
+                PnP_ThermostatComponent_SendCurrentTemperature(g_thermostatHandle2, deviceClient);
             }
 
             IoTHubDeviceClient_LL_DoWork(deviceClient);
@@ -519,13 +573,17 @@ int main(void)
             numberOfIterations++;
         }
 
-        // Free the memory allocated to track simulated thermostat.
-        PnP_ThermostatComponent_Destroy(g_thermostatHandle2);
-        PnP_ThermostatComponent_Destroy(g_thermostatHandle1);
+        // The remainder of the code is used for cleaning up our allocated resources. It won't be executed in this 
+        // sample (because the loop above is infinite and // is only broken out of by Control-C of the program), but 
+        // it is included for reference.
 
-        // Clean up the iothub sdk handle
+        // Free the memory allocated to track simulated thermostat.
+        PnP_ThermostatComponent_Destroy(g_thermostatHandle1);
+        PnP_ThermostatComponent_Destroy(g_thermostatHandle2);
+
+        // Clean up the IoT Hub sdk handle.
         IoTHubDeviceClient_LL_Destroy(deviceClient);
-        // Free all the sdk subsystem
+        // Free all IoT Hub subsystem.
         IoTHub_Deinit();
     }
 

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.c
@@ -318,7 +318,10 @@ void PnP_TempControlComponent_Report_MaxTempSinceLastReboot_Property(PNP_THERMOS
     }
     else
     {
-        IOTHUB_CLIENT_REPORTED_PROPERTY maxTempProperty = { IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, g_maxTempSinceLastRebootPropertyName, maximumTemperatureAsString };
+        IOTHUB_CLIENT_REPORTED_PROPERTY maxTempProperty;
+        maxTempProperty.structVersion = IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1;
+        maxTempProperty.name = g_maxTempSinceLastRebootPropertyName;
+        maxTempProperty.value =  maximumTemperatureAsString;
 
         unsigned char* propertySerialized = NULL;
         size_t propertySerializedLength;

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.c
@@ -355,7 +355,7 @@ void PnP_ThermostatComponent_ProcessPropertyUpdate(PNP_THERMOSTAT_COMPONENT_HAND
     else
     {
         char* next;
-        double targetTemperature = strtol(propertyValue, &next, 10);
+        double targetTemperature = strtod(propertyValue, &next);
         if ((propertyValue == next) || (targetTemperature == LONG_MAX) || (targetTemperature == LONG_MIN))
         {
             LogError("Property %s is not a valid integer", propertyValue);

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <limits.h>
 
 // PnP routines
 #include "pnp_thermostat_component.h"
@@ -390,7 +391,7 @@ void PnP_ThermostatComponent_SendCurrentTemperature(PNP_THERMOSTAT_COMPONENT_HAN
     {
         LogError("snprintf of current temperature telemetry failed");
     }
-    // Create the message handle and specify its metadata
+    // Create the message handle and specify its metadata.
     else if ((messageHandle = IoTHubMessage_CreateFromString(temperatureStringBuffer)) == NULL)
     {
         LogError("IoTHubMessage_PnP_CreateFromString failed");

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.c
@@ -8,45 +8,63 @@
 #include <time.h>
 
 // PnP routines
-#include "pnp_protocol.h"
 #include "pnp_thermostat_component.h"
+#include "iothub_client_properties.h"
 
 // Core IoT SDK utilities
 #include "azure_c_shared_utility/xlogging.h"
 
-// The default temperature to use before any is set
-#define DEFAULT_TEMPERATURE_VALUE 22
+#include "pnp_status_values.h"
 
 // Size of buffer to store ISO 8601 time.
 #define TIME_BUFFER_SIZE 128
 
-// Name of command this component supports to retrieve a report about the component.
-static const char g_getMaxMinReport[] = "getMaxMinReport";
+// Size of buffer to store current temperature telemetry.
+#define CURRENT_TEMPERATURE_BUFFER_SIZE  32
 
-// Names of properties for desired/reporting
+// Size of buffer to store the maximum temp since reboot property.
+#define MAX_TEMPERATURE_SINCE_REBOOT_BUFFER_SIZE 32
+
+// Maximum component size.  The spec (https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/dtdlv2.md#component)
+// defines the maximum component length as 64 to which we need to reserve the null-terminator.
+#define MAX_COMPONENT_NAME_LENGTH (64 + 1)
+
+// Names of properties for desired/reporting.
 static const char g_targetTemperaturePropertyName[] = "targetTemperature";
 static const char g_maxTempSinceLastRebootPropertyName[] = "maxTempSinceLastReboot";
 
+// Name of command this component supports to retrieve a report about the component.
+static const char g_getMaxMinReport[] = "getMaxMinReport";
+
+// The default temperature to use before any is set
+#define DEFAULT_TEMPERATURE_VALUE 22
+
 // Format string to create an ISO 8601 time.  This corresponds to the DTDL datetime schema item.
 static const char g_ISO8601Format[] = "%Y-%m-%dT%H:%M:%SZ";
-// Format string for sending temperature telemetry
+
+// Format string for sending temperature telemetry.
 static const char g_temperatureTelemetryBodyFormat[] = "{\"temperature\":%.02f}";
-// Format string for building getMaxMinReport response
+
+// Format string for building getMaxMinReport response.
 static const char g_maxMinCommandResponseFormat[] = "{\"maxTemp\":%.2f,\"minTemp\":%.2f,\"avgTemp\":%.2f,\"startTime\":\"%s\",\"endTime\":\"%s\"}";
-// Format string for sending maxTempSinceLastReboot property
+
+// Format string for sending maxTempSinceLastReboot property.
 static const char g_maxTempSinceLastRebootPropertyFormat[] = "%.2f";
-// Format of the body when responding to a targetTemperature 
+
+// Format of the body when responding to a targetTemperature.
 static const char g_targetTemperaturePropertyResponseFormat[] = "%.2f";
+
+// Metadata to add to telemetry messages.
+static const char g_jsonContentType[] = "application/json";
+static const char g_utf8EncodingType[] = "utf8";
+
+// Response description is an optional, human readable message including more information
+// about the setting of the temperature.  On success cases, this sample does not 
+// send a description to save bandwidth but on error cases we'll provide some hints.
+static const char g_temperaturePropertyResponseDescriptionNotInt[] = "desired temperature is not a number";
 
 // Start time of the program, stored in ISO 8601 format string for UTC
 char g_programStartTime[TIME_BUFFER_SIZE] = {0};
-
-
-// Response description is an optional, human readable message including more information
-// about the setting of the temperature.  Because we accept all temperature requests, we 
-// always indicate a success.  An actual sensor could optionally return information about
-// a temperature being out of range or a mechanical issue on the device on error cases.
-static const char g_temperaturePropertyResponseDescription[] = "success";
 
 //
 // PNP_THERMOSTAT_COMPONENT simulates a thermostat component
@@ -56,7 +74,7 @@ static const char g_temperaturePropertyResponseDescription[] = "success";
 typedef struct PNP_THERMOSTAT_COMPONENT_TAG
 {
     // Name of this component
-    char componentName[PNP_MAXIMUM_COMPONENT_LENGTH + 1];
+    char componentName[MAX_COMPONENT_NAME_LENGTH];
     // Current temperature of this thermostat component
     double currentTemperature;
     // Minimum temperature this thermostat has been at during current execution run of this thermostat component
@@ -71,7 +89,7 @@ typedef struct PNP_THERMOSTAT_COMPONENT_TAG
 PNP_THERMOSTAT_COMPONENT;
 
 //
-// BuildUtcTimeFromCurrentTime writes the current time, in ISO 8601 format, into the specified buffer
+// BuildUtcTimeFromCurrentTime writes the current time, in ISO 8601 format, into the specified buffer.
 //
 static bool BuildUtcTimeFromCurrentTime(char* utcTimeBuffer, size_t utcTimeBufferSize)
 {
@@ -95,14 +113,13 @@ static bool BuildUtcTimeFromCurrentTime(char* utcTimeBuffer, size_t utcTimeBuffe
     return result;
 }
 
-
 PNP_THERMOSTAT_COMPONENT_HANDLE PnP_ThermostatComponent_CreateHandle(const char* componentName)
 {
     PNP_THERMOSTAT_COMPONENT* thermostatComponent;
 
-    if (strlen(componentName) > PNP_MAXIMUM_COMPONENT_LENGTH)
+    if (strlen(componentName) > 64)
     {
-        LogError("componentName=%s is too long.  Maximum length is=%d", componentName, PNP_MAXIMUM_COMPONENT_LENGTH);
+        LogError("componentName %s is too long.  Maximum length is %d", componentName, 64);
         thermostatComponent = NULL;
     }
     // On initial invocation, store the UTC time into g_programStartTime global.
@@ -157,7 +174,8 @@ static bool BuildMaxMinCommandResponse(PNP_THERMOSTAT_COMPONENT* pnpThermostatCo
         LogError("snprintf to determine string length for command response failed");
         result = false;
     }
-    // We MUST allocate the response buffer.  It is returned to the IoTHub SDK in the direct method callback and the SDK in turn sends this to the server.
+    // We must allocate the response buffer.  It is returned to the IoTHub SDK in the command callback and the SDK in turn sends this to the server.
+    // The SDK takes responsibility for the buffer and will free it.
     else if ((responseBuilder = calloc(1, responseBuilderSize + 1)) == NULL)
     {
         LogError("Unable to allocate %lu bytes", (unsigned long)(responseBuilderSize + 1));
@@ -195,7 +213,7 @@ int PnP_ThermostatComponent_ProcessCommand(PNP_THERMOSTAT_COMPONENT_HANDLE pnpTh
 
     if (strcmp(pnpCommandName, g_getMaxMinReport) != 0)
     {
-        LogError("PnP command=%s is not supported on thermostat component", pnpCommandName);
+        LogError("Command %s is not supported on thermostat component", pnpCommandName);
         result = PNP_STATUS_NOT_FOUND;
     }
     // See caveats section in ../readme.md; we don't actually respect this sinceStr to keep the sample simple,
@@ -207,12 +225,12 @@ int PnP_ThermostatComponent_ProcessCommand(PNP_THERMOSTAT_COMPONENT_HANDLE pnpTh
     }
     else if (BuildMaxMinCommandResponse(pnpThermostatComponent, response, responseSize) == false)
     {
-        LogError("Unable to build response for component=%s", pnpThermostatComponent->componentName);
+        LogError("Unable to build response for component %s", pnpThermostatComponent->componentName);
         result = PNP_STATUS_INTERNAL_ERROR;
     }
     else
     {
-        LogInfo("Returning success from command request for component=%s", pnpThermostatComponent->componentName);
+        LogInfo("Returning success from command request for component %s", pnpThermostatComponent->componentName);
         result = PNP_STATUS_SUCCESS;
     }
 
@@ -246,125 +264,153 @@ static void UpdateTemperatureAndStatistics(PNP_THERMOSTAT_COMPONENT* pnpThermost
 }
 
 //
-// SendTargetTemperatureResponse sends a PnP property indicating the device has received and accepted the desired targeted temperature.
+// SendTargetTemperatureResponse sends a PnP property indicating the device has received the desired targeted temperature
 //
-static void SendTargetTemperatureResponse(PNP_THERMOSTAT_COMPONENT* pnpThermostatComponent, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClientLL, int version)
+static void SendTargetTemperatureResponse(PNP_THERMOSTAT_COMPONENT* pnpThermostatComponent, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient, const char* desiredTemperatureString, int responseStatus, int version, const char* description)
 {
-    char targetTemperatureAsString[32];
     IOTHUB_CLIENT_RESULT iothubClientResult;
-    STRING_HANDLE jsonToSend = NULL;
 
-    if (snprintf(targetTemperatureAsString, sizeof(targetTemperatureAsString), g_targetTemperaturePropertyResponseFormat, pnpThermostatComponent->currentTemperature) < 0)
+    // IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE in this case specifies the response to a desired temperature.
+    IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE temperatureProperty;
+    memset(&temperatureProperty, 0, sizeof(temperatureProperty));
+    // Specify the structure version (not to be confused with the $version on IoT Hub) to protect back-compat in case the structure adds fields.
+    temperatureProperty.structVersion= IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE_STRUCT_VERSION_1;
+    // This represents the version of the request from IoT Hub.  It needs to be returned so service applications can determine
+    // what current version of the writable property the device is currently using, as the server may update the property even when the device
+    // is offline.
+    temperatureProperty.ackVersion = version;
+    // Result of request, which maps to HTTP status code.
+    temperatureProperty.result = responseStatus;
+    temperatureProperty.name = g_targetTemperaturePropertyName;
+    temperatureProperty.value = desiredTemperatureString;
+    temperatureProperty.description = description;
+
+    unsigned char* propertySerialized = NULL;
+    size_t propertySerializedLength;
+
+    // The first step of reporting properties is to serialize IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE into JSON for sending.
+    if ((iothubClientResult = IoTHubClient_Serialize_WritablePropertyResponse(&temperatureProperty, 1, pnpThermostatComponent->componentName, &propertySerialized, &propertySerializedLength)) != IOTHUB_CLIENT_OK)
     {
-        LogError("Unable to create target temperature string for reporting result");
+        LogError("Unable to serialize updated property, error=%d", iothubClientResult);
     }
-    else if ((jsonToSend = PnP_CreateReportedPropertyWithStatus(pnpThermostatComponent->componentName, g_targetTemperaturePropertyName, targetTemperatureAsString, 
-                                                                      PNP_STATUS_SUCCESS, g_temperaturePropertyResponseDescription, version)) == NULL)
+    // The output of IoTHubClient_Serialize_WritablePropertyResponse is sent to IoTHubDeviceClient_LL_SendPropertiesAsync to perform network I/O.
+    else if ((iothubClientResult = IoTHubDeviceClient_LL_SendPropertiesAsync(deviceClient, propertySerialized, propertySerializedLength, NULL, NULL)) != IOTHUB_CLIENT_OK)
     {
-        LogError("Unable to build reported property response");
+        LogError("Unable to send updated property, error=%d", iothubClientResult);
     }
     else
     {
-        const char* jsonToSendStr = STRING_c_str(jsonToSend);
-        size_t jsonToSendStrLen = strlen(jsonToSendStr);
-
-        if ((iothubClientResult = IoTHubDeviceClient_LL_SendReportedState(deviceClientLL, (const unsigned char*)jsonToSendStr, jsonToSendStrLen, NULL, NULL)) != IOTHUB_CLIENT_OK)
-        {
-            LogError("Unable to send reported state, error=%d", iothubClientResult);
-        }
-        else
-        {
-            LogInfo("Sending acknowledgement of property to IoTHub for component=%s", pnpThermostatComponent->componentName);
-        }
+        LogInfo("Sending acknowledgement of property to IoTHub for component %s", pnpThermostatComponent->componentName);
     }
-
-    STRING_delete(jsonToSend);
+    IoTHubClient_Serialize_Properties_Destroy(propertySerialized);
 }
 
-void PnP_TempControlComponent_Report_MaxTempSinceLastReboot_Property(PNP_THERMOSTAT_COMPONENT_HANDLE pnpThermostatComponentHandle, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClientLL)
+void PnP_TempControlComponent_Report_MaxTempSinceLastReboot_Property(PNP_THERMOSTAT_COMPONENT_HANDLE pnpThermostatComponentHandle, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient)
 {
     PNP_THERMOSTAT_COMPONENT* pnpThermostatComponent = (PNP_THERMOSTAT_COMPONENT*)pnpThermostatComponentHandle;
-    char maximumTemperatureAsString[32];
+    char maximumTemperatureAsString[MAX_TEMPERATURE_SINCE_REBOOT_BUFFER_SIZE];
     IOTHUB_CLIENT_RESULT iothubClientResult;
-    STRING_HANDLE jsonToSend = NULL;
 
     if (snprintf(maximumTemperatureAsString, sizeof(maximumTemperatureAsString), g_maxTempSinceLastRebootPropertyFormat, pnpThermostatComponent->maxTemperature) < 0)
     {
         LogError("Unable to create max temp since last reboot string for reporting result");
     }
-    else if ((jsonToSend = PnP_CreateReportedProperty(pnpThermostatComponent->componentName, g_maxTempSinceLastRebootPropertyName, maximumTemperatureAsString)) == NULL)
-    {
-        LogError("Unable to build max temp since last reboot property");
-    }
     else
     {
-        const char* jsonToSendStr = STRING_c_str(jsonToSend);
-        size_t jsonToSendStrLen = strlen(jsonToSendStr);
+        IOTHUB_CLIENT_REPORTED_PROPERTY maxTempProperty = { IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, g_maxTempSinceLastRebootPropertyName, maximumTemperatureAsString };
 
-        if ((iothubClientResult = IoTHubDeviceClient_LL_SendReportedState(deviceClientLL, (const unsigned char*)jsonToSendStr, jsonToSendStrLen, NULL, NULL)) != IOTHUB_CLIENT_OK)
+        unsigned char* propertySerialized = NULL;
+        size_t propertySerializedLength;
+
+        // The first step of reporting properties is to serialize IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE into JSON for sending.
+        if ((iothubClientResult = IoTHubClient_Serialize_ReportedProperties(&maxTempProperty, 1, pnpThermostatComponent->componentName, &propertySerialized, &propertySerializedLength)) != IOTHUB_CLIENT_OK)
+        {
+            LogError("Unable to serialize reported state, error=%d", iothubClientResult);
+        }
+        // The output of IoTHubClient_Serialize_ReportedProperties is sent to IoTHubDeviceClient_LL_SendPropertiesAsync to perform network I/O.
+        else if ((iothubClientResult = IoTHubDeviceClient_LL_SendPropertiesAsync(deviceClient, propertySerialized, propertySerializedLength,  NULL, NULL)) != IOTHUB_CLIENT_OK)
         {
             LogError("Unable to send reported state, error=%d", iothubClientResult);
         }
         else
         {
-            LogInfo("Sending maximumTemperatureSinceLastReboot property to IoTHub for component=%s", pnpThermostatComponent->componentName);
+            LogInfo("Sending %s property to IoTHub for component %s", g_maxTempSinceLastRebootPropertyName, pnpThermostatComponent->componentName);
         }
+        IoTHubClient_Serialize_Properties_Destroy(propertySerialized);
     }
-
-    STRING_delete(jsonToSend);
 }
 
-void PnP_ThermostatComponent_ProcessPropertyUpdate(PNP_THERMOSTAT_COMPONENT_HANDLE pnpThermostatComponentHandle, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClientLL, const char* propertyName, JSON_Value* propertyValue, int version)
+void PnP_ThermostatComponent_ProcessPropertyUpdate(PNP_THERMOSTAT_COMPONENT_HANDLE pnpThermostatComponentHandle, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient, const char* propertyName, const char* propertyValue, int version)
 {
     PNP_THERMOSTAT_COMPONENT* pnpThermostatComponent = (PNP_THERMOSTAT_COMPONENT*)pnpThermostatComponentHandle;
 
     if (strcmp(propertyName, g_targetTemperaturePropertyName) != 0)
     {
-        LogError("Property=%s was requested to be changed but is not part of the thermostat interface definition", propertyName);
-    }
-    else if (json_value_get_type(propertyValue) != JSONNumber)
-    {
-        LogError("JSON field %s is not a number", g_targetTemperaturePropertyName);
+        LogError("Property %s was requested to be changed but is not part of the thermostat interface definition", propertyName);
     }
     else
     {
-        double targetTemperature = json_value_get_number(propertyValue);
-
-        LogInfo("Received targetTemperature=%f for component=%s", targetTemperature, pnpThermostatComponent->componentName);
-        
-        bool maxTempUpdated = false;
-        UpdateTemperatureAndStatistics(pnpThermostatComponent, targetTemperature, &maxTempUpdated);
-
-        // The device needs to let the service know that it has received the targetTemperature desired property.
-        SendTargetTemperatureResponse(pnpThermostatComponent, deviceClientLL, version);
-        
-        if (maxTempUpdated)
+        char* next;
+        double targetTemperature = strtol(propertyValue, &next, 10);
+        if ((propertyValue == next) || (targetTemperature == LONG_MAX) || (targetTemperature == LONG_MIN))
         {
-            // If the Maximum temperature has been updated, we also report this as a property.
-            PnP_TempControlComponent_Report_MaxTempSinceLastReboot_Property(pnpThermostatComponent, deviceClientLL);
+            LogError("Property %s is not a valid integer", propertyValue);
+            SendTargetTemperatureResponse(pnpThermostatComponent, deviceClient, propertyValue, PNP_STATUS_BAD_FORMAT, version, g_temperaturePropertyResponseDescriptionNotInt);
+        }
+        else
+        {
+            LogInfo("Received targetTemperature %f for component %s", targetTemperature, pnpThermostatComponent->componentName);
+            
+            bool maxTempUpdated = false;
+            UpdateTemperatureAndStatistics(pnpThermostatComponent, targetTemperature, &maxTempUpdated);
+
+            // The device needs to let the service know that it has received the targetTemperature desired property.
+            SendTargetTemperatureResponse(pnpThermostatComponent, deviceClient, propertyValue, PNP_STATUS_SUCCESS, version, NULL);
+            
+            if (maxTempUpdated)
+            {
+                // If the maximum temperature has been updated, we also report this as a property.
+                PnP_TempControlComponent_Report_MaxTempSinceLastReboot_Property(pnpThermostatComponent, deviceClient);
+            }
         }
     }
 }
 
-void PnP_ThermostatComponent_SendTelemetry(PNP_THERMOSTAT_COMPONENT_HANDLE pnpThermostatComponentHandle, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClientLL)
+void PnP_ThermostatComponent_SendCurrentTemperature(PNP_THERMOSTAT_COMPONENT_HANDLE pnpThermostatComponentHandle, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient)
 {
     PNP_THERMOSTAT_COMPONENT* pnpThermostatComponent = (PNP_THERMOSTAT_COMPONENT*)pnpThermostatComponentHandle;
     IOTHUB_MESSAGE_HANDLE messageHandle = NULL;
-    IOTHUB_CLIENT_RESULT iothubResult;
+    IOTHUB_MESSAGE_RESULT messageResult;
+    IOTHUB_CLIENT_RESULT iothubClientResult;
 
-    char temperatureStringBuffer[32];
+    char temperatureStringBuffer[CURRENT_TEMPERATURE_BUFFER_SIZE];
 
+    // Create the telemetry message body to send.
     if (snprintf(temperatureStringBuffer, sizeof(temperatureStringBuffer), g_temperatureTelemetryBodyFormat, pnpThermostatComponent->currentTemperature) < 0)
     {
         LogError("snprintf of current temperature telemetry failed");
     }
-    else if ((messageHandle = PnP_CreateTelemetryMessageHandle(pnpThermostatComponent->componentName, temperatureStringBuffer)) == NULL)
+    // Create the message handle and specify its metadata
+    else if ((messageHandle = IoTHubMessage_CreateFromString(temperatureStringBuffer)) == NULL)
     {
-        LogError("Unable to create telemetry message");
+        LogError("IoTHubMessage_PnP_CreateFromString failed");
     }
-    else if ((iothubResult = IoTHubDeviceClient_LL_SendEventAsync(deviceClientLL, messageHandle, NULL, NULL)) != IOTHUB_CLIENT_OK)
+    else if ((messageResult = IoTHubMessage_SetContentTypeSystemProperty(messageHandle, g_jsonContentType)) != IOTHUB_MESSAGE_OK)
     {
-        LogError("Unable to send telemetry message, error=%d", iothubResult);
+        LogError("IoTHubMessage_SetContentTypeSystemProperty failed, error=%d", messageResult);
+    }
+    else if ((messageResult = IoTHubMessage_SetContentEncodingSystemProperty(messageHandle, g_utf8EncodingType)) != IOTHUB_MESSAGE_OK)
+    {
+        LogError("IoTHubMessage_SetContentEncodingSystemProperty failed, error=%d", messageResult);
+    }
+    else if ((messageResult = IoTHubMessage_SetComponentName(messageHandle, pnpThermostatComponent->componentName)) != IOTHUB_MESSAGE_OK)
+    {
+        LogError("IoTHubMessage_SetContentEncodingSystemProperty failed, error=%d", messageResult);
+    }
+    // Send the telemetry message.
+    else if ((iothubClientResult = IoTHubDeviceClient_LL_SendTelemetryAsync(deviceClient, messageHandle, NULL, NULL)) != IOTHUB_CLIENT_OK)
+    {
+        LogError("Unable to send telemetry message, error=%d", iothubClientResult);
     }
 
     IoTHubMessage_Destroy(messageHandle);

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.c
@@ -26,16 +26,15 @@
 // Size of buffer to store the maximum temp since reboot property.
 #define MAX_TEMPERATURE_SINCE_REBOOT_BUFFER_SIZE 32
 
-// Maximum component size.  The spec (https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/dtdlv2.md#component)
-// defines the maximum component length as 64 to which we need to reserve the null-terminator.
-#define MAX_COMPONENT_NAME_LENGTH (64 + 1)
+// Maximum component size.  This comes from the spec https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/dtdlv2.md#component.
+#define MAX_COMPONENT_NAME_LENGTH 64
 
 // Names of properties for desired/reporting.
 static const char g_targetTemperaturePropertyName[] = "targetTemperature";
 static const char g_maxTempSinceLastRebootPropertyName[] = "maxTempSinceLastReboot";
 
 // Name of command this component supports to retrieve a report about the component.
-static const char g_getMaxMinReport[] = "getMaxMinReport";
+static const char g_getMaxMinReportCommandName[] = "getMaxMinReport";
 
 // The default temperature to use before any is set
 #define DEFAULT_TEMPERATURE_VALUE 22
@@ -75,7 +74,7 @@ char g_programStartTime[TIME_BUFFER_SIZE] = {0};
 typedef struct PNP_THERMOSTAT_COMPONENT_TAG
 {
     // Name of this component
-    char componentName[MAX_COMPONENT_NAME_LENGTH];
+    char componentName[MAX_COMPONENT_NAME_LENGTH + 1];
     // Current temperature of this thermostat component
     double currentTemperature;
     // Minimum temperature this thermostat has been at during current execution run of this thermostat component
@@ -118,9 +117,9 @@ PNP_THERMOSTAT_COMPONENT_HANDLE PnP_ThermostatComponent_CreateHandle(const char*
 {
     PNP_THERMOSTAT_COMPONENT* thermostatComponent;
 
-    if (strlen(componentName) > 64)
+    if (strlen(componentName) > MAX_COMPONENT_NAME_LENGTH)
     {
-        LogError("componentName %s is too long.  Maximum length is %d", componentName, 64);
+        LogError("componentName %s is too long.  Maximum length is %d", componentName, MAX_COMPONENT_NAME_LENGTH);
         thermostatComponent = NULL;
     }
     // On initial invocation, store the UTC time into g_programStartTime global.
@@ -212,7 +211,7 @@ int PnP_ThermostatComponent_ProcessCommand(PNP_THERMOSTAT_COMPONENT_HANDLE pnpTh
     const char* sinceStr;
     int result;
 
-    if (strcmp(pnpCommandName, g_getMaxMinReport) != 0)
+    if (strcmp(pnpCommandName, g_getMaxMinReportCommandName) != 0)
     {
         LogError("Command %s is not supported on thermostat component", pnpCommandName);
         result = PNP_STATUS_NOT_FOUND;

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.h
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.h
@@ -34,8 +34,8 @@ PNP_THERMOSTAT_COMPONENT_HANDLE PnP_ThermostatComponent_CreateHandle(const char*
 void PnP_ThermostatComponent_Destroy(PNP_THERMOSTAT_COMPONENT_HANDLE pnpThermostatComponentHandle);
 
 //
-// PnP_ThermostatComponent_ProcessCommand is used to process any incoming PnP Commands, transferred via the IoTHub device method channel,
-// to the given PNP_THERMOSTAT_COMPONENT_HANDLE.  The function returns an HTTP style return code to indicate success or failure.
+// PnP_ThermostatComponent_ProcessCommand is used to process any incoming PnP Commands to the given PNP_THERMOSTAT_COMPONENT_HANDLE.  
+// The function returns an HTTP style return code to indicate success or failure.
 //
 int PnP_ThermostatComponent_ProcessCommand(PNP_THERMOSTAT_COMPONENT_HANDLE pnpThermostatComponentHandle, const char *pnpCommandName, JSON_Value* commandJsonValue, unsigned char** response, size_t* responseSize);
 
@@ -43,17 +43,17 @@ int PnP_ThermostatComponent_ProcessCommand(PNP_THERMOSTAT_COMPONENT_HANDLE pnpTh
 // PnP_ThermostatComponent_ProcessPropertyUpdate processes an incoming property update and, if the property is in the thermostat's model, will
 // send a reported property acknowledging receipt of the property request from IoTHub.
 //
-void PnP_ThermostatComponent_ProcessPropertyUpdate(PNP_THERMOSTAT_COMPONENT_HANDLE pnpThermostatComponentHandle, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClientLL, const char* propertyName, JSON_Value* propertyValue, int version);
+void PnP_ThermostatComponent_ProcessPropertyUpdate(PNP_THERMOSTAT_COMPONENT_HANDLE pnpThermostatComponentHandle, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient, const char* propertyName, const char* propertyValue, int version);
 
 //
-// PnP_ThermostatComponent_SendTelemetry sends telemetry indicating the current temperature of the thermostat.
+// PnP_ThermostatComponent_SendCurrentTemperature sends a telemetry message indicating the current temperature.
 //
-void PnP_ThermostatComponent_SendTelemetry(PNP_THERMOSTAT_COMPONENT_HANDLE pnpThermostatComponentHandle, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClientLL);
+void PnP_ThermostatComponent_SendCurrentTemperature(PNP_THERMOSTAT_COMPONENT_HANDLE pnpThermostatComponentHandle, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient);
 
 //
 // PnP_TempControlComponent_Report_MaxTempSinceLastReboot_Property sends a property indicating maxTempSinceLastReboot.  Since 
-// this property is not "writeable" in the DTDL, the application can invoke this at startup.
+// this property is not "writable" in the DTDL, the application can invoke this at startup.
 //
-void PnP_TempControlComponent_Report_MaxTempSinceLastReboot_Property(PNP_THERMOSTAT_COMPONENT_HANDLE pnpThermostatComponentHandle, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClientLL);
+void PnP_TempControlComponent_Report_MaxTempSinceLastReboot_Property(PNP_THERMOSTAT_COMPONENT_HANDLE pnpThermostatComponentHandle, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient);
 
 #endif /* PNP_THERMOSTAT_CONTROLLER_H */

--- a/iothub_client/src/iothub_message.c
+++ b/iothub_client/src/iothub_message.c
@@ -1225,6 +1225,20 @@ bool IoTHubMessage_IsSecurityMessage(IOTHUB_MESSAGE_HANDLE iotHubMessageHandle)
     return result;
 }
 
+IOTHUB_MESSAGE_RESULT IoTHubMessage_SetComponentName(IOTHUB_MESSAGE_HANDLE iotHubMessageHandle, const char* componentName)
+{
+    (void)iotHubMessageHandle;
+    (void)componentName;
+    return 0;
+}
+
+const char* IoTHubMessage_GetComponentName(IOTHUB_MESSAGE_HANDLE iotHubMessageHandle)
+{
+    (void)iotHubMessageHandle;
+    return NULL;
+}
+
+
 void IoTHubMessage_Destroy(IOTHUB_MESSAGE_HANDLE iotHubMessageHandle)
 {
     /*Codes_SRS_IOTHUBMESSAGE_01_004: [If iotHubMessageHandle is NULL, IoTHubMessage_Destroy shall do nothing.] */

--- a/iothub_client/src/iothub_message.c
+++ b/iothub_client/src/iothub_message.c
@@ -1260,7 +1260,6 @@ IOTHUB_MESSAGE_RESULT IoTHubMessage_SetComponentName(IOTHUB_MESSAGE_HANDLE iotHu
         }
     }
     return result;
-
 }
 
 const char* IoTHubMessage_GetComponentName(IOTHUB_MESSAGE_HANDLE iotHubMessageHandle)

--- a/iothub_client/src/iothub_message.c
+++ b/iothub_client/src/iothub_message.c
@@ -429,7 +429,7 @@ IOTHUB_MESSAGE_HANDLE IoTHubMessage_Clone(IOTHUB_MESSAGE_HANDLE iotHubMessageHan
             }
             else if (source->componentName != NULL && mallocAndStrcpy_s(&result->componentName, source->componentName) != 0)
             {
-                LogError("unable to copy inputName");
+                LogError("unable to copy componentName");
                 DestroyMessageData(result);
                 result = NULL;
             }

--- a/iothub_client/src/iothubtransport_mqtt_common.c
+++ b/iothub_client/src/iothubtransport_mqtt_common.c
@@ -90,6 +90,7 @@ static const char* DIAGNOSTIC_ID_PROPERTY = "diagid";
 static const char* DIAGNOSTIC_CONTEXT_PROPERTY = "diagctx";
 static const char* CONNECTION_DEVICE_ID = "cdid";
 static const char* CONNECTION_MODULE_ID_PROPERTY = "cmid";
+static const char* MESSAGE_COMPONENT_ID = "sub";
 
 static const char* DIAGNOSTIC_CONTEXT_CREATION_TIME_UTC_PROPERTY = "creationtimeutc";
 
@@ -778,6 +779,17 @@ static int addSystemPropertiesTouMqttMessage(IOTHUB_MESSAGE_HANDLE iothub_messag
             }
         }
     }
+
+    if (result == 0)
+    {
+        const char* component_name = IoTHubMessage_GetComponentName(iothub_message_handle);
+        if (component_name != NULL)
+        {
+            result = addSystemPropertyToTopicString(topic_string, index, MESSAGE_COMPONENT_ID, component_name, urlencode);
+            index++;
+        }
+    }
+
     *index_ptr = index;
     return result;
 }

--- a/iothub_client/tests/iothubmessage_ut/iothubmessage_ut.c
+++ b/iothub_client/tests/iothubmessage_ut/iothubmessage_ut.c
@@ -80,6 +80,7 @@ static const char* TEST_CONNECTION_DEVICE_ID = "connectiondeviceid";
 static const char* TEST_CONNECTION_DEVICE_ID2 = "connectiondeviceid2";
 static const char* TEST_CONNECTION_MODULE_ID = "connectionmoduleid";
 static const char* TEST_CONNECTION_MODULE_ID2 = "connectionmoduleid2";
+static const char* TEST_COMPONENT_NAME = "testComponentName";
 static const char* TEST_PROPERTY_KEY = "property_key";
 static const char* TEST_PROPERTY_VALUE = "property_value";
 static const char* TEST_NON_ASCII_PROPERTY_KEY = "\x01property_key";
@@ -587,7 +588,7 @@ TEST_FUNCTION(IoTHubMessage_Destroy_With_NULL_handle_does_nothing)
 }
 
 /*Tests_SRS_IOTHUBMESSAGE_01_003: [IoTHubMessage_Destroy shall free all resources associated with iotHubMessageHandle.]  */
-TEST_FUNCTION(IoTHubMessage_Destroy_destroys_a_BYTEARRAY_IoTHubMEssage)
+TEST_FUNCTION(IoTHubMessage_Destroy_destroys_a_BYTEARRAY_IoTHubMessage)
 {
     // arrange
     IOTHUB_MESSAGE_HANDLE h = IoTHubMessage_CreateFromByteArray(c, 1);
@@ -595,6 +596,7 @@ TEST_FUNCTION(IoTHubMessage_Destroy_destroys_a_BYTEARRAY_IoTHubMEssage)
 
     STRICT_EXPECTED_CALL(BUFFER_delete(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(Map_Destroy(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
@@ -626,6 +628,7 @@ TEST_FUNCTION(IoTHubMessage_Destroy_destroys_a_STRING_IoTHubMessage)
 
     STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(Map_Destroy(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
@@ -2253,6 +2256,41 @@ TEST_FUNCTION(IoTHubMessage_GetMessageUserIdProperty_ConnectionModuleId_Not_Set_
 TEST_FUNCTION(IoTHubMessage_GetUserIdSystemProperty_SUCCEED)
 {
     get_string_succeeds_impl(IoTHubMessage_SetMessageUserIdSystemProperty, IoTHubMessage_GetMessageUserIdSystemProperty, TEST_MESSAGE_USER_ID);
+}
+
+TEST_FUNCTION(IoTHubMessage_SetComponentName_NULL_handle_Fails)
+{
+    set_string_NULL_handle_fails_impl(IoTHubMessage_SetComponentName, TEST_COMPONENT_NAME);
+}
+
+TEST_FUNCTION(IoTHubMessage_SetComponentName_NULL_MessageId_Fails)
+{
+    set_string_NULL_string_fails_impl(IoTHubMessage_SetComponentName);
+}
+
+TEST_FUNCTION(IoTHubMessage_SetComponentName_SUCCEED)
+{
+    set_string_succeeds_impl(IoTHubMessage_SetComponentName, TEST_COMPONENT_NAME);
+}
+
+TEST_FUNCTION(IoTHubMessage_SetComponentName_ComponentName_Not_NULL_SUCCEED)
+{
+    set_string_string_already_allocated_succeeds_impl(IoTHubMessage_SetComponentName, "output_string2");
+}
+
+TEST_FUNCTION(IoTHubMessage_GetComponentName_NULL_handle_Fails)
+{
+    get_string_NULL_handle_fails_impl(IoTHubMessage_GetComponentName);
+}
+
+TEST_FUNCTION(IoTHubMessage_GetComponentName_ComponentName_Not_Set_Fails)
+{
+    get_string_not_set_fails_impl(IoTHubMessage_GetComponentName);
+}
+
+TEST_FUNCTION(IoTHubMessage_GetComponentName_SUCCEED)
+{
+    get_string_succeeds_impl(IoTHubMessage_SetComponentName, IoTHubMessage_GetComponentName, TEST_COMPONENT_NAME);
 }
 
 END_TEST_SUITE(iothubmessage_ut)

--- a/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
+++ b/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
@@ -194,6 +194,7 @@ static const char* TEST_DIAG_ID = "1234abcd";
 static const char* TEST_DIAG_CREATION_TIME_UTC = "1506054516.100";
 static const char* TEST_MESSAGE_CREATION_TIME_UTC = "2010-01-01T01:00:00.000Z";
 static const char* TEST_OUTPUT_NAME = "TestOutputName";
+static const char* TEST_COMPONENT_NAME = "TestComponentName";
 
 static const char* PROPERTY_SEPARATOR = "&";
 static const char* DIAGNOSTIC_CONTEXT_CREATION_TIME_UTC_PROPERTY = "creationtimeutc";
@@ -1293,6 +1294,7 @@ static void setup_IoTHubTransport_MQTT_Common_DoWork_emtpy_msg_mocks(void)
     STRICT_EXPECTED_CALL(IoTHubMessage_GetContentTypeSystemProperty(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(IoTHubMessage_GetContentEncodingSystemProperty(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(IoTHubMessage_GetMessageCreationTimeUtcSystemProperty(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(IoTHubMessage_GetComponentName(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(IoTHubMessage_GetDiagnosticPropertyData(IGNORED_PTR_ARG));
 
     STRICT_EXPECTED_CALL(IoTHubMessage_GetOutputName(IGNORED_PTR_ARG));
@@ -1344,6 +1346,7 @@ static void setup_IoTHubTransport_MQTT_Common_DoWork_resend_events_mocks(
     const char* message_creation_time_utc,
     bool auto_urlencode,
     const char* output_name,
+    const char* component_name,
     bool security_msg)
 {
     TEST_DIAG_DATA.diagnosticId = (char*)diag_id;
@@ -1434,6 +1437,15 @@ static void setup_IoTHubTransport_MQTT_Common_DoWork_resend_events_mocks(
         STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)).CallCannotFail();
         STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG));
     }
+
+    STRICT_EXPECTED_CALL(IoTHubMessage_GetComponentName(IGNORED_PTR_ARG)).SetReturn(component_name);
+    if (auto_urlencode && (component_name != NULL))
+    {
+        STRICT_EXPECTED_CALL(URL_EncodeString(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)).CallCannotFail();
+        STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG));
+    } 
+
     STRICT_EXPECTED_CALL(IoTHubMessage_GetDiagnosticPropertyData(IGNORED_PTR_ARG)).SetReturn(&TEST_DIAG_DATA);
 
     bool validMessage = true;
@@ -1491,6 +1503,7 @@ static void setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks(
     const char* message_creation_time_utc,
     bool auto_urlencode,
     const char* output_name,
+    const char* component_name,
     bool security_msg)
 {
     TEST_DIAG_DATA.diagnosticId = (char*)diag_id;
@@ -1581,6 +1594,15 @@ static void setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks(
         STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)).CallCannotFail();
         STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG));
     }
+
+    STRICT_EXPECTED_CALL(IoTHubMessage_GetComponentName(IGNORED_PTR_ARG)).SetReturn(component_name);
+    if (auto_urlencode && (component_name != NULL))
+    {
+        STRICT_EXPECTED_CALL(URL_EncodeString(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)).CallCannotFail();
+        STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG));
+    }
+
     STRICT_EXPECTED_CALL(IoTHubMessage_GetDiagnosticPropertyData(IGNORED_PTR_ARG)).SetReturn(&TEST_DIAG_DATA);
 
     bool validMessage = true;
@@ -4635,7 +4657,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_with_1_event_item_succeeds)
     IoTHubTransport_MQTT_Common_DoWork(handle);
     umock_c_reset_all_calls();
 
-    setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks(NULL, NULL, 0, TEST_IOTHUB_MSG_BYTEARRAY, false, NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, NULL, false);
+    setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks(NULL, NULL, 0, TEST_IOTHUB_MSG_BYTEARRAY, false, NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, NULL, NULL, false);
 
     // act
     IoTHubTransport_MQTT_Common_DoWork(handle);
@@ -4819,7 +4841,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_with_security_msg_succeeds)
     IoTHubTransport_MQTT_Common_DoWork(handle);
     umock_c_reset_all_calls();
 
-    setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks(NULL, NULL, 0, TEST_IOTHUB_MSG_STRING, false, NULL, NULL, NULL, "json/application", NULL, NULL, NULL, false, NULL, true);
+    setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks(NULL, NULL, 0, TEST_IOTHUB_MSG_STRING, false, NULL, NULL, NULL, "json/application", NULL, NULL, NULL, false, NULL, NULL, true);
 
     // act
     IoTHubTransport_MQTT_Common_DoWork(handle);
@@ -4856,7 +4878,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_with_1_event_item_fail)
     IoTHubTransport_MQTT_Common_DoWork(handle);
     umock_c_reset_all_calls();
 
-    setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks(NULL, NULL, 0, TEST_IOTHUB_MSG_BYTEARRAY, false, NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, NULL, false);
+    setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks(NULL, NULL, 0, TEST_IOTHUB_MSG_BYTEARRAY, false, NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, NULL, NULL, false);
     umock_c_negative_tests_snapshot();
 
     // act
@@ -4916,7 +4938,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_with_1_event_item_with_properti
     IoTHubTransport_MQTT_Common_DoWork(handle);
     umock_c_reset_all_calls();
 
-    setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks((const char* const**)&keys, (const char* const**)&values, propCount, TEST_IOTHUB_MSG_BYTEARRAY, false, NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, NULL, false);
+    setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks((const char* const**)&keys, (const char* const**)&values, propCount, TEST_IOTHUB_MSG_BYTEARRAY, false, NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, NULL, NULL, false);
 
     // act
     IoTHubTransport_MQTT_Common_DoWork(handle);
@@ -4962,7 +4984,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_with_1_event_item_with_2_proper
     IoTHubTransport_MQTT_Common_DoWork(handle);
     umock_c_reset_all_calls();
 
-    setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks((const char* const**)&keys, (const char* const**)&values, propCount, TEST_IOTHUB_MSG_BYTEARRAY, false, NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, NULL, false);
+    setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks((const char* const**)&keys, (const char* const**)&values, propCount, TEST_IOTHUB_MSG_BYTEARRAY, false, NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, NULL, NULL, false);
 
     // act
     IoTHubTransport_MQTT_Common_DoWork(handle);
@@ -5010,7 +5032,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_with_1_event_item_with_properti
     IoTHubTransport_MQTT_Common_DoWork(handle);
     umock_c_reset_all_calls();
 
-    setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks((const char* const**)&keys, (const char* const**)&values, propCount, TEST_IOTHUB_MSG_BYTEARRAY, false, NULL, NULL, NULL, NULL, NULL, NULL, NULL, true, NULL, false);
+    setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks((const char* const**)&keys, (const char* const**)&values, propCount, TEST_IOTHUB_MSG_BYTEARRAY, false, NULL, NULL, NULL, NULL, NULL, NULL, NULL, true, NULL, NULL, false);
 
     // act
     IoTHubTransport_MQTT_Common_DoWork(handle);
@@ -5058,7 +5080,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_with_1_event_item_with_2_proper
     IoTHubTransport_MQTT_Common_DoWork(handle);
     umock_c_reset_all_calls();
 
-    setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks((const char* const**)&keys, (const char* const**)&values, propCount, TEST_IOTHUB_MSG_BYTEARRAY, false, NULL, NULL, NULL, NULL, NULL, NULL, NULL, true, NULL, false);
+    setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks((const char* const**)&keys, (const char* const**)&values, propCount, TEST_IOTHUB_MSG_BYTEARRAY, false, NULL, NULL, NULL, NULL, NULL, NULL, NULL, true, NULL, NULL, false);
 
     // act
     IoTHubTransport_MQTT_Common_DoWork(handle);
@@ -5139,7 +5161,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_resend_message_succeeds)
     umock_c_reset_all_calls();
 
     g_current_ms += 5*60*1000;
-    setup_IoTHubTransport_MQTT_Common_DoWork_resend_events_mocks(NULL, NULL, 0, TEST_IOTHUB_MSG_STRING, false, NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, NULL, false);
+    setup_IoTHubTransport_MQTT_Common_DoWork_resend_events_mocks(NULL, NULL, 0, TEST_IOTHUB_MSG_STRING, false, NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, NULL, NULL, false);
 
     // act
     IoTHubTransport_MQTT_Common_DoWork(handle);
@@ -5411,7 +5433,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_with_1_event_item_STRING_type_s
     IoTHubTransport_MQTT_Common_DoWork(handle);
     umock_c_reset_all_calls();
 
-    setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks(NULL, NULL, 0, TEST_IOTHUB_MSG_STRING, false, NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, NULL, false);
+    setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks(NULL, NULL, 0, TEST_IOTHUB_MSG_STRING, false, NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, NULL, NULL, false);
 
     // act
     IoTHubTransport_MQTT_Common_DoWork(handle);
@@ -5457,7 +5479,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_with_message_system_properties_
     umock_c_reset_all_calls();
 
     setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks(NULL, NULL, 0, TEST_IOTHUB_MSG_STRING, false,
-        "msg_id", "core_id", TEST_CONTENT_TYPE, TEST_CONTENT_ENCODING, TEST_DIAG_ID, TEST_DIAG_CREATION_TIME_UTC, TEST_MESSAGE_CREATION_TIME_UTC, false, TEST_OUTPUT_NAME, false);
+        "msg_id", "core_id", TEST_CONTENT_TYPE, TEST_CONTENT_ENCODING, TEST_DIAG_ID, TEST_DIAG_CREATION_TIME_UTC, TEST_MESSAGE_CREATION_TIME_UTC, false, TEST_OUTPUT_NAME, TEST_COMPONENT_NAME, false);
 
     // act
     IoTHubTransport_MQTT_Common_DoWork(handle);
@@ -5500,7 +5522,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_with_message_system_properties_
     umock_c_reset_all_calls();
 
     setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks(NULL, NULL, 0, TEST_IOTHUB_MSG_STRING, false,
-        "msg_id", "core_id", TEST_CONTENT_TYPE, TEST_CONTENT_ENCODING, TEST_DIAG_ID, TEST_DIAG_CREATION_TIME_UTC, TEST_MESSAGE_CREATION_TIME_UTC, true, NULL, false);
+        "msg_id", "core_id", TEST_CONTENT_TYPE, TEST_CONTENT_ENCODING, TEST_DIAG_ID, TEST_DIAG_CREATION_TIME_UTC, TEST_MESSAGE_CREATION_TIME_UTC, true, NULL, TEST_COMPONENT_NAME, false);
 
     // act
     IoTHubTransport_MQTT_Common_DoWork(handle);
@@ -5542,7 +5564,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_with_message_incomplete_diagnos
     umock_c_reset_all_calls();
 
     setup_IoTHubTransport_MQTT_Common_DoWork_events_mocks(NULL, NULL, 0, TEST_IOTHUB_MSG_STRING, false,
-        NULL, NULL, NULL, NULL, TEST_DIAG_ID, NULL, NULL, false, NULL, false);
+        NULL, NULL, NULL, NULL, TEST_DIAG_ID, NULL, NULL, false, NULL, NULL, false);
 
     // act
     IoTHubTransport_MQTT_Common_DoWork(handle);


### PR DESCRIPTION
*Bulk of this change.*

* Rework PnP sample to stop using the "helper sample" and instead use official API.  
  
  I tried to keep the multi-component sample as close as feasible to the single component sample, which we've reviewed a bunch already.  This is for consistency for customers mostly and also to leverage all the PR muscle put into the initial review.

*Additionally...*

* `pnp_simple_thermostat.c` fixes, both bug fixes (like strtod and not strtol) and how DPS portions are optionally included in CMake.

* Fix `pnp_dps_ll.c`.  I had previously contemplated some sort of helper API that would generate the `{"modelId":"<modelId>"}` JSON blob.  We could add later if we wanted, but... this JSON is pretty straightforward and I think vast majority of time should just be a `static const char` (because ModelId doesn't change much).  So I removed the references to this JSON builder API (which was never implemented fortunately) and just showed a more direct C string build up.