### PR TITLE
Add instruction to sign certs with intermediate CA

### DIFF
--- a/iothub_client/samples/iothub_ll_client_x509_sample/readme.md
+++ b/iothub_client/samples/iothub_ll_client_x509_sample/readme.md
@@ -2,9 +2,9 @@
 
 ## Build instructions
 
-1. Modify `.\iothub_ll_client_x509_sample.c`: update `connectionString`, `x509certificate` and 
-`x509privatekey`.
-   (Optionally, you can change configuration regarding transport, global endpoint, etc.)
+1. Modify `.\iothub_ll_client_x509_sample.c`: update the `connectionString`, `x509certificate` and 
+`x509privatekey` variables.
+   (Optionally, you can change configuration regarding transport, etc.)
 
 1. If you are using an OpenSSL engine, uncomment the `#define SAMPLE_OPENSSL_ENGINE` and set it to the
    OpenSSL Engine name. Instead of a PEM certificate, `x509privatekey` will contain the private key ID
@@ -32,21 +32,21 @@ cd build
 
 ### TLS Options
 
-Additional TLS stack specific configuration is available through `IoTHubDeviceClient_LL_SetOption`.
+Additional TLS stack specific configuration is available through `IoTHubDeviceClient_LL_SetOption`. Some of the available options can be found [here](https://github.com/Azure/azure-iot-sdk-c/blob/main/doc/Iothub_sdk_options.md#common-transport-options).
 
 ### Long X509 Client Certificate Chains
 
 When using chains with more than one level, the device must send all chain certificates up to but 
-not including the CA configured on the service. The certificates will be sent part of the TLS 
+not including the CA configured on the service. The certificates will be sent as part of the TLS 
 handshake in order for the service to build a valid chain. 
 
 For TLS stacks such as OpenSSL and mbedTLS, this is achieved by creating a PEM certificate store 
 (i.e. concatenating the Intermediates as well as the Device Certificate PEM contents) and passing 
-it to the C-SDK via `x509certificate`.
+it to the C-SDK via the `x509certificate` variable.
 
-In Windows, all intermediates must be present in the Intermediate Certificate Store and 
-`x509certificate` should contain only the device certificate. SChannel will automatically build the 
-chain and send the required certificates to the service.
+In Windows, all intermediates must be present in the Intermediate Certificate Store and the 
+`x509certificate` variable should contain only the device certificate. SChannel will automatically 
+build the chain and send the required certificates to the service.
 
 __Note:__ Using a multi-level chain increases the overhead of each TLS connection. All intermediate 
 certificates unknown to the service must be sent on every new connection. Both the client and 

--- a/iothub_client/samples/iothub_ll_client_x509_sample/readme.md
+++ b/iothub_client/samples/iothub_ll_client_x509_sample/readme.md
@@ -1,9 +1,9 @@
-# Azure IoT Provisioning Client Sample: Using X509 Client Certificates
+# Azure IoT Hub Client Sample: Using X509 Client Certificates
 
 ## Build instructions
 
-1. Modify `.\prov_dev_client_ll_x509_sample.c`: update `id_scope`, `registration_id`, 
-   `x509certificate` and `x509privatekey`.
+1. Modify `.\iothub_ll_client_x509_sample.c`: update `connectionString`, `x509certificate` and 
+`x509privatekey`.
    (Optionally, you can change configuration regarding transport, global endpoint, etc.)
 
 1. If you are using an OpenSSL engine, uncomment the `#define SAMPLE_OPENSSL_ENGINE` and set it to the
@@ -11,12 +11,12 @@
    as expected by the OpenSSL engine. (e.g. in case of engine `pkcs11`, `x509privatekey` will contain
    a PKCS#11 URI such as `pkcs11:object=test-privkey;type=private?pin-value=1234`.)
 
-1. Configure the IoT SDK (Hub and DPS clients) to use the custom X509 HSM.
+1. Configure and build the SDK and sample
 
     ```sh
     # At the root of the repository
     cd build
-    cmake -DCMAKE_BUILD_TYPE=Debug -Duse_prov_client=ON -Dhsm_type_x509=ON ..
+    cmake ..
     cmake --build . -j
     ```
 
@@ -25,21 +25,14 @@
 ```sh
 # At the root of the repository
 cd build
-./provisioning_client/samples/prov_dev_client_ll_x509_sample/prov_dev_client_ll_x509_sample
+./iothub_client/samples/iothub_ll_client_x509_sample/iothub_ll_client_x509_sample
 ```
 
 ## Configuring the TLS Stack
 
 ### TLS Options
 
-Additional TLS stack specific configuration is available through the following two APIs:
-
-* For DPS: `Prov_Device_LL_SetOption`
-* For Hub: `IoTHubDeviceClient_LL_SetOption`
-
-Both DPS and Hub clients should be configured with the same TLS stack parameters. (e.g. if configuring 
-OPTION_OPENSSL_ENGINE by calling `Prov_Device_LL_SetOption`, the application must also call 
-`IoTHubDeviceClient_LL_SetOption` using the same OPTION_OPENSSL_ENGINE key and the same engine name.)
+Additional TLS stack specific configuration is available through `IoTHubDeviceClient_LL_SetOption`.
 
 ### Long X509 Client Certificate Chains
 

--- a/provisioning_client/samples/prov_dev_client_ll_x509_sample/readme.md
+++ b/provisioning_client/samples/prov_dev_client_ll_x509_sample/readme.md
@@ -2,8 +2,8 @@
 
 ## Build instructions
 
-1. Modify `.\prov_dev_client_ll_x509_sample.c`: update `id_scope`, `registration_id`, 
-   `x509certificate` and `x509privatekey`.
+1. Modify `.\prov_dev_client_ll_x509_sample.c`: update the `id_scope`, `registration_id`, 
+   `x509certificate` and `x509privatekey` variables.
    (Optionally, you can change configuration regarding transport, global endpoint, etc.)
 
 1. If you are using an OpenSSL engine, uncomment the `#define SAMPLE_OPENSSL_ENGINE` and set it to the
@@ -37,6 +37,8 @@ Additional TLS stack specific configuration is available through the following t
 * For DPS: `Prov_Device_LL_SetOption`
 * For Hub: `IoTHubDeviceClient_LL_SetOption`
 
+Some of the available options can be found [here](https://github.com/Azure/azure-iot-sdk-c/blob/main/doc/Iothub_sdk_options.md#common-transport-options).
+
 Both DPS and Hub clients should be configured with the same TLS stack parameters. (e.g. if configuring 
 OPTION_OPENSSL_ENGINE by calling `Prov_Device_LL_SetOption`, the application must also call 
 `IoTHubDeviceClient_LL_SetOption` using the same OPTION_OPENSSL_ENGINE key and the same engine name.)
@@ -44,16 +46,16 @@ OPTION_OPENSSL_ENGINE by calling `Prov_Device_LL_SetOption`, the application mus
 ### Long X509 Client Certificate Chains
 
 When using chains with more than one level, the device must send all chain certificates up to but 
-not including the CA configured on the service. The certificates will be sent part of the TLS 
+not including the CA configured on the service. The certificates will be sent as part of the TLS 
 handshake in order for the service to build a valid chain. 
 
 For TLS stacks such as OpenSSL and mbedTLS, this is achieved by creating a PEM certificate store 
 (i.e. concatenating the Intermediates as well as the Device Certificate PEM contents) and passing 
-it to the C-SDK via `x509certificate`.
+it to the C-SDK via the `x509certificate` variable.
 
-In Windows, all intermediates must be present in the Intermediate Certificate Store and 
-`x509certificate` should contain only the device certificate. SChannel will automatically build the 
-chain and send the required certificates to the service.
+In Windows, all intermediates must be present in the Intermediate Certificate Store and the
+`x509certificate` variable should contain only the device certificate. SChannel will automatically 
+build the chain and send the required certificates to the service.
 
 __Note:__ Using a multi-level chain increases the overhead of each TLS connection. All intermediate 
 certificates unknown to the service must be sent on every new connection. Both the client and 

--- a/tools/CACertificates/CACertificateOverview.md
+++ b/tools/CACertificates/CACertificateOverview.md
@@ -109,8 +109,8 @@ This will create files mydevice* that contain the public key, private key, and P
 
 #### IoT Leaf Device
 
-* Run `./certGen.sh create_device_certificate mydevice` to create the new device certificate.  
-  This will create the files ./certs/new-device.* that contain the public key and PFX and ./private/new-device.key.pem that contains the device's private key.  
+* Run `./certGen.sh create_device_certificate mydevice` to create the new device certificate. If the device certificate needs to be signed by intermediate CA, run `./certGen.sh create_device_certificate_from_intermediate mydevice` instead to chain up the device certificate to the intermediate certificate.  
+  These commands will create the files ./certs/new-device.* that contain the public key and PFX and ./private/new-device.key.pem that contains the device's private key.  
 
 * `cd ./certs && cat new-device.cert.pem azure-iot-test-only.intermediate.cert.pem azure-iot-test-only.root.ca.cert.pem > new-device-full-chain.cert.pem` to get the public key.
 

--- a/tools/CACertificates/CACertificateOverview.md
+++ b/tools/CACertificates/CACertificateOverview.md
@@ -109,8 +109,8 @@ This will create files mydevice* that contain the public key, private key, and P
 
 #### IoT Leaf Device
 
-* Run `./certGen.sh create_device_certificate mydevice` to create the new device certificate. If the device certificate needs to be signed by intermediate CA, run `./certGen.sh create_device_certificate_from_intermediate mydevice` instead to chain up the device certificate to the intermediate certificate.  
-  These commands will create the files ./certs/new-device.* that contain the public key and PFX and ./private/new-device.key.pem that contains the device's private key.  
+* Run `./certGen.sh create_device_certificate mydevice` to create the new device certificate, which will chain directly to the root CA. 
+  * If the device certificate needs to be signed by an intermediate CA instead, run `./certGen.sh create_device_certificate_from_intermediate mydevice` to chain the device certificate to the intermediate certificate. __Note:__ When using chains with more than one level, the device must send all chain certificates up to but not including the one configured on the service during TLS handshake. This is required for the service to create a valid chain.
 
 * `cd ./certs && cat new-device.cert.pem azure-iot-test-only.intermediate.cert.pem azure-iot-test-only.root.ca.cert.pem > new-device-full-chain.cert.pem` to get the public key.
 


### PR DESCRIPTION
Default method "create_device_certificate" will create a device certificate which is chained up to the root certificate directly.
In group enrollment scenario of Device Provisioning Service, users may want the device certs to be chained up to the intermediate certificate. So "create_device_certificate_from_intermediate" should be noted.

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [N/A because only .md file will be changed] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `main` branch. 
  - [ ] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)
https://docs.microsoft.com/en-us/azure/iot-dps/tutorial-group-enrollments
This tutorial will not work with "create_device_certificate" command, because the device certs need to be signed by the intermediate CA.

# Description of the problem
"create_device_certificate_from_intermediate" should be noted because device certificates need to be signed by the intermediate CA in many scenarios.

# Description of the solution
Add notes about this command to the .md file.