### PR TITLE
rollback provisioning CMake changes

### DIFF
--- a/provisioning_client/CMakeLists.txt
+++ b/provisioning_client/CMakeLists.txt
@@ -21,15 +21,24 @@ set(AUTH_CLIENT_H_FILES
     ${CMAKE_CURRENT_LIST_DIR}/inc/azure_prov_client/iothub_security_factory.h
     )
 
+set(AUTH_CLIENT_C_FILES
+    ${CMAKE_CURRENT_LIST_DIR}/src/prov_auth_client.c
+    ${CMAKE_CURRENT_LIST_DIR}/src/prov_security_factory.c
+    ${CMAKE_CURRENT_LIST_DIR}/src/iothub_auth_client.c
+    ${CMAKE_CURRENT_LIST_DIR}/src/iothub_security_factory.c)
+
 set(HSM_CLIENT_LIBRARY)
 
 set(HSM_CLIENT_H_FILES
-    ${CMAKE_CURRENT_LIST_DIR}/adapters/hsm_client_data.h
-)
+    ${CMAKE_CURRENT_LIST_DIR}/adapters/hsm_client_data.h)
+set(HSM_CLIENT_C_FILES
+    ${CMAKE_CURRENT_LIST_DIR}/adapters/hsm_client_data.c)
 
 if (${hsm_type_custom})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHSM_AUTH_TYPE_CUSTOM")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHSM_AUTH_TYPE_CUSTOM")
+
+    set(HSM_CLIENT_LIBRARY ${CUSTOM_HSM_LIB})
 elseif (${use_prov_client})
     if (${run_e2e_tests})
         # For e2e test we need to run a custom HSM to handle testing
@@ -46,7 +55,6 @@ elseif (${use_prov_client})
             set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHSM_TYPE_SYMM_KEY")
         endif()
 
-        # TODO: Remove once utpm CMake is updated
         include_directories(${TPM_C_INC_FOLDER})
 
         # Include the riot directories
@@ -56,6 +64,11 @@ elseif (${use_prov_client})
 
         # For e2e test a custom HSM is needed
         add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/tests/common_prov_e2e/prov_hsm)
+
+        set(HSM_CLIENT_LIBRARY ${HSM_CLIENT_LIBRARY} msr_riot utpm prov_hsm)
+        if (WIN32)
+            set(HSM_CLIENT_LIBRARY ${HSM_CLIENT_LIBRARY} Tbs)
+        endif ()
     else ()
         if (${hsm_type_x509})
             # Using x509
@@ -64,11 +77,15 @@ elseif (${use_prov_client})
 
             set(HSM_CLIENT_H_FILES ${HSM_CLIENT_H_FILES}
                 ${CMAKE_CURRENT_LIST_DIR}/adapters/hsm_client_riot.h)
+            set(HSM_CLIENT_C_FILES ${HSM_CLIENT_C_FILES}
+                ${CMAKE_CURRENT_LIST_DIR}/adapters/hsm_client_riot.c)
 
             # Include the riot directories
             include_directories(${CMAKE_CURRENT_LIST_DIR}/deps/RIoT/Simulation/DICE)
             include_directories(${CMAKE_CURRENT_LIST_DIR}/deps/RIoT/Simulation/RIoT/Core)
             include_directories(${CMAKE_CURRENT_LIST_DIR}/deps/RIoT/Simulation/RIoT/Core/RIoTCrypt/include)
+
+            set(HSM_CLIENT_LIBRARY ${HSM_CLIENT_LIBRARY} msr_riot)
         endif()
 
         if (${hsm_type_sastoken})
@@ -78,14 +95,20 @@ elseif (${use_prov_client})
 
             set(HSM_CLIENT_H_FILES ${HSM_CLIENT_H_FILES}
                 ${CMAKE_CURRENT_LIST_DIR}/adapters/hsm_client_tpm.h)
+            set(HSM_CLIENT_C_FILES ${HSM_CLIENT_C_FILES}
+                ${CMAKE_CURRENT_LIST_DIR}/adapters/hsm_client_tpm.c)
 
             if (${use_tpm_simulator})
                 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_EMULATOR_MODULE")
                 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_EMULATOR_MODULE")
             endif()
 
-            # TODO: Remove once utpm CMake is updated
             include_directories(${TPM_C_INC_FOLDER})
+
+            set(HSM_CLIENT_LIBRARY ${HSM_CLIENT_LIBRARY} utpm)
+            if (WIN32)
+                set(HSM_CLIENT_LIBRARY ${HSM_CLIENT_LIBRARY} Tbs)
+            endif ()
         endif ()
 
         if (${hsm_type_symm_key})
@@ -94,6 +117,8 @@ elseif (${use_prov_client})
 
             set(HSM_CLIENT_H_FILES ${HSM_CLIENT_H_FILES} 
                 ${CMAKE_CURRENT_LIST_DIR}/adapters/hsm_client_key.h)
+            set(HSM_CLIENT_C_FILES ${HSM_CLIENT_C_FILES} 
+                ${CMAKE_CURRENT_LIST_DIR}/adapters/hsm_client_key.c)
         endif()
     endif ()
 endif ()
@@ -104,14 +129,24 @@ if (${hsm_type_edge_module})
 
     set(HSM_CLIENT_H_FILES ${HSM_CLIENT_H_FILES}
         ${CMAKE_CURRENT_LIST_DIR}/adapters/hsm_client_http_edge.h)
+    set(HSM_CLIENT_C_FILES ${HSM_CLIENT_C_FILES}
+        ${CMAKE_CURRENT_LIST_DIR}/adapters/hsm_client_http_edge.c)
+
+    set(HSM_CLIENT_LIBRARY ${HSM_CLIENT_LIBRARY} uhttp)
 endif()
+
+
+function(link_security_client whatExeIsBuilding)
+    target_link_libraries(${whatExeIsBuilding} prov_auth_client)
+    target_link_libraries(${whatExeIsBuilding} hsm_security_client)
+endfunction()
 
 if(${use_openssl})
     add_definitions(-DUSE_OPENSSL)
 endif()
 
 set(PROV_DEVICE_CLIENT_SOURCE_C_FILES
-)
+    ${CMAKE_CURRENT_LIST_DIR}/src/prov_device_client.c)
 
 set(PROV_DEVICE_CLIENT_SOURCE_H_FILES
     ${CMAKE_CURRENT_LIST_DIR}/inc/azure_prov_client/prov_client_const.h
@@ -126,6 +161,15 @@ set(PROV_DEVICE_LL_CLEINT_SOURCE_H_FILES
 
 set(DEV_AUTH_MODULES_CLIENT_INC_FOLDER "${CMAKE_CURRENT_LIST_DIR}/inc" "${CMAKE_CURRENT_LIST_DIR}/inc/internal" CACHE INTERNAL "this is what needs to be included if using iothub_client lib" FORCE)
 
+include_directories(${DEV_AUTH_MODULES_CLIENT_INC_FOLDER})
+include_directories(${SHARED_UTIL_INC_FOLDER})
+if (NOT ${use_installed_dependencies})
+  include_directories(${CMAKE_CURRENT_LIST_DIR}/../deps/parson)
+endif()
+include_directories(${UHTTP_C_INC_FOLDER})
+include_directories(${IOTHUB_CLIENT_INC_FOLDER})
+include_directories(${CMAKE_CURRENT_LIST_DIR}/adapters)
+
 if(${memory_trace})
     add_definitions(-DGB_MEASURE_MEMORY_FOR_THIS -DGB_DEBUG_ALLOC)
 endif()
@@ -135,122 +179,47 @@ if(WIN32)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 ENDIF(WIN32)
 
-# Create the HSM security client
-add_library(hsm_security_client
-    ${CMAKE_CURRENT_LIST_DIR}/adapters/hsm_client_data.c
-    $<$<BOOL:${hsm_type_edge_module}>:${CMAKE_CURRENT_LIST_DIR}/adapters/hsm_client_http_edge.c>
-    $<$<BOOL:${hsm_type_symm_key}>:${CMAKE_CURRENT_LIST_DIR}/adapters/hsm_client_key.c>
-    $<$<BOOL:${hsm_type_sastoken}>:${CMAKE_CURRENT_LIST_DIR}/adapters/hsm_client_tpm.c>
-    $<$<BOOL:${hsm_type_x509}>:${CMAKE_CURRENT_LIST_DIR}/adapters/hsm_client_riot.c>
-)
-
-target_include_directories(hsm_security_client
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/adapters>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/azureiot/include>
-)
-
+add_library(hsm_security_client ${HSM_CLIENT_C_FILES} ${HSM_CLIENT_H_FILES})
 setSdkTargetBuildProperties(hsm_security_client)
-
-# TODO: Remove once uhttp target has the includes
-include_directories(${UHTTP_C_INC_FOLDER})
-
-target_link_libraries(hsm_security_client
-    PUBLIC
-        parson::parson
-        aziotsharedutil
-        $<$<BOOL:${hsm_type_custom}>:${CUSTOM_HSM_LIB}>
-        $<$<BOOL:${hsm_type_edge_module}>:uhttp>
-        $<$<BOOL:${hsm_type_sastoken}>:utpm>
-        $<$<BOOL:${hsm_type_x509}>:msr_riot>
-        $<$<AND:$<BOOL:${run_e2e_tests}>,$<BOOL:${use_prov_client}>>:msr_riot>
-        $<$<AND:$<BOOL:${run_e2e_tests}>,$<BOOL:${use_prov_client}>>:utpm>
-        $<$<AND:$<BOOL:${run_e2e_tests}>,$<BOOL:${use_prov_client}>>:prov_hsm>
-        $<$<BOOL:${WIN32}>:Tbs>
-)
-
+linkSharedUtil(hsm_security_client)
+target_link_libraries(hsm_security_client ${HSM_CLIENT_LIBRARY})
 set(provisioning_libs ${provisioning_libs} hsm_security_client)
 set(provisioning_headers ${provisioning_headers} ${HSM_CLIENT_H_FILES})
 
-# Create the provisioning auth client
-add_library(prov_auth_client
-    ${CMAKE_CURRENT_LIST_DIR}/src/prov_auth_client.c
-    ${CMAKE_CURRENT_LIST_DIR}/src/prov_security_factory.c
-    ${CMAKE_CURRENT_LIST_DIR}/src/iothub_auth_client.c
-    ${CMAKE_CURRENT_LIST_DIR}/src/iothub_security_factory.c
-)
-target_include_directories(prov_auth_client
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/azureiot/include>
-)
-target_link_libraries(prov_auth_client
-    PUBLIC
-        aziotsharedutil
-        hsm_security_client
-)
+add_library(prov_auth_client ${AUTH_CLIENT_C_FILES} ${AUTH_CLIENT_H_FILES})
 setSdkTargetBuildProperties(prov_auth_client)
+linkSharedUtil(prov_auth_client)
+target_link_libraries(prov_auth_client hsm_security_client)
 set(provisioning_libs ${provisioning_libs} prov_auth_client)
 set(provisioning_headers ${provisioning_headers} ${AUTH_CLIENT_H_FILES})
 
 if(${use_prov_client} OR (${use_prov_client_core} AND ${run_e2e_tests}))
-    # Provisioning LL client
-    add_library(prov_device_ll_client
-        ${CMAKE_CURRENT_LIST_DIR}/src/prov_device_ll_client.c
-    )
-    target_include_directories(prov_device_ll_client
-        PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/azureiot/include>
-    )
+    add_library(prov_device_ll_client ${PROV_DEVICE_LL_CLIENT_SOURCE_C_FILES} ${PROV_DEVICE_LL_CLEINT_SOURCE_H_FILES})
     setSdkTargetBuildProperties(prov_device_ll_client)
+    linkSharedUtil(prov_device_ll_client)
+    link_security_client(prov_device_ll_client)
     set(provisioning_libs ${provisioning_libs} prov_device_ll_client)
     set(provisioning_headers ${provisioning_headers} ${PROV_DEVICE_LL_CLEINT_SOURCE_H_FILES})
+    target_link_libraries(prov_device_ll_client parson::parson)
 
-    target_link_libraries(prov_device_ll_client
-        PUBLIC
-            aziotsharedutil
-            prov_auth_client
-            hsm_security_client
-            parson::parson
-    )
-
-    # Convenience provisioning client
-    add_library(prov_device_client 
-        ${CMAKE_CURRENT_LIST_DIR}/src/prov_device_client.c
-    )
-    target_include_directories(prov_device_client
-        PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/azureiot/include>
-    )
-
+    add_library(prov_device_client ${PROV_DEVICE_CLIENT_SOURCE_C_FILES} ${PROV_DEVICE_CLIENT_SOURCE_H_FILES})
     setSdkTargetBuildProperties(prov_device_client)
-    target_link_libraries(prov_device_client
-        PUBLIC
-            prov_device_ll_client
-            parson::parson
-    )
+    target_link_libraries(prov_device_client  prov_device_ll_client)
     set(provisioning_libs ${provisioning_libs} prov_device_client)
     set(provisioning_headers ${provisioning_headers} ${PROV_DEVICE_CLIENT_SOURCE_H_FILES})
+    target_link_libraries(prov_device_client parson::parson)
+
 
     if (${build_as_dynamic})
-        add_library(prov_device_client_dll
-            SHARED
-                ${CMAKE_CURRENT_LIST_DIR}/src/prov_device_client.c
-                ${CMAKE_CURRENT_LIST_DIR}/src/prov_device_client_dll.def
+        add_library(prov_device_client_dll SHARED
+            ${PROV_DEVICE_CLIENT_SOURCE_C_FILES}
+            ${PROV_DEVICE_CLEINT_SOURCE_H_FILES}
+            ${PROV_DEVICE_LL_CLIENT_SOURCE_C_FILES}
+            ${PROV_DEVICE_LL_CLEINT_SOURCE_H_FILES}
+            ${CMAKE_CURRENT_LIST_DIR}/src/prov_device_client_dll.def
         )
-        target_include_directories(prov_device_client_dll
-            PUBLIC
-                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
-                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/azureiot/include>
-        )
-
-        target_link_libraries(prov_device_client_dll
-            prov_device_ll_client
-            aziotsharedutil
-            parson::parson
-        )
+        linkSharedUtil(prov_device_client_dll)
+        target_link_libraries(prov_device_client_dll prov_device_ll_client parson::parson)
 
         if(NOT WIN32)
             set_target_properties(prov_device_client_dll PROPERTIES OUTPUT_NAME "prov_device_client")
@@ -283,20 +252,11 @@ if(${use_prov_client} OR (${use_prov_client_core} AND ${run_e2e_tests}))
         # Provisioning http Transport Client library
         add_library(prov_http_transport ${PROV_HTTP_CLIENT_C_FILES} ${PROV_HTTP_CLIENT_H_FILES})
         setSdkTargetBuildProperties(prov_http_transport)
-        target_include_directories(prov_http_transport
-            PUBLIC
-                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
-                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/azureiot/include>
-        )
+        linkSharedUtil(prov_http_transport)
         set(provisioning_libs ${provisioning_libs} prov_http_transport)
         set(provisioning_headers ${provisioning_headers} ${PROV_HTTP_CLIENT_H_FILES})
 
-        target_link_libraries(prov_http_transport
-            PUBLIC
-                uhttp
-                aziotsharedutil
-                parson::parson
-        )
+        target_link_libraries(prov_http_transport uhttp)
     endif()
 
     if (${use_amqp})
@@ -308,6 +268,10 @@ if(${use_prov_client} OR (${use_prov_client_core} AND ${run_e2e_tests}))
             ${CMAKE_CURRENT_LIST_DIR}/inc/azure_prov_client/internal/prov_transport_amqp_common.h
             ${CMAKE_CURRENT_LIST_DIR}/inc/azure_prov_client/internal/prov_transport_private.h
             ${CMAKE_CURRENT_LIST_DIR}/inc/azure_prov_client/internal/prov_sasl_tpm.h)
+        set(PROV_AMQP_CLIENT_C_FILES
+            ${CMAKE_CURRENT_LIST_DIR}/src/prov_transport_amqp_client.c
+            ${CMAKE_CURRENT_LIST_DIR}/src/prov_transport_amqp_common.c
+            ${CMAKE_CURRENT_LIST_DIR}/src/prov_sasl_tpm.c)
 
         set(PROV_AMQP_WS_CLIENT_H_FILES
             ${CMAKE_CURRENT_LIST_DIR}/inc/azure_prov_client/prov_transport.h
@@ -315,44 +279,23 @@ if(${use_prov_client} OR (${use_prov_client_core} AND ${run_e2e_tests}))
             ${CMAKE_CURRENT_LIST_DIR}/inc/azure_prov_client/internal/prov_transport_amqp_common.h
             ${CMAKE_CURRENT_LIST_DIR}/inc/azure_prov_client/internal/prov_transport_private.h
             ${CMAKE_CURRENT_LIST_DIR}/inc/azure_prov_client/internal/prov_sasl_tpm.h)
-
-        # Provisioning AMQP Websocket transport
-        add_library(prov_amqp_ws_transport
+        set(PROV_AMQP_WS_CLIENT_C_FILES
             ${CMAKE_CURRENT_LIST_DIR}/src/prov_transport_amqp_ws_client.c
             ${CMAKE_CURRENT_LIST_DIR}/src/prov_transport_amqp_common.c
-            ${CMAKE_CURRENT_LIST_DIR}/src/prov_sasl_tpm.c
-        )
+            ${CMAKE_CURRENT_LIST_DIR}/src/prov_sasl_tpm.c)
+
+        add_library(prov_amqp_ws_transport ${PROV_AMQP_WS_CLIENT_C_FILES} ${PROV_AMQP_WS_CLIENT_H_FILES})
         setSdkTargetBuildProperties(prov_amqp_ws_transport)
-        target_link_libraries(prov_amqp_ws_transport
-            PUBLIC
-                uamqp
-                aziotsharedutil
-        )
-        target_include_directories(prov_amqp_ws_transport
-            PUBLIC
-                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
-                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/azureiot/include>
-        )
+        linkSharedUtil(prov_amqp_ws_transport)
+        target_link_libraries(prov_amqp_ws_transport uamqp)
         set(provisioning_libs ${provisioning_libs} prov_amqp_ws_transport)
         set(provisioning_headers ${provisioning_headers} ${PROV_AMQP_WS_CLIENT_H_FILES})
 
-        # Provisioning AMQP transport library
-        add_library(prov_amqp_transport
-            ${CMAKE_CURRENT_LIST_DIR}/src/prov_transport_amqp_client.c
-            ${CMAKE_CURRENT_LIST_DIR}/src/prov_transport_amqp_common.c
-            ${CMAKE_CURRENT_LIST_DIR}/src/prov_sasl_tpm.c
-        )
+        # Provisioning amqp Transport Client library
+        add_library(prov_amqp_transport ${PROV_AMQP_CLIENT_C_FILES} ${PROV_AMQP_CLIENT_H_FILES})
         setSdkTargetBuildProperties(prov_amqp_transport)
-        target_link_libraries(prov_amqp_transport
-            PUBLIC
-                uamqp
-                aziotsharedutil
-        )
-        target_include_directories(prov_amqp_transport
-            PUBLIC
-                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
-                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/azureiot/include>
-        )
+        linkSharedUtil(prov_amqp_transport)
+        target_link_libraries(prov_amqp_transport uamqp)
         set(provisioning_libs ${provisioning_libs} prov_amqp_transport)
         set(provisioning_headers ${provisioning_headers} ${PROV_AMQP_CLIENT_H_FILES})
     endif()
@@ -365,48 +308,31 @@ if(${use_prov_client} OR (${use_prov_client_core} AND ${run_e2e_tests}))
             ${CMAKE_CURRENT_LIST_DIR}/inc/azure_prov_client/prov_transport_mqtt_client.h
             ${CMAKE_CURRENT_LIST_DIR}/inc/azure_prov_client/internal/prov_transport_private.h
             ${CMAKE_CURRENT_LIST_DIR}/inc/azure_prov_client/internal/prov_transport_mqtt_common.h)
+        set(PROV_MQTT_CLIENT_C_FILES
+            ${CMAKE_CURRENT_LIST_DIR}/src/prov_transport_mqtt_client.c
+            ${CMAKE_CURRENT_LIST_DIR}/src/prov_transport_mqtt_common.c)
 
         set(PROV_MQTT_WS_CLIENT_H_FILES
             ${CMAKE_CURRENT_LIST_DIR}/inc/azure_prov_client/prov_transport.h
             ${CMAKE_CURRENT_LIST_DIR}/inc/azure_prov_client/prov_transport_mqtt_ws_client.h
             ${CMAKE_CURRENT_LIST_DIR}/inc/azure_prov_client/internal/prov_transport_private.h
             ${CMAKE_CURRENT_LIST_DIR}/inc/azure_prov_client/internal/prov_transport_mqtt_common.h)
-
-        # Provisioning MQTT Websocket transport library
-        add_library(prov_mqtt_ws_transport
+        set(PROV_MQTT_WS_CLIENT_C_FILES
             ${CMAKE_CURRENT_LIST_DIR}/src/prov_transport_mqtt_ws_client.c
-            ${CMAKE_CURRENT_LIST_DIR}/src/prov_transport_mqtt_common.c
-        )
+            ${CMAKE_CURRENT_LIST_DIR}/src/prov_transport_mqtt_common.c)
+
+        add_library(prov_mqtt_ws_transport ${PROV_MQTT_WS_CLIENT_C_FILES} ${PROV_MQTT_WS_CLIENT_H_FILES})
         setSdkTargetBuildProperties(prov_mqtt_ws_transport)
-        target_link_libraries(prov_mqtt_ws_transport
-            PUBLIC
-                umqtt
-                aziotsharedutil
-        )
-        target_include_directories(prov_mqtt_ws_transport
-            PUBLIC
-                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
-                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/azureiot/include>
-        )
+        linkSharedUtil(prov_mqtt_ws_transport)
+        target_link_libraries(prov_mqtt_ws_transport umqtt)
         set(provisioning_libs ${provisioning_libs} prov_mqtt_ws_transport)
         set(provisioning_headers ${provisioning_headers} ${PROV_MQTT_WS_CLIENT_H_FILES})
 
-        # Provisioning MQTT transport library
-        add_library(prov_mqtt_transport 
-            ${CMAKE_CURRENT_LIST_DIR}/src/prov_transport_mqtt_client.c
-            ${CMAKE_CURRENT_LIST_DIR}/src/prov_transport_mqtt_common.c
-        )
+        # Provisioning mqtt Transport Client library
+        add_library(prov_mqtt_transport ${PROV_MQTT_CLIENT_C_FILES} ${PROV_MQTT_CLIENT_H_FILES})
         setSdkTargetBuildProperties(prov_mqtt_transport)
-        target_link_libraries(prov_mqtt_transport
-            PUBLIC
-                umqtt
-                aziotsharedutil
-        )
-        target_include_directories(prov_mqtt_transport
-            PUBLIC
-                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
-                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/azureiot/include>
-        )
+        linkSharedUtil(prov_mqtt_transport)
+        target_link_libraries(prov_mqtt_transport umqtt)
         set(provisioning_libs ${provisioning_libs} prov_mqtt_transport)
         set(provisioning_headers ${provisioning_headers} ${PROV_MQTT_CLIENT_H_FILES})
     endif()


### PR DESCRIPTION
Rolling back the structural changes from #2152 here until I can figure out why RIOT is intermittently producing an invalid cert.