### PR TITLE
Bugfix: "extern C" was put in wrong place

### DIFF
--- a/provisioning_client/inc/azure_prov_client/prov_transport.h
+++ b/provisioning_client/inc/azure_prov_client/prov_transport.h
@@ -11,9 +11,9 @@
 #include "azure_prov_client/prov_client_const.h"
 
 #ifdef __cplusplus
-extern "C" {
 #include <cstdint>
 #include <cstdlib>
+extern "C" {
 #else
 #include <stdbool.h>
 #include <stdint.h>


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `main` branch. 
  - [ ] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
Compilation failed on the old one GCC compiler (used version was: 5.2.0)
I've got error like:
[code]
/usr/include/c++/5.2.0/cstdlib: In function 'long long int std::abs(long long int)':
/usr/include/c++/5.2.0/cstdlib:174:20: error: conflicting declaration of C function 'long long int std::abs(long long int)'
   abs(long long __x) { return __builtin_llabs (__x); }
                    ^
/usr/include/c++/5.2.0/cstdlib:166:3: note: previous declaration 'long int std::abs(long int)'
   abs(long __i) { return __builtin_labs(__i); }
   ^
[/code]

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
