### PR TITLE
Fix valgrind issues in E2E tests

### DIFF
--- a/iothub_client/tests/common_dt_e2e/iothubclient_common_dt_e2e.c
+++ b/iothub_client/tests/common_dt_e2e/iothubclient_common_dt_e2e.c
@@ -905,6 +905,11 @@ void dt_e2e_send_module_id_test(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol, IOTHU
 
     char *twinData = dt_e2e_get_twin_from_service(serviceClientDeviceTwinHandle, deviceToUse);
 
+    IoTHubDeviceTwin_Destroy(serviceClientDeviceTwinHandle);
+    IoTHubServiceClientAuth_Destroy(iotHubServiceClientHandle);
+    destroy_on_device_or_module();
+    device_desired_deinit(deviceDesiredData);
+
     JSON_Value *rootValue = json_parse_string(twinData);
     ASSERT_IS_NOT_NULL(rootValue);
     JSON_Object *rootObject = json_value_get_object(rootValue);
@@ -916,10 +921,6 @@ void dt_e2e_send_module_id_test(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol, IOTHU
     // cleanup
     json_value_free(rootValue);
     free(twinData);
-    IoTHubDeviceTwin_Destroy(serviceClientDeviceTwinHandle);
-    IoTHubServiceClientAuth_Destroy(iotHubServiceClientHandle);
-    destroy_on_device_or_module();
-    device_desired_deinit(deviceDesiredData);
 }
 
 

--- a/iothub_client/tests/common_e2e/iothubclient_common_e2e.c
+++ b/iothub_client/tests/common_e2e/iothubclient_common_e2e.c
@@ -607,7 +607,7 @@ static void client_connect_to_hub(IOTHUB_PROVISIONED_DEVICE* deviceToUse, IOTHUB
 
     if (test_protocol_type == TEST_AMQP || test_protocol_type == TEST_AMQP_WEBSOCKETS)
     {
-        unsigned int svc2cl_keep_alive_timeout_secs = 120; // service will send pings at 120 x 7/8 = 105 seconds. Higher the value, lesser the frequency of service side pings.
+        size_t svc2cl_keep_alive_timeout_secs = 120; // service will send pings at 120 x 7/8 = 105 seconds. Higher the value, lesser the frequency of service side pings.
         setoption_on_device_or_module(OPTION_SERVICE_SIDE_KEEP_ALIVE_FREQ_SECS, &svc2cl_keep_alive_timeout_secs, "Cannot set OPTION_SERVICE_SIDE_KEEP_ALIVE_FREQ_SECS");
 
         // Set keep alive for remote idle is optional. If it is not set the default ratio of 1/2 will be used. For default value of 4 minutes, it will be 2 minutes (120 seconds)

--- a/iothub_client/tests/common_longhaul/iothub_client_common_longhaul.c
+++ b/iothub_client/tests/common_longhaul/iothub_client_common_longhaul.c
@@ -1677,14 +1677,14 @@ static void check_for_reported_properties_update_on_service_side(IOTHUB_LONGHAUL
 {
     char* twin = NULL;
 
-    for (int i = 0; i < 3 && twin == NULL; i++)
+    for (int i = 0; i < NETWORK_RETRY_ATTEMPTS && twin == NULL; i++)
     {
         twin = IoTHubDeviceTwin_GetTwin(iotHubLonghaul->iotHubSvcDevTwinHandle, iotHubLonghaul->deviceInfo->deviceId);
         if (twin == NULL)
         {
             // this API can fail due to network issues (ex: DNS issues)
             // try a few times before reporting an error
-            ThreadAPI_Sleep(10 * 1000); // Sleep 10 seconds
+            ThreadAPI_Sleep(NETWORK_RETRY_DELAY_MSEC); 
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `main` branch. 
  - [ ] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 