### PR TITLE
typos | readme sanitation | remove en-us from links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 # Need Support?
 * Have a feature request for SDKs? Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize.
 * Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag "azure-iot-hub".
-* Need Support? Every customer with an active Azure subscription has access to [support](https://docs.microsoft.com/en-us/azure/azure-supportability/how-to-create-azure-support-request) with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
+* Need Support? Every customer with an active Azure subscription has access to [support](https://docs.microsoft.com/azure/azure-supportability/how-to-create-azure-support-request) with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
 * Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on GitHub ([C](https://github.com/Azure/azure-iot-sdk-c), [Java](https://github.com/Azure/azure-iot-sdk-java), [.NET](https://github.com/Azure/azure-iot-sdk-csharp), [Node.js](https://github.com/Azure/azure-iot-sdk-node), [Python](https://github.com/Azure/azure-iot-sdk-python)).
 
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -21,7 +21,7 @@ https://github.com/Azure/azure-iot-sdk-c/releases/latest
 
 3. Do not share information from your Azure subscription here (connection strings, service names (IoT Hub name, Device Provisioning Service scope ID), etc...). If you need to share any of this information, you can create a ticket and get assistance from the Microsoft Support.
 
-How to Submit an Azure Support Ticket: https://docs.microsoft.com/en-us/azure/azure-supportability/how-to-create-azure-support-request
+How to Submit an Azure Support Ticket: https://docs.microsoft.com/azure/azure-supportability/how-to-create-azure-support-request
 
 
 4. Include enough information for us to address the bug:

--- a/.github/ISSUE_TEMPLATE/technical-question.md
+++ b/.github/ISSUE_TEMPLATE/technical-question.md
@@ -15,7 +15,7 @@ For quick and reliable answers on your technical product questions from Microsof
 
 For answers on your developer questions from the largest community developer ecosystem, ask your question on Stack Overflow. We actively monitor all questions tagged wtih "azure-iot-sdk".
 
-Additionally, if your technical question requires submitting service logs, you can submit an [Azure Support Ticket](https://docs.microsoft.com/en-us/azure/azure-supportability/how-to-create-azure-support-request).
+Additionally, if your technical question requires submitting service logs, you can submit an [Azure Support Ticket](https://docs.microsoft.com/azure/azure-supportability/how-to-create-azure-support-request).
 
 If you have a question specifically on a Microsoft page you've read, please open an issue on the document itself. This ensures you get the fastest targeted response, and you can do this by scrolling to the bottom of the page to the **Feedback** section. 
 

--- a/SECURITY.MD
+++ b/SECURITY.MD
@@ -4,7 +4,7 @@
 
 Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
 
-If you believe you have found a security vulnerability in any Microsoft-owned repository that meets Microsoft's [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)) of a security vulnerability, please report it to us as described below.
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets Microsoft's [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/previous-versions/tn-archive/cc751383(v=technet.10)) of a security vulnerability, please report it to us as described below.
 
 ## Reporting Security Issues
 
@@ -12,7 +12,7 @@ If you believe you have found a security vulnerability in any Microsoft-owned re
 
 Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
 
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/msrc/pgp-key-msrc).
 
 You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc). 
 
@@ -36,6 +36,6 @@ We prefer all communications to be in English.
 
 ## Policy
 
-Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://www.microsoft.com/en-us/msrc/cvd).
+Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://www.microsoft.com/msrc/cvd).
 
 <!-- END MICROSOFT SECURITY.MD BLOCK -->

--- a/build_all/docs/Doxyfile
+++ b/build_all/docs/Doxyfile
@@ -1281,7 +1281,7 @@ DOCSET_PUBLISHER_NAME  = Publisher
 # If the GENERATE_HTMLHELP tag is set to YES then doxygen generates three
 # additional HTML index files: index.hhp, index.hhc, and index.hhk. The
 # index.hhp is a project file that can be read by Microsoft's HTML Help Workshop
-# (see: http://www.microsoft.com/en-us/download/details.aspx?id=21138) on
+# (see: http://www.microsoft.com/download/details.aspx?id=21138) on
 # Windows.
 #
 # The HTML Help Workshop contains a compiler that can convert all HTML output

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1282,7 +1282,7 @@ DOCSET_PUBLISHER_NAME  = Publisher
 # If the GENERATE_HTMLHELP tag is set to YES then doxygen generates three
 # additional HTML index files: index.hhp, index.hhc, and index.hhk. The
 # index.hhp is a project file that can be read by Microsoft's HTML Help Workshop
-# (see: http://www.microsoft.com/en-us/download/details.aspx?id=21138) on
+# (see: http://www.microsoft.com/download/details.aspx?id=21138) on
 # Windows.
 #
 # The HTML Help Workshop contains a compiler that can convert all HTML output

--- a/doc/configure_tls_protocol_version_and_ciphers.md
+++ b/doc/configure_tls_protocol_version_and_ciphers.md
@@ -8,11 +8,11 @@ To use exclusively TLS 1.2 in Microsoft Windows using SChannel, disable the supp
 
 Be aware that this action might impact other applications in the systems that might not support higher versions of TLS.
 
-To disable support in SChannel for TLS 1.0, follow this [documentation](https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-and-disable-tls-10).
+To disable support in SChannel for TLS 1.0, follow this [documentation](https://docs.microsoft.com/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-and-disable-tls-10).
 
-To disable support in SChannel for TLS 1.1, follow this [documentation](https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-and-disable-tls-11).
+To disable support in SChannel for TLS 1.1, follow this [documentation](https://docs.microsoft.com/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enable-and-disable-tls-11).
 
-For more information on TLS configuration please see the [following documentation](https://docs.microsoft.com/en-us/dotnet/framework/network-programming/tls). 
+For more information on TLS configuration please see the [following documentation](https://docs.microsoft.com/dotnet/framework/network-programming/tls). 
 
 
 ### OpenSSL
@@ -60,7 +60,7 @@ Currently the Azure IoT C SDK does not directly set the minimum version of TLS t
 
 ### SChannel (Microsoft Windows)
 
-To configure additional ciphers for SChannel please follow this [documentation](https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enabling-or-disabling-additional-cipher-suites).
+To configure additional ciphers for SChannel please follow this [documentation](https://docs.microsoft.com/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs#enabling-or-disabling-additional-cipher-suites).
 
 
 ### OpenSSL

--- a/doc/connection_and_messaging_reliability.md
+++ b/doc/connection_and_messaging_reliability.md
@@ -26,19 +26,19 @@ This is a brief note to clarify how authentication is done in the IoTHub Device/
 
 Authentication of a client in the SDK can be done using either
 
-- [SAS tokens](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-security#security-tokens), or 
+- [SAS tokens](https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-security#security-tokens), or 
 
-- [x509 certificates](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-security#supported-x509-certificates), or
+- [x509 certificates](https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-security#supported-x509-certificates), or
 
-- [Device Provisioning Service](https://docs.microsoft.com/en-us/azure/iot-dps/).
+- [Device Provisioning Service](https://docs.microsoft.com/azure/iot-dps/).
 
 This section does not describe the details of Device Provisioning Service (DPS), please use the link above for details.
 
 When using SAS tokens, authentication can be done by:
 
-- Providing [your own SAS token](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-security#authentication), or
+- Providing [your own SAS token](https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-security#authentication), or
 
-- Giving the device keys to the SDK (using the device connection string - see ["Alternate Device Credentials"](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-device-sdk-c-iothubclient#alternate-device-credentials) in our documentation) and letting it create the SAS tokens for you (this is the most usual authentication method).
+- Giving the device keys to the SDK (using the device connection string - see ["Alternate Device Credentials"](https://docs.microsoft.com/azure/iot-hub/iot-hub-device-sdk-c-iothubclient#alternate-device-credentials) in our documentation) and letting it create the SAS tokens for you (this is the most usual authentication method).
 
 As mentioned in the articles above, SAS tokens have an expiration time.
 
@@ -105,7 +105,7 @@ Each of these layers provide status and error events to the above through functi
 
   - Telemetry messages to complete sending;
 
-  - [CBS authentication token](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-security#security-tokens) refresh to be completed.
+  - [CBS authentication token](https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-security#security-tokens) refresh to be completed.
 
 1. Through failures reported by the socket APIs;
 

--- a/doc/devbox_setup.md
+++ b/doc/devbox_setup.md
@@ -376,10 +376,10 @@ make
 [azure-shared-c-utility]:https://github.com/Azure/azure-c-shared-utility
 [azure-uamqp-c]:https://github.com/Azure/azure-uamqp-c
 [azure-umqtt-c]:https://github.com/Azure/azure-umqtt-c
-[sln-file]:https://msdn.microsoft.com/en-us/library/bb165951.aspx
+[sln-file]:https://msdn.microsoft.com/library/bb165951.aspx
 [git]:http://www.git-scm.com
 [CMake]:https://cmake.org/
-[MSBuild]:https://msdn.microsoft.com/en-us/library/0k6kkbsd.aspx
+[MSBuild]:https://msdn.microsoft.com/library/0k6kkbsd.aspx
 [Compilation and Installation]:https://wiki.openssl.org/index.php/Compilation_and_Installation#Windows
 [Ubuntu]:http://www.ubuntu.com/desktop
 [gcc]:https://gcc.gnu.org/
@@ -390,6 +390,6 @@ make
 [clang]:https://clang.llvm.org/
 [device_samples]: ../iothub_client/samples/
 [latest-release]:https://github.com/Azure/azure-iot-sdk-c/releases/latest
-[Windows 10 IoT Core]:https://docs.microsoft.com/en-us/windows/iot-core/develop-your-app/buildingappsforiotcore
+[Windows 10 IoT Core]:https://docs.microsoft.com/windows/iot-core/develop-your-app/buildingappsforiotcore
 [vcpkg]:https://github.com/Microsoft/vcpkg
 [windows-and-openssl]:./windows_and_openssl.md

--- a/iothub_client/readme.md
+++ b/iothub_client/readme.md
@@ -100,7 +100,7 @@ In addition to the simple samples found in the current repository, you can find 
 
 
 [iot-dev-center]: http://azure.com/iotdev
-[iot-hub-documentation]: https://docs.microsoft.com/en-us/azure/iot-hub/
+[iot-hub-documentation]: https://docs.microsoft.com/azure/iot-hub/
 [device-catalog]: https://catalog.azureiotsuite.com
 [devbox-setup]: ../doc/devbox_setup.md
 [setup-iothub]: https://aka.ms/howtocreateazureiothub

--- a/iothub_client/samples/iotedge_downstream_device_sample/iotedge_downstream_device_sample.c
+++ b/iothub_client/samples/iotedge_downstream_device_sample/iotedge_downstream_device_sample.c
@@ -3,8 +3,8 @@
 
 // This sample demonstrates how a downstream device connects to an Edge device. For more details
 // pertaining to this scenario please see:
-// https://docs.microsoft.com/en-us/azure/iot-edge/how-to-create-transparent-gateway-linux OR
-// https://docs.microsoft.com/en-us/azure/iot-edge/how-to-create-transparent-gateway-windows
+// https://docs.microsoft.com/azure/iot-edge/how-to-create-transparent-gateway-linux OR
+// https://docs.microsoft.com/azure/iot-edge/how-to-create-transparent-gateway-windows
 //
 // CAVEAT: This sample is to demonstrate azure IoT client concepts only and is not a guide design principles or style
 // Checking of return codes and error values shall be omitted for brevity. Please practice sound engineering practices

--- a/iothub_client/samples/iothub_client_sample_mqtt_dm/pi_device/readme.md
+++ b/iothub_client/samples/iothub_client_sample_mqtt_dm/pi_device/readme.md
@@ -5,8 +5,8 @@
 The following instructions explain how to do a firmware update on a Raspberry Pi 3 running Raspbian using Azure IoT Hub.
 The sample is a simple C application that will run on a Raspberry Pi, establish connection with Azure IoT Hub and wait for a "firmware update" call from Azure IoT Hub.
 Before jumping in, it is recommended to read through the following documentation in order to understand the way device management is done using Azure IoT Hub:
--   [Overview of Azure IoT Hub Device Management](https://azure.microsoft.com/en-us/documentation/articles/iot-hub-device-management-overview/)
--   [Device Management tutorials](https://azure.microsoft.com/en-us/documentation/articles/iot-hub-device-management-get-started/)
+-   [Overview of Azure IoT Hub Device Management](https://azure.microsoft.com/documentation/articles/iot-hub-device-management-overview/)
+-   [Device Management tutorials](https://azure.microsoft.com/documentation/articles/iot-hub-device-management-get-started/)
 
 ## Prerequisites
 You should have the following items ready before beginning the process:
@@ -15,7 +15,7 @@ You should have the following items ready before beginning the process:
 -   If running MacOS or Linux, you are set.
 -   If running Windows 10:
     -   64-bit version of Windows 10 Anniversary update build 14393 or later
-    -   Follow the instructions [here](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) to install the Windows Subsystem for Linux. 
+    -   Follow the instructions [here](https://msdn.microsoft.com/commandline/wsl/install_guide) to install the Windows Subsystem for Linux. 
 -   If running previous versions of Windows:
 	-   [CygWin for Windows](https://www.cygwin.com/install.html), in order to run the few UNIX commands the following tutorial uses.
 -   Required hardware:
@@ -30,13 +30,13 @@ You should have the following items ready before beginning the process:
 
 ## Setup your IoT Hub and provision a device
 In order to run this sample, you will need to have a Device Management enabled IoT Hub instance.
-Follow the [getting started with device management instructions](https://azure.microsoft.com/en-us/documentation/articles/iot-hub-device-management-get-started#create-a-device-management-enabled-iot-hub) to create the IoT Hub and a device identity.
+Follow the [getting started with device management instructions](https://azure.microsoft.com/documentation/articles/iot-hub-device-management-get-started#create-a-device-management-enabled-iot-hub) to create the IoT Hub and a device identity.
 Make a copy of the device's connection string.
 
 ## The device application sample
 In order to simplify the experience with the Raspberry Pi, we have created a simple application that acts as an agent.
 The application needs to be installed on the current running image on the Raspberry Pi.
-Once installed and started, the application establishes connection with Azure IoT Hub, reports on the current firmware version using the [Device Twins](https://azure.microsoft.com/en-us/documentation/articles/iot-hub-node-node-twin-getstarted/) feature (you can learn more on how to [use device twins to configure devices here](https://azure.microsoft.com/en-us/documentation/articles/iot-hub-node-node-twin-how-to-configure/)), and awaits for a "Firmware Update" command from the Cloud (through the [Device Method](https://azure.microsoft.com/en-us/documentation/articles/iot-hub-c2d-methods/) feature).
+Once installed and started, the application establishes connection with Azure IoT Hub, reports on the current firmware version using the [Device Twins](https://azure.microsoft.com/documentation/articles/iot-hub-node-node-twin-getstarted/) feature (you can learn more on how to [use device twins to configure devices here](https://azure.microsoft.com/documentation/articles/iot-hub-node-node-twin-how-to-configure/)), and awaits for a "Firmware Update" command from the Cloud (through the [Device Method](https://azure.microsoft.com/documentation/articles/iot-hub-c2d-methods/) feature).
 The instructions below show how to trigger the firmware update after preparing a new firmware image.
 Once triggered, the application will download the new firmware image package, install it then reboot the device.
 The new firmware image contains the application already, which is setup to run as a service at boottime, reporting on the new firmware image version through Device Twins.
@@ -105,7 +105,7 @@ Assuming you have an older version of Raspbian running on your Raspberry Pi, fol
 	sudo systemctl start iothub_client_sample_firmware_update
 	```
 
--   When running, the application will update the reported state of its Device Twin to Azure IoT Hub. You can verify that youre device is correctly connected by checking the reported properties of the device. You can learn more [here](https://azure.microsoft.com/en-us/documentation/articles/iot-hub-node-node-twin-getstarted/) on how to work with Device Twins.
+-   When running, the application will update the reported state of its Device Twin to Azure IoT Hub. You can verify that youre device is correctly connected by checking the reported properties of the device. You can learn more [here](https://azure.microsoft.com/documentation/articles/iot-hub-node-node-twin-getstarted/) on how to work with Device Twins.
 
 ### Save the application and its settings for next step
 For preparing the new firmware image, we will need to get a copy of the sample application as deployed and configured in the "old" firmware.

--- a/iothub_client/tests/iothubclient_uploadtoblob_e2e/iothubclient_uploadtoblob_e2e.c
+++ b/iothub_client/tests/iothubclient_uploadtoblob_e2e/iothubclient_uploadtoblob_e2e.c
@@ -223,7 +223,7 @@ static void sleep_between_upload_blob_e2e_tests(void)
 {
     // We need a Sleep() between each E2E test.  Current (as of October, 2020) throttling
     // rules limit an S1 hub to 1.67 upload initiations per second for the entire IoT Hub (not just per device).
-    // https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-quotas-throttling
+    // https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-quotas-throttling
     //
     // On gate runs, we have many instances of this test executable running at the same time and we cannot orchestrate
     // them.  Most individual testcases take <1 second to run.  Without a sleep, this amount of traffic

--- a/jenkins/raspberrypi/run_this_to_setup_a_pi_for_e2e_tests.sh
+++ b/jenkins/raspberrypi/run_this_to_setup_a_pi_for_e2e_tests.sh
@@ -34,7 +34,7 @@ sudo apt-get install -y vim git build-essential pkg-config git cmake libssl-dev 
 
 ###################################################################################################
 # DOWNLOAD AND INSTALL LINUX AGENT
-# FOR WALKTHROUGH: https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/v2-linux?view=azure-devops
+# FOR WALKTHROUGH: https://docs.microsoft.com/azure/devops/pipelines/agents/v2-linux?view=azure-devops
 # NOTE: You need a Azure DevOps PAT Token. Described in the link above. 
 ###################################################################################################
 cd ~

--- a/jenkins/raspberrypi/setup_pi_for_e2e_tests.sh
+++ b/jenkins/raspberrypi/setup_pi_for_e2e_tests.sh
@@ -35,7 +35,7 @@ sudo apt-get install -y vim git build-essential pkg-config git cmake libssl-dev 
 
 ###################################################################################################
 # DOWNLOAD AND INSTALL LINUX AGENT
-# FOR WALKTHROUGH: https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/v2-linux?view=azure-devops
+# FOR WALKTHROUGH: https://docs.microsoft.com/azure/devops/pipelines/agents/v2-linux?view=azure-devops
 # NOTE: You need a Azure DevOps PAT Token. Described in the link above. 
 ###################################################################################################
 cd ~

--- a/provisioning_client/devdoc/azure_provisioning_faq.md
+++ b/provisioning_client/devdoc/azure_provisioning_faq.md
@@ -1,6 +1,6 @@
 # Azure IoT Provisioning Client FAQ
 
-Here is where we answer question pertaining to the IoT Provisioning Client.  Please read the following documents for an overview of the [Device Provisioning Service](https://docs.microsoft.com/en-us/azure/iot-dps/)
+Here is where we answer question pertaining to the IoT Provisioning Client.  Please read the following documents for an overview of the [Device Provisioning Service](https://docs.microsoft.com/azure/iot-dps/)
 
 ## x509 Provisioning
 
@@ -18,7 +18,7 @@ Here is where we answer question pertaining to the IoT Provisioning Client.  Ple
 
     For more information on switching between development and production scenarios, refer to [using provisioning client](https://github.com/Azure/azure-iot-sdk-c/blob/master/provisioning_client/devdoc/using_provisioning_client.md)
     
-    For more reading on certificates information, please see [security concept document](https://docs.microsoft.com/en-us/azure/iot-dps/concepts-security#x509-certificates)
+    For more reading on certificates information, please see [security concept document](https://docs.microsoft.com/azure/iot-dps/concepts-security#x509-certificates)
 
 - What if I want the certificate private key to never leave the hardware?
 
@@ -38,13 +38,13 @@ Here is where we answer question pertaining to the IoT Provisioning Client.  Ple
 
 - Coming soon
 
-For more reading on Symmetric key information please see [Symmetric key concept doc](https://docs.microsoft.com/en-us/azure/iot-dps/concepts-symmetric-key-attestation)
+For more reading on Symmetric key information please see [Symmetric key concept doc](https://docs.microsoft.com/azure/iot-dps/concepts-symmetric-key-attestation)
 
 ## TPM Provisioning
 
 - Coming soon
 
-For more reading on TPM information please see [TPM Attestation doc](https://docs.microsoft.com/en-us/azure/iot-dps/concepts-tpm-attestation)
+For more reading on TPM information please see [TPM Attestation doc](https://docs.microsoft.com/azure/iot-dps/concepts-tpm-attestation)
 
 ## Related documents
 

--- a/provisioning_client/samples/readme.md
+++ b/provisioning_client/samples/readme.md
@@ -20,4 +20,4 @@
 
 ### Running Samples
 
-You don't need any special hardware to test the samples.  After you create your [Device Provisioning hub](https://docs.microsoft.com/en-us/azure/iot-dps/quick-setup-auto-provision), you can just follow the [provisioning SDK documentation](https://github.com/Azure/azure-iot-sdk-c/blob/master/provisioning_client/devdoc/using_provisioning_client.md).
+You don't need any special hardware to test the samples.  After you create your [Device Provisioning hub](https://docs.microsoft.com/azure/iot-dps/quick-setup-auto-provision), you can just follow the [provisioning SDK documentation](https://github.com/Azure/azure-iot-sdk-c/blob/master/provisioning_client/devdoc/using_provisioning_client.md).

--- a/provisioning_service_client/samples/prov_sc_bulk_operation_sample/readme.md
+++ b/provisioning_service_client/samples/prov_sc_bulk_operation_sample/readme.md
@@ -36,6 +36,6 @@ This is a quick tutorial with the steps to create and delete Individual Enrollme
 [root-link]: https://github.com/Azure/azure-iot-sdk-c
 [source-code-link]: ../../src
 [tpm-simulator-link]: https://github.com/Azure/azure-iot-sdk-java/tree/master/provisioning/provisioning-tools/tpm-simulator
-[dice-link]: https://azure.microsoft.com/en-us/blog/azure-iot-supports-new-security-hardware-to-strengthen-iot-security/
+[dice-link]: https://azure.microsoft.com/blog/azure-iot-supports-new-security-hardware-to-strengthen-iot-security/
 [devbox-setup-link]: ../../../doc/devbox_setup.md
 [ca-cert-link]: ../../../tools/CACertificates

--- a/provisioning_service_client/samples/prov_sc_enrollment_group_sample/readme.md
+++ b/provisioning_service_client/samples/prov_sc_enrollment_group_sample/readme.md
@@ -54,7 +54,7 @@ This is a quick tutorial with the steps to create, update, get, and delete an En
 
 [root-link]: https://github.com/Azure/azure-iot-sdk-c
 [source-code-link]: ../../src
-[dice-link]: https://azure.microsoft.com/en-us/blog/azure-iot-supports-new-security-hardware-to-strengthen-iot-security/
+[dice-link]: https://azure.microsoft.com/blog/azure-iot-supports-new-security-hardware-to-strengthen-iot-security/
 [devbox-setup-link]: ../../../doc/devbox-setup.md
 [ca-cert-link]: ../../../tools/CACertificates
-[ca-cert-portal-link]: https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-security-x509-get-started
+[ca-cert-portal-link]: https://docs.microsoft.com/azure/iot-hub/iot-hub-security-x509-get-started

--- a/provisioning_service_client/samples/prov_sc_individual_enrollment_sample/readme.md
+++ b/provisioning_service_client/samples/prov_sc_individual_enrollment_sample/readme.md
@@ -64,6 +64,6 @@ This is a quick tutorial with the steps to create, update, get, and delete an In
 [root-link]: https://github.com/Azure/azure-iot-sdk-c
 [source-code-link]: ../../src
 [tpm-simulator-link]: https://github.com/Azure/azure-iot-sdk-java/tree/master/provisioning/provisioning-tools/tpm-simulator
-[dice-link]: https://azure.microsoft.com/en-us/blog/azure-iot-supports-new-security-hardware-to-strengthen-iot-security/
+[dice-link]: https://azure.microsoft.com/blog/azure-iot-supports-new-security-hardware-to-strengthen-iot-security/
 [devbox-setup-link]: ../../../doc/devbox_setup.md
 [ca-cert-link]: ../../../tools/CACertificates

--- a/provisioning_service_client/samples/readme.md
+++ b/provisioning_service_client/samples/readme.md
@@ -22,5 +22,5 @@ In order to run the samples, you will first need to do the following:
 * [Query](prov_sc_query_sample) - Run a query operation on the Provisioning Service
 
 [setup-iot-hub]: https://aka.ms/howtocreateazureiothub
-[setup-provisioning-service]: https://docs.microsoft.com/en-us/azure/iot-dps/quick-setup-auto-provision
+[setup-provisioning-service]: https://docs.microsoft.com/azure/iot-dps/quick-setup-auto-provision
 [devbox-setup]: ../../doc/devbox_setup.md

--- a/readme.md
+++ b/readme.md
@@ -3,10 +3,10 @@
 [![Build Status](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_apis/build/status/c/integrate-into-repo-C)](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/latest?definitionId=85)
 
 
-The Azure IOT Hub Device SDK allows applications written in C99 or later or C++ to communicate easily with [Azure IoT Hub](https://azure.microsoft.com/en-us/services/iot-hub/), [Azure IoT Central][Azure-IoT-Central] and to
+The Azure IOT Hub Device SDK allows applications written in C99 or later or C++ to communicate easily with [Azure IoT Hub](https://azure.microsoft.com/services/iot-hub/), [Azure IoT Central][Azure-IoT-Central] and to
  [Azure IoT Device Provisioning][Azure-IoT-Device-Provisioning].  This repo includes the source code for the libraries, setup instructions, and samples demonstrating use scenarios.
 
-For constained devices - where memory is measured in kilobytes and not megabytes - there are even lighter weight SDK options available.  See [Other Azure IoT SDKs](#other-azure-iot-sdks) for more.
+For constrained devices - where memory is measured in kilobytes and not megabytes - there are even lighter weight SDK options available.  See [Other Azure IoT SDKs](#other-azure-iot-sdks) for more.
 
 ## Table of Contents
 - [Azure IoT C SDKs and Libraries](#azure-iot-c-sdks-and-libraries)
@@ -26,9 +26,10 @@ For constained devices - where memory is measured in kilobytes and not megabytes
   - [Support](#support)
   - [Read More](#read-more)
   - [SDK Folder Structure](#sdk-folder-structure)
+    - [Deprecated Folders](#deprecated-folders)
 - [Releases](#releases)
   - [New Features and Critical Bug Fixes](#new-features-and-critical-bug-fixes)
-  - [Long Term Support (LTS)](#long-term-support)
+  - [Long Term Support (LTS)](#long-term-support-lts)
     - [LTS Schedule](#lts-schedule)
   - [Release Example](#release-example)
 
@@ -49,15 +50,20 @@ For a more in depth explanation as to why the IoT services are doing this, pleas
 [this article](https://techcommunity.microsoft.com/t5/internet-of-things/azure-iot-tls-critical-changes-are-almost-here-and-why-you/ba-p/2393169).
 
 ## Getting the SDK
-  The simplest way to get started with the Azure IoT SDKs on supported platforms is to use the following packages and libraries:
-  * mbed:                                      [Device SDK library on MBED](./iothub_client/readme.md#mbed)
-  * Arduino:                                   [Device SDK library in the Arduino IDE](./iothub_client/readme.md#arduino)
-  * Windows:                                   [Device SDK on Vcpkg](./doc/setting_up_vcpkg.md#setup-c-sdk-vcpkg-for-windows-development-environment)
-  * iOS:                                       [Device SDK on CocoaPod](https://cocoapods.org/pods/AzureIoTHubClient)
+
+Please note, for constrained device scenarios like the below mbed and Arduino, there are better, lighter weight SDK options available.  See [Other Azure IoT SDKs](#other-azure-iot-sdks) for more.
+
+The simplest way to get started with the Azure IoT SDKs on supported platforms is to use the following packages and libraries:
+
+- mbed:                                      [Device SDK library on MBED](./iothub_client/readme.md#mbed)
+- Arduino:                                   [Device SDK library in the Arduino IDE](./iothub_client/readme.md#arduino)
+- Windows:                                   [Device SDK on Vcpkg](./doc/setting_up_vcpkg.md#setup-c-sdk-vcpkg-for-windows-development-environment)
+- iOS:                                       [Device SDK on CocoaPod](https://cocoapods.org/pods/AzureIoTHubClient)
 
 For other platforms - including Linux - you need to clone and build the SDK directly.  You may also build it directly for the platforms above.  Instructions can be found [here](./iothub_client/readme.md#compile).
 
 ## Samples
+
 There are many samples available for the SDK.  More information can be found [here](./samples/readme.md).
 
 ## SDK API Reference Documentation
@@ -68,7 +74,9 @@ The API reference documentation for the C SDKs can be found [here][c-api-referen
 
 To find Azure IoT SDKs in other languages, please refer to the [guidance here][about-iot-sdks].
 
-**Note on constrained devices**: The `Embedded C SDK` is an alternative for constrained devices which enables the BYO (bring your own) network approach: IoT developers have the freedom of choice to bring an MQTT client, TLS and Socket of their choice to create a device solution. Find more information about the Embedded C SDK [here](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/iot).
+- [Azure IoT SDK for Embedded C](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/iot) is an alternative for **constrained devices** which enables the BYO (bring your own) network approach: IoT developers have the freedom of choice to bring MQTT client, TLS and Socket of their choice to create a device solution.
+- [Azure IoT middleware for Azure RTOS](https://github.com/azure-rtos/netxduo/tree/master/addons/azure_iot) builds on top of the embedded SDK and tightly couples with the Azure RTOS family of networking and OS products. This gives you very performant and small applications for real-time, constrained devices.
+- [Azure IoT middleware for FreeRTOS](https://github.com/Azure/azure-iot-middleware-freertos) builds on top of the embedded SDK and takes care of the MQTT stack while integrating with FreeRTOS. This maintains the focus on constrained devices and gives users a distilled Azure IoT feature set while allowing for flexibility with their networking stack.
 
 ## Developing Azure IoT Applications
 
@@ -103,10 +111,10 @@ This SDK also contains options you can set and platform specific features.  You 
 
 
 ### Provisioning Client SDK
+
 This repository contains [provisioning client SDK](./provisioning_client) for the [Device Provisioning Service](https://docs.microsoft.com/azure/iot-dps/).
 
 :heavy_check_mark: feature available  :heavy_multiplication_x: feature planned but not supported  :heavy_minus_sign: no support planned
-
 
 | Features                    | mqtt               | mqtt-ws            | amqp               | amqp-ws            | https              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 |-----------------------------|--------------------|--------------------|--------------------|--------------------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -120,7 +128,7 @@ The IoT Hub device SDK for C can be used with a broad range of OS platforms and 
 
 The minimum requirements are for the device platform to support the following:
 
-- **Support Azure IoT TLS over TCP/IP Requirements**: https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-tls-support
+- **Support Azure IoT TLS over TCP/IP Requirements**: https://docs.microsoft.com/azure/iot-hub/iot-hub-tls-support
 - **Support SHA-256** (optional): necessary to generate the secure token for authenticating the device with the service. Different authentication methods are available and not all require SHA-256.
 - **Have a Real Time Clock or implement code to connect to an NTP server**: necessary for both establishing the TLS connection and generating the secure token for authentication.
 - **Having at least 64KB of RAM**: the memory footprint of the SDK depends on the SDK and protocol used as well as the platform targeted. The smallest footprint is achieved targeting microcontrollers.
@@ -131,8 +139,9 @@ You can find an exhaustive list of the OS platforms the various SDKs have been t
 ## Porting the Azure IoT Device Client SDK for C to New Devices
 
 The C SDKs and Libraries:
-* Are written in ANSI C (C99) and avoids compiler extensions to maximize code portability and broad platform compatibility.
-* Expose a platform abstraction layer to isolate OS dependencies (threading and mutual exclusion mechanisms, communications protocol e.g. HTTP). Refer to our [porting guide][c-porting-guide] for more information about our abstraction layer.
+
+- Are written in ANSI C (C99) and avoids compiler extensions to maximize code portability and broad platform compatibility.
+- Expose a platform abstraction layer to isolate OS dependencies (threading and mutual exclusion mechanisms, communications protocol e.g. HTTP). Refer to our [porting guide][c-porting-guide] for more information about our abstraction layer.
 
 In the repository you will find instructions and build tools to compile and run the device client SDK for C on Linux, Windows and microcontroller platforms (refer to the links above for more information on compiling the device client for C).
 
@@ -143,19 +152,20 @@ If you are considering porting the device client SDK for C to a new platform, ch
 If you encounter any bugs, have suggestions for new features or if you would like to become an active contributor to this project please follow the instructions provided in the [contribution guidelines](.github/CONTRIBUTING.md).
 
 ## Support
-* Have a feature request for SDKs? Please post it on [Azure Community Feedback](https://feedback.azure.com/d365community/forum/fcb810f7-f824-ec11-b6e6-000d3a4f0da0) to help us prioritize.
-* Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag "azure-iot-hub".
-* Need Support? Every customer with an active Azure subscription has access to [support](https://docs.microsoft.com/en-us/azure/azure-supportability/how-to-create-azure-support-request) with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
-* Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on [our GitHub issues][c-github-issues].
+
+- Have a feature request for SDKs? Please post it on [Azure Community Feedback](https://feedback.azure.com/d365community/forum/fcb810f7-f824-ec11-b6e6-000d3a4f0da0) to help us prioritize.
+- Have a technical question? Ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-iot-hub) with tag "azure-iot-hub".
+- Need Support? Every customer with an active Azure subscription has access to [support](https://docs.microsoft.com/azure/azure-supportability/how-to-create-azure-support-request) with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
+- Found a bug? Please help us fix it by thoroughly documenting it and filing an issue on [our GitHub issues][c-github-issues].
 
 ## Read More
 
-* [Azure IoT Hub documentation][iot-hub-documentation]
-* [Prepare your development environment to use the Azure IoT device SDK for C][devbox-setup]
-* [Setup IoT Hub][setup-iothub]
-* [Azure IoT device SDK for C tutorial][c-sdk-intro]
-* [How to port the C libraries to other OS platforms](https://github.com/Azure/azure-c-shared-utility/blob/master/devdoc/porting_guide.md)
-* [Cross compilation example][c-cross-compile]
+- [Azure IoT Hub documentation][iot-hub-documentation]
+- [Prepare your development environment to use the Azure IoT device SDK for C][devbox-setup]
+- [Setup IoT Hub][setup-iothub]
+- [Azure IoT device SDK for C tutorial][c-sdk-intro]
+- [How to port the C libraries to other OS platforms](https://github.com/Azure/azure-c-shared-utility/blob/master/devdoc/porting_guide.md)
+- [Cross compilation example][c-cross-compile]
 
 ## SDK Folder Structure
 
@@ -269,8 +279,8 @@ Microsoft collects performance and usage information which may be used to provid
 [c-porting-guide]: https://github.com/Azure/azure-c-shared-utility/blob/master/devdoc/porting_guide.md
 [c-cross-compile]: doc/SDK_cross_compile_example.md
 [c-api-reference]: https://docs.microsoft.com/azure/iot-hub/iot-c-sdk-ref/
-[about-iot-sdks]:https://docs.microsoft.com/en-us/azure/iot-develop/about-iot-sdks
-[Azure-IoT-Central]: https://docs.microsoft.com/en-us/azure/iot-central/
+[about-iot-sdks]:https://docs.microsoft.com/azure/iot-develop/about-iot-sdks
+[Azure-IoT-Central]: https://docs.microsoft.com/azure/iot-central/
 [Azure-IoT-Device-Provisioning]: https://docs.microsoft.com/azure/iot-dps/
-[iot-plug-and-play]: https://docs.microsoft.com/en-us/azure/iot-pnp/overview-iot-plug-and-play
+[iot-plug-and-play]: https://docs.microsoft.com/azure/iot-pnp/overview-iot-plug-and-play
 [c-github-issues]: https://github.com/Azure/azure-iot-sdk-c/issues

--- a/tools/CACertificates/CACertificateOverview.md
+++ b/tools/CACertificates/CACertificateOverview.md
@@ -18,7 +18,7 @@ A more detailed document explaining Edge and showing its use of certificates gen
 
 ## Note about Edge Devices
 
-To generate device certificates for the device running Edge itself, use the [Edge device using X.509 certificates](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-auto-provision-x509-certs) guide.  
+To generate device certificates for the device running Edge itself, use the [Edge device using X.509 certificates](https://docs.microsoft.com/azure/iot-edge/how-to-auto-provision-x509-certs) guide.  
 
 To generate device certificates for leaf devices that are connecting via an Edge gateway, see the instructions below.
 
@@ -130,5 +130,5 @@ From start menu, open `manage computer certificates` and navigate Certificates -
 
 Bash outputs certificates to the current working directory, so there is no analogous system cleanup needed.
 
-[the official documentation]: https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-security-x509-get-started
-[Edge gateway creation documentation]: https://docs.microsoft.com/en-us/azure/iot-edge/how-to-create-gateway-device
+[the official documentation]: https://docs.microsoft.com/azure/iot-hub/iot-hub-security-x509-get-started
+[Edge gateway creation documentation]: https://docs.microsoft.com/azure/iot-edge/how-to-create-gateway-device


### PR DESCRIPTION
- `/en-us` removes the ability for microsoft to redirect to other languages
- added the middlewares to the top level readme
- sanitized the top level readme a bit
- typo fix