### PR TITLE
Cleanup MQTT responseId parsing

### DIFF
--- a/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
+++ b/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
@@ -1711,7 +1711,7 @@ static void setup_message_recv_callback_device_twin_mocks(const char* token_type
         .CallCannotFail();
     STRICT_EXPECTED_CALL(STRING_TOKENIZER_get_next_token(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG)).SetReturn(0);
     STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG))
-        .SetReturn("4")
+        .SetReturn("?$rid=4")
         .IgnoreArgument_handle()
         .CallCannotFail();
 
@@ -4051,7 +4051,7 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_send_get_twin_succeed)
     STRICT_EXPECTED_CALL(STRING_TOKENIZER_get_next_token(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .SetReturn(0);
     STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG))
-        .SetReturn("2");
+        .SetReturn("?$rid=2");
     STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(STRING_TOKENIZER_destroy(IGNORED_PTR_ARG));
 

--- a/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
+++ b/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
@@ -6115,7 +6115,7 @@ TEST_FUNCTION(IoTHubTransportMqtt_MessageRecv_device_twin_succeed)
     IoTHubTransport_MQTT_Common_Destroy(handle);
 }
 
-static void test_invalid_mqtt_twin_topic_setup(const char* mqtt_topic, const char* response_id)
+static void test_invalid_mqtt_twin_topic_setup(const char* mqtt_topic, const char* status_code, const char* response_id)
 {
     // arrange
     IOTHUBTRANSPORT_CONFIG config = { 0 };
@@ -6158,13 +6158,21 @@ static void test_invalid_mqtt_twin_topic_setup(const char* mqtt_topic, const cha
     STRICT_EXPECTED_CALL(STRING_TOKENIZER_get_next_token(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG)).SetReturn(0);
     STRICT_EXPECTED_CALL(STRING_TOKENIZER_get_next_token(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG)).SetReturn(0);
     STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)).SetReturn("res");
-    STRICT_EXPECTED_CALL(STRING_TOKENIZER_get_next_token(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG)).SetReturn(0);
-    STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)).SetReturn("200");
 
-    if (response_id != NULL)
+    if (status_code != NULL)
     {
         STRICT_EXPECTED_CALL(STRING_TOKENIZER_get_next_token(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG)).SetReturn(0);
-        STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)).SetReturn(response_id);
+        STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)).SetReturn(status_code);
+
+        if (response_id != NULL)
+        {
+            STRICT_EXPECTED_CALL(STRING_TOKENIZER_get_next_token(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG)).SetReturn(0);
+            STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG)).SetReturn(response_id);
+        }
+        else
+        {
+            STRICT_EXPECTED_CALL(STRING_TOKENIZER_get_next_token(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG)).SetReturn(1);
+        }
     }
     else
     {
@@ -6187,14 +6195,19 @@ static void test_invalid_mqtt_twin_topic_setup(const char* mqtt_topic, const cha
     IoTHubTransport_MQTT_Common_Destroy(handle);
 }
 
+TEST_FUNCTION(IoTHubTransportMqtt_MessageRecv_device_twin_missing_status_code_fails)
+{
+    test_invalid_mqtt_twin_topic_setup(TEST_MQTT_DEV_TWIN_MSG_TOPIC_INVALID_REQUEST_ID, NULL, NULL);
+}
+
 TEST_FUNCTION(IoTHubTransportMqtt_MessageRecv_device_twin_invalid_request_id_fails)
 {
-    test_invalid_mqtt_twin_topic_setup(TEST_MQTT_DEV_TWIN_MSG_TOPIC_INVALID_REQUEST_ID, "?$NotSetRequestId=2");
+    test_invalid_mqtt_twin_topic_setup(TEST_MQTT_DEV_TWIN_MSG_TOPIC_INVALID_REQUEST_ID, "200", "?$NotSetRequestId=2");
 }
 
 TEST_FUNCTION(IoTHubTransportMqtt_MessageRecv_device_twin_missing_request_id_fails)
 {
-    test_invalid_mqtt_twin_topic_setup(TEST_MQTT_DEV_TWIN_MSG_TOPIC_INVALID_REQUEST_ID, NULL);
+    test_invalid_mqtt_twin_topic_setup(TEST_MQTT_DEV_TWIN_MSG_TOPIC_MISSING_REQUEST_ID, "200", NULL);
 }
 
 TEST_FUNCTION(IoTHubTransportMqtt_MessageRecv_device_twin_fail)


### PR DESCRIPTION
Based off of #1436 by @fgiancane8 - once again thanks Francesco for your help finding this & contributing back.

The initial #1436 was about catching some variables that were maybe uninitialized.  From follow-up, this was on a gcc on ESP32 since our gates should normally catch it.  Attempts to repro with various gcc versions and explicit `maybe-uninitialized` along with various optimization flags were unsuccessful on my part.

Refactor code a bit to hopefully make var setting more clear.  

That said, there's another problem here.  The initial line to parse for the requestId part of the token isn't right.
```c
STRING_TOKENIZER_get_next_token(token_handle, token_value, "/?$rid=")
```

The tokenizer is treating the "/?$rid=" as delimiters and not the full string.  As a quick experiment I put "/?$Qid=" as the argument and still got a 0 return value (success) on scanning for the passed string of "rid" and not "qid".  This isn't what we want.

So... as an additional change here, continue to tokenize just on the single "/" and then later check that the "/?$rid=" is received.  I moved the code into the "main" loop (the new `token_count==4` block) to maintain symmetry with existing code now that we're using "/" like rest of it.

This will cause topics that previously "passed" to fail now.  Justification::
* We're on a callback thread so this change won't impact the API caller.  
* Since the requestID would've been busted most of the time the caller would've ended up not matching it to anything in its table anyway.  
* Review of both the [Azure IoT MQTT twin spec](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-mqtt-support#retrieving-a-device-twins-properties) and the Azure Embedded SDK where [?rid is explicitly checked](https://github.com/Azure/azure-sdk-for-c/blob/3bff336816e7e03ac5add09c6911683d981ac6ae/sdk/src/azure/iot/az_iot_hub_client_twin.c#L163) make me comfortable making the lack of this value a failure (where it wasn't previously).

Furthermore cleanup UT to actually return the more realistic "/rid=" during test data and some tests to simulate this situation.