### PR TITLE
Update Node version on gate from 10=>16

### DIFF
--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -17,7 +17,7 @@ jobs:
       python-software-properties \
       build-essential \
       pkg-config
-      sudo curl -sL https://deb.nodesource.com/setup_10.x | bash -
+      sudo curl -sL https://deb.nodesource.com/setup_16.x | bash -
       sudo apt-get install -y nodejs
     displayName: 'Setup'
   - script: |


### PR DESCRIPTION
C SDK gate is running an older version of Node.  Bring it up to appropriate supported version.