### PR TITLE
Add option to not add warnings-as-errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,15 +31,19 @@ endif()
 
 include (CTest)
 
-if (MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /wd4232")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4 /wd4232")
-    # Make warning as error
-    add_definitions(/WX)
-else()
-    # Make warning as error
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+option(enable_warnings "enable strict warnings-as-errors based on the compiler" ON)
+
+if (enable_warnings)
+    if (MSVC)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /wd4232")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4 /wd4232")
+        # Make warning as error
+        add_definitions(/WX)
+    else()
+        # Make warning as error
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+    endif()
 endif()
 
 IF(WIN32)


### PR DESCRIPTION
As part of rolling the vcpkg MacOS CI forward, new warnings have been added to the compiler which causes azure-iot-sdk-c to no longer build. Since the user is almost never in a position to triage and fix new (possibly spurious) build breaks caused by this, it is vcpkg policy to disable `-WX`/`-Werror` for all package builds to maximize forward compatibility with upgrading compilers.

We've added a temporary patch as part of https://github.com/microsoft/vcpkg/pull/19207/files, however we'd like to merge the option of disabling these upstream so we can remove that patch on the next release.

I've added the option such that it preserves the existing semantics of the build by default.