### PR TITLE
Remove macro util wrapping from doxygen docs

### DIFF
--- a/iothub_client/inc/iothub_client.h
+++ b/iothub_client/inc/iothub_client.h
@@ -34,10 +34,6 @@
 #include "iothub_client_ll.h"
 
 #ifndef IOTHUB_CLIENT_INSTANCE_TYPE
-/**
- * @brief IoT Hub device client handle
- * 
- */
 typedef IOTHUB_CLIENT_CORE_HANDLE IOTHUB_CLIENT_HANDLE;
 #define IOTHUB_CLIENT_INSTANCE_TYPE
 #endif // IOTHUB_CLIENT_INSTANCE

--- a/iothub_client/inc/iothub_client_core_common.h
+++ b/iothub_client/inc/iothub_client_core_common.h
@@ -185,7 +185,7 @@ extern "C"
     /** @brief    This struct captures IoTHub client configuration. */
     typedef struct IOTHUB_CLIENT_CONFIG_TAG
     {
-        /** @brief A function pointer that is passed into the IoTHubClientCreate().
+        /** @brief A function pointer that is passed into the @c IoTHubClientCreate.
         *    A function definition for AMQP is defined in the include @c iothubtransportamqp.h.
         *   A function definition for HTTP is defined in the include @c iothubtransporthttp.h
         *   A function definition for MQTT is defined in the include @c iothubtransportmqtt.h */

--- a/iothub_client/inc/iothub_device_client.h
+++ b/iothub_client/inc/iothub_device_client.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 /** @file iothub_device_client.h
-*    @brief Extends the IoTHubClient_LL with additional features.
+*    @brief Extends the IoTHubCLient_LL with additional features.
 *
 *    @details IoTHubDeviceClient extends the IoTHubDeviceClient_LL
 *             with 2 features:
@@ -25,10 +25,6 @@
 #include "iothub_device_client_ll.h"
 
 #ifndef IOTHUB_DEVICE_CLIENT_INSTANCE_TYPE
-/**
- * @brief IoT Hub device client handle
- * 
- */
 typedef IOTHUB_CLIENT_CORE_HANDLE IOTHUB_DEVICE_CLIENT_HANDLE;
 #define IOTHUB_DEVICE_CLIENT_INSTANCE_TYPE
 #endif // IOTHUB_CLIENT_INSTANCE
@@ -52,7 +48,7 @@ extern "C"
     *                   <pre>HostName=[IoT Hub name goes here].[IoT Hub suffix goes here, e.g., private.azure-devices-int.net];DeviceId=[Device ID goes here];SharedAccessSignature=SharedAccessSignature sr=[IoT Hub name goes here].[IoT Hub suffix goes here, e.g., private.azure-devices-int.net]/devices/[Device ID goes here]&sig=[SAS Token goes here]&se=[Expiry Time goes here];</pre>
     *                </blockquote>
     *
-    * @return    A non-NULL #IOTHUB_DEVICE_CLIENT_HANDLE value that is used when
+    * @return    A non-NULL @c IOTHUB_DEVICE_CLIENT_HANDLE value that is used when
     *             invoking other functions for IoT Hub client and @c NULL on failure.
     */
     MOCKABLE_FUNCTION(, IOTHUB_DEVICE_CLIENT_HANDLE, IoTHubDeviceClient_CreateFromConnectionString, const char*, connectionString, IOTHUB_CLIENT_TRANSPORT_PROVIDER, protocol);
@@ -66,7 +62,7 @@ extern "C"
     *           The API does not allow sharing of a connection across multiple
     *           devices. This is a blocking call.
     *
-    * @return   A non-NULL #IOTHUB_DEVICE_CLIENT_HANDLE value that is used when
+    * @return   A non-NULL @c IOTHUB_DEVICE_CLIENT_HANDLE value that is used when
     *           invoking other functions for IoT Hub client and @c NULL on failure.
     */
     MOCKABLE_FUNCTION(, IOTHUB_DEVICE_CLIENT_HANDLE, IoTHubDeviceClient_Create, const IOTHUB_CLIENT_CONFIG*, config);
@@ -81,7 +77,7 @@ extern "C"
     *           The API allows sharing of a connection across multiple
     *           devices. This is a blocking call.
     *
-    * @return   A non-NULL #IOTHUB_DEVICE_CLIENT_HANDLE value that is used when
+    * @return   A non-NULL @c IOTHUB_DEVICE_CLIENT_HANDLE value that is used when
     *           invoking other functions for IoT Hub client and @c NULL on failure.
     */
     MOCKABLE_FUNCTION(, IOTHUB_DEVICE_CLIENT_HANDLE, IoTHubDeviceClient_CreateWithTransport, TRANSPORT_HANDLE, transportHandle, const IOTHUB_CLIENT_CONFIG*, config);
@@ -94,7 +90,7 @@ extern "C"
     * @param    device_id       Pointer to the device Id of the device
     * @param    protocol        Function pointer for protocol implementation
     *
-    * @return    A non-NULL #IOTHUB_DEVICE_CLIENT_HANDLE value that is used when
+    * @return    A non-NULL @c IOTHUB_DEVICE_CLIENT_HANDLE value that is used when
     *            invoking other functions for IoT Hub client and @c NULL on failure.
     */
     MOCKABLE_FUNCTION(, IOTHUB_DEVICE_CLIENT_HANDLE, IoTHubDeviceClient_CreateFromDeviceAuth, const char*, iothub_uri, const char*, device_id, IOTHUB_CLIENT_TRANSPORT_PROVIDER, protocol);

--- a/iothub_client/inc/iothub_device_client_ll.h
+++ b/iothub_client/inc/iothub_device_client_ll.h
@@ -52,7 +52,7 @@ typedef struct IOTHUB_CLIENT_CORE_LL_HANDLE_DATA_TAG* IOTHUB_DEVICE_CLIENT_LL_HA
     *                    <pre>HostName=[IoT Hub name goes here].[IoT Hub suffix goes here, e.g., private.azure-devices-int.net];DeviceId=[Device ID goes here];SharedAccessKey=[Device key goes here];</pre>
     *                </blockquote>
     *
-    * @return    A non-NULL #IOTHUB_DEVICE_CLIENT_LL_HANDLE value that is used when
+    * @return    A non-NULL @c IOTHUB_DEVICE_CLIENT_LL_HANDLE value that is used when
     *             invoking other functions for IoT Hub client and @c NULL on failure.
     */
      MOCKABLE_FUNCTION(, IOTHUB_DEVICE_CLIENT_LL_HANDLE, IoTHubDeviceClient_LL_CreateFromConnectionString, const char*, connectionString, IOTHUB_CLIENT_TRANSPORT_PROVIDER, protocol);
@@ -66,7 +66,7 @@ typedef struct IOTHUB_CLIENT_CORE_LL_HANDLE_DATA_TAG* IOTHUB_DEVICE_CLIENT_LL_HA
     *           The API does not allow sharing of a connection across multiple
     *           devices. This is a blocking call.
     *
-    * @return    A non-NULL #IOTHUB_DEVICE_CLIENT_LL_HANDLE value that is used when
+    * @return    A non-NULL @c IOTHUB_DEVICE_CLIENT_LL_HANDLE value that is used when
     *            invoking other functions for IoT Hub client and @c NULL on failure.
     */
      MOCKABLE_FUNCTION(, IOTHUB_DEVICE_CLIENT_LL_HANDLE, IoTHubDeviceClient_LL_Create, const IOTHUB_CLIENT_CONFIG*, config);
@@ -80,7 +80,7 @@ typedef struct IOTHUB_CLIENT_CORE_LL_HANDLE_DATA_TAG* IOTHUB_DEVICE_CLIENT_LL_HA
     *           The API *allows* sharing of a connection across multiple
     *           devices. This is a blocking call.
     *
-    * @return   A non-NULL #IOTHUB_DEVICE_CLIENT_LL_HANDLE value that is used when
+    * @return   A non-NULL @c IOTHUB_DEVICE_CLIENT_LL_HANDLE value that is used when
     *           invoking other functions for IoT Hub client and @c NULL on failure.
     */
      MOCKABLE_FUNCTION(, IOTHUB_DEVICE_CLIENT_LL_HANDLE, IoTHubDeviceClient_LL_CreateWithTransport, const IOTHUB_CLIENT_DEVICE_CONFIG*, config);
@@ -94,7 +94,7 @@ typedef struct IOTHUB_CLIENT_CORE_LL_HANDLE_DATA_TAG* IOTHUB_DEVICE_CLIENT_LL_HA
      * @param    device_auth_handle     A device auth handle used to generate the connection string
      * @param    protocol               Function pointer for protocol implementation
      *
-     * @return   A non-NULL #IOTHUB_DEVICE_CLIENT_LL_HANDLE value that is used when
+     * @return   A non-NULL @c IOTHUB_DEVICE_CLIENT_LL_HANDLE value that is used when
      *           invoking other functions for IoT Hub client and @c NULL on failure.
      */
      MOCKABLE_FUNCTION(, IOTHUB_DEVICE_CLIENT_LL_HANDLE, IoTHubDeviceClient_LL_CreateFromDeviceAuth, const char*, iothub_uri, const char*, device_id, IOTHUB_CLIENT_TRANSPORT_PROVIDER, protocol);

--- a/iothub_client/inc/iothub_message.h
+++ b/iothub_client/inc/iothub_message.h
@@ -27,8 +27,7 @@ extern "C"
     IOTHUB_MESSAGE_INVALID_TYPE,             \
     IOTHUB_MESSAGE_ERROR                     \
 
-/**
- * @brief Enumeration specifying the status of calls to various
+/** @brief Enumeration specifying the status of calls to various
 *  APIs in this module.
 */
 MU_DEFINE_ENUM_WITHOUT_INVALID(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_RESULT_VALUES);
@@ -38,15 +37,11 @@ IOTHUBMESSAGE_BYTEARRAY, \
 IOTHUBMESSAGE_STRING, \
 IOTHUBMESSAGE_UNKNOWN \
 
-/**
- * @brief Enumeration specifying the content type of the given message.
+/** @brief Enumeration specifying the content type of the a given
+* message.
 */
 MU_DEFINE_ENUM_WITHOUT_INVALID(IOTHUBMESSAGE_CONTENT_TYPE, IOTHUBMESSAGE_CONTENT_TYPE_VALUES);
 
-/**
- * @brief IoT Hub message handle.
- * 
- */
 typedef struct IOTHUB_MESSAGE_HANDLE_DATA_TAG* IOTHUB_MESSAGE_HANDLE;
 
 /** @brief diagnostic related data*/


### PR DESCRIPTION
With help from @jspaith 

Adds a step to the doxygen deployment which removes the `MOCKABLE_FUNCTION` and `MU_DEFINE_ENUM` from headers to make doxygen look better.

closes #2119 