### PR TITLE
Better explain master=>main rename in readme and more details in document

### DIFF
--- a/doc/master_to_main_rename.md
+++ b/doc/master_to_main_rename.md
@@ -2,6 +2,13 @@
 
 The Azure IoT C SDK initially used a branch named `master` as its primary branch.  This was renamed to `main` on December 1, 2021.
 
+## Implications to tools and scripts referencing this repo
+When a web request to an older link to this repo that contains `master` in it - for instance [https://github.com/Azure/azure-iot-sdk-c/blob/master/doc/master_to_main_rename.md](https://github.com/Azure/azure-iot-sdk-c/blob/master/doc/master_to_main_rename.md - GitHub will automatically redirect this to `main`.
+
+GitHub will **not** redirect tools, scripts, command line requests, etc. that reference the `master` branch, however.  These will instead fail accessing the deleted branch.  You will need to change these to reference this repo's `main` branch.
+
+## Implications to local clones of this repo
+
 **If you cloned this repo after December 1, 2021, you can ignore the rest of this document.**
   * Git clones after the default rename will use `main` and do the right thing.
 

--- a/doc/master_to_main_rename.md
+++ b/doc/master_to_main_rename.md
@@ -3,9 +3,9 @@
 The Azure IoT C SDK initially used a branch named `master` as its primary branch.  This was renamed to `main` on December 1, 2021.
 
 ## Implications to tools and scripts referencing this repo
-When a web request to an older link to this repo that contains `master` in it - for instance [https://github.com/Azure/azure-iot-sdk-c/blob/master/doc/master_to_main_rename.md](https://github.com/Azure/azure-iot-sdk-c/blob/master/doc/master_to_main_rename.md - GitHub will automatically redirect this to `main`.
+When a web request to an older link to this repo that contains `master` in it - for instance [https://github.com/Azure/azure-iot-sdk-c/blob/**master**/doc/master_to_main_rename.md](https://github.com/Azure/azure-iot-sdk-c/blob/master/doc/master_to_main_rename.md) - GitHub will automatically redirect this to `main`.
 
-GitHub will **not** redirect tools, scripts, command line requests, etc. that reference the `master` branch, however.  These will instead fail accessing the deleted branch.  You will need to change these to reference this repo's `main` branch.
+GitHub will **not** redirect tools, scripts, command line requests, etc. that explicitly reference the `master` branch, however.  These will instead fail accessing the deleted branch.  You will need to change these to reference this repo's `main` branch.
 
 ## Implications to local clones of this repo
 

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,11 @@
 # Azure IoT C SDKs and Libraries
 
-## Important branch rename information
-As of [December 1, 2021](#de09b35289313665f0d359835c661f8cb2a0fdf1), we have changed the default branch of this repo from `master` to `main`.  This may impact both your local clones of this repro made before this change as well as tools you have referencing `master`.  See [here](./doc/master_to_main_rename.md) for more information.
-
 [![Build Status](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_apis/build/status/c/integrate-into-repo-C)](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/latest?definitionId=85)
 
+## Important branch rename information
+As of [December 1, 2021](https://github.com/Azure/azure-iot-sdk-c/commit/de09b35289313665f0d359835c661f8cb2a0fdf1), we have changed the default branch of this repo from `master` to `main`.  This may impact both your local clones of this repro made before this change as well as tools you have referencing `master`.  See [here](./doc/master_to_main_rename.md) for more information.
 
+## Introduction
 The Azure IOT Hub Device SDK allows applications written in C99 or later or C++ to communicate easily with [Azure IoT Hub](https://azure.microsoft.com/services/iot-hub/), [Azure IoT Central][Azure-IoT-Central] and to
  [Azure IoT Device Provisioning][Azure-IoT-Device-Provisioning].  This repo includes the source code for the libraries, setup instructions, and samples demonstrating use scenarios.
 

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,8 @@
 # Azure IoT C SDKs and Libraries
 
+## Important branch rename information
+As of [December 1, 2021](#de09b35289313665f0d359835c661f8cb2a0fdf1), we have changed the default branch of this repo from `master` to `main`.  This may impact both your local clones of this repro made before this change as well as tools you have referencing `master`.  See [here](./doc/master_to_main_rename.md) for more information.
+
 [![Build Status](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_apis/build/status/c/integrate-into-repo-C)](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/latest?definitionId=85)
 
 


### PR DESCRIPTION
We won't leave the top of main readme.md around forever - will create a GitHub issue to be IOU to remove in a month or so.