### PR TITLE
PnP feature gate enablement

### DIFF
--- a/iothub_client/CMakeLists.txt
+++ b/iothub_client/CMakeLists.txt
@@ -250,7 +250,7 @@ endif()
 set(IOTHUB_CLIENT_INC_FOLDER ${CMAKE_CURRENT_LIST_DIR}/inc CACHE INTERNAL "this is what needs to be included if using iothub_client lib" FORCE)
 
 
-if(NOT ${dont_use_uploadtoblob} OR ${use_edge_modules} AND NOT ${use_installed_dependencies})
+if(NOT ${use_installed_dependencies})
     include_directories(${CMAKE_CURRENT_LIST_DIR}/../deps/parson)
 endif()
 

--- a/iothub_client/samples/pnp/pnp_simple_thermostat/pnp_simple_thermostat.c
+++ b/iothub_client/samples/pnp/pnp_simple_thermostat/pnp_simple_thermostat.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <time.h>
 #include <limits.h>
+#include <math.h>
 
 // JSON parser library.
 #include "parson.h"
@@ -416,7 +417,7 @@ static void Thermostat_ProcessTargetTemperature(IOTHUB_DEVICE_CLIENT_LL_HANDLE d
 {
     char* next;
     double targetTemperature = strtod(property->value.str, &next);
-    if ((property->value.str == next) || (targetTemperature == LONG_MAX) || (targetTemperature == LONG_MIN))
+    if ((property->value.str == next) || (targetTemperature == HUGE_VAL) || (targetTemperature == (-1*HUGE_VAL)))
     {
         LogError("Property %s is not a valid number", property->value.str);
         SendTargetTemperatureResponse(deviceClient, property->value.str, PNP_STATUS_BAD_FORMAT, propertiesVersion, g_temperaturePropertyResponseDescriptionNotInt);

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <time.h>
 #include <limits.h>
+#include <math.h>
 
 // PnP routines
 #include "pnp_thermostat_component.h"
@@ -355,7 +356,7 @@ void PnP_ThermostatComponent_ProcessPropertyUpdate(PNP_THERMOSTAT_COMPONENT_HAND
     {
         char* next;
         double targetTemperature = strtod(propertyValue, &next);
-        if ((propertyValue == next) || (targetTemperature == LONG_MAX) || (targetTemperature == LONG_MIN))
+        if ((propertyValue == next) || (targetTemperature == HUGE_VAL) || (targetTemperature == (-1*HUGE_VAL)))
         {
             LogError("Property %s is not a valid number", propertyValue);
             SendTargetTemperatureResponse(pnpThermostatComponent, deviceClient, propertyValue, PNP_STATUS_BAD_FORMAT, version, g_temperaturePropertyResponseDescriptionNotInt);

--- a/iothub_client/src/iothub_client_properties.c
+++ b/iothub_client/src/iothub_client_properties.c
@@ -79,7 +79,7 @@ static int PropertySnprintf(char* buffer, size_t count, const char* format, ...)
     va_start(arg_list, format);
 
     int currentOutputBytes = vsnprintf(buffer, count, format, arg_list);
-    if ((currentOutputBytes < 0) || (currentOutputBytes == count))
+    if ((currentOutputBytes < 0) || (currentOutputBytes == (int)count))
     {
         return -1;
     }

--- a/iothub_client/src/iothub_client_properties.c
+++ b/iothub_client/src/iothub_client_properties.c
@@ -142,6 +142,8 @@ static bool WriteReportedProperties(const IOTHUB_CLIENT_REPORTED_PROPERTY* prope
     char* currentWrite = (char*)serializedProperties;
     size_t remainingBytes = serializedPropertiesLength;
 
+    *requiredBytes = 0;
+
     if (WriteOpeningBrace(componentName,  &currentWrite, requiredBytes, &remainingBytes) != true)
     {
         LogError("Cannot write properties string");
@@ -179,6 +181,8 @@ static bool WriteWritableResponseProperties(const IOTHUB_CLIENT_WRITABLE_PROPERT
 {
     char* currentWrite = (char*)serializedProperties;
     size_t remainingBytes = serializedPropertiesLength;
+
+    *requiredBytes = 0;
 
     if (WriteOpeningBrace(componentName,  &currentWrite, requiredBytes, &remainingBytes) != true)
     {
@@ -254,7 +258,6 @@ IOTHUB_CLIENT_RESULT IoTHubClient_Serialize_ReportedProperties(const IOTHUB_CLIE
 {
     IOTHUB_CLIENT_RESULT result;
     size_t requiredBytes = 0;
-    size_t requiredBytes2 = 0;
     unsigned char* serializedPropertiesBuffer = NULL;
 
     if ((VerifySerializeReportedProperties(properties, numProperties) == false) || (serializedProperties == NULL) || (serializedPropertiesLength == NULL))
@@ -272,7 +275,7 @@ IOTHUB_CLIENT_RESULT IoTHubClient_Serialize_ReportedProperties(const IOTHUB_CLIE
         LogError("Cannot allocate %lu bytes", (unsigned long)requiredBytes);
         result = IOTHUB_CLIENT_ERROR;
     }
-    else if (WriteReportedProperties(properties, numProperties, componentName, serializedPropertiesBuffer, requiredBytes, &requiredBytes2) != true)
+    else if (WriteReportedProperties(properties, numProperties, componentName, serializedPropertiesBuffer, requiredBytes, &requiredBytes) != true)
     {
         LogError("Cannot write properties buffer");
         result = IOTHUB_CLIENT_ERROR;
@@ -335,7 +338,6 @@ IOTHUB_CLIENT_RESULT IoTHubClient_Serialize_WritablePropertyResponse(
 {
     IOTHUB_CLIENT_RESULT result;
     size_t requiredBytes = 0;
-    size_t requiredBytes2 = 0;
     unsigned char* serializedPropertiesBuffer = NULL;
 
     if ((VerifySerializeWritableReportedProperties(properties, numProperties) == false) || (serializedProperties == NULL) || (serializedPropertiesLength == NULL))
@@ -353,7 +355,7 @@ IOTHUB_CLIENT_RESULT IoTHubClient_Serialize_WritablePropertyResponse(
         LogError("Cannot allocate %lu bytes", (unsigned long)requiredBytes);
         result = IOTHUB_CLIENT_ERROR;
     }
-    else if (WriteWritableResponseProperties(properties, numProperties, componentName, serializedPropertiesBuffer, requiredBytes, &requiredBytes2) != true)
+    else if (WriteWritableResponseProperties(properties, numProperties, componentName, serializedPropertiesBuffer, requiredBytes, &requiredBytes) != true)
     {
         LogError("Cannot write properties buffer");
         result = IOTHUB_CLIENT_ERROR;

--- a/iothub_client/src/iothub_client_properties.c
+++ b/iothub_client/src/iothub_client_properties.c
@@ -72,8 +72,7 @@ static void AdvanceCountersAfterWrite(int currentOutputBytes, char** currentWrit
 }
 
 // To correctly check snprintf for success, we need to check both it's not negative AND 
-// that the (number of bytes written ) != (sizeof buffer).  If the latter case happens, it means
-// that snprintf has truncated the write and that there's actually an error.
+// that the (number of bytes written ) != (sizeof buffer).
 static int PropertySnprintf(char* buffer, size_t count, const char* format, ...)
 {
     va_list arg_list;
@@ -156,7 +155,7 @@ static bool WriteReportedProperties(const IOTHUB_CLIENT_REPORTED_PROPERTY* prope
         int currentOutputBytes;
 
         if ((currentOutputBytes = PropertySnprintf(currentWrite, remainingBytes, PROPERTY_FORMAT_NAME_VALUE, 
-                                            properties[i].name, properties[i].value, AddCommaIfNeeded(lastProperty))) < 0)
+                                                    properties[i].name, properties[i].value, AddCommaIfNeeded(lastProperty))) < 0)
         {
             LogError("Cannot write properties string");
             return false;
@@ -167,7 +166,7 @@ static bool WriteReportedProperties(const IOTHUB_CLIENT_REPORTED_PROPERTY* prope
     if (WriteClosingBrace(componentName != NULL, &currentWrite, requiredBytes, &remainingBytes) != true)
     {
         LogError("Cannot write properties string");
-        return (size_t)-1;
+        return false;
     }
 
     *requiredBytes = (*requiredBytes + 1);
@@ -198,7 +197,7 @@ static bool WriteWritableResponseProperties(const IOTHUB_CLIENT_WRITABLE_PROPERT
         if (properties[i].description == NULL)
         {
             if ((currentOutputBytes = PropertySnprintf(currentWrite, remainingBytes, PROPERTY_FORMAT_WRITABLE_RESPONSE, properties[i].name, 
-                                                properties[i].value, properties[i].result, properties[i].ackVersion, AddCommaIfNeeded(lastProperty))) < 0)
+                                                        properties[i].value, properties[i].result, properties[i].ackVersion, AddCommaIfNeeded(lastProperty))) < 0)
             {
                 LogError("Cannot write properties string");
                 return false;
@@ -207,7 +206,7 @@ static bool WriteWritableResponseProperties(const IOTHUB_CLIENT_WRITABLE_PROPERT
         else
         {
             if ((currentOutputBytes = PropertySnprintf(currentWrite, remainingBytes, PROPERTY_FORMAT_WRITABLE_RESPONSE_WITH_DESCRIPTION, properties[i].name, 
-                                                properties[i].value, properties[i].result, properties[i].ackVersion, properties[i].description, AddCommaIfNeeded(lastProperty))) < 0)
+                                                        properties[i].value, properties[i].result, properties[i].ackVersion, properties[i].description, AddCommaIfNeeded(lastProperty))) < 0)
             {
                 LogError("Cannot write properties string");
                 return false;

--- a/iothub_client/src/iothub_client_properties.c
+++ b/iothub_client/src/iothub_client_properties.c
@@ -70,7 +70,7 @@ static void AdvanceCountersAfterWrite(int currentOutputBytes, char** currentWrit
 }
 
 // WriteOpeningBrace adds opening brace for JSON to be generated, either a simple "{" or more complex format if componentName is specified.
-static bool WriteOpeningBrace(const char* componentName, char** currentWrite, size_t* requiredBytes, size_t* remainingBytes) // char* currentWrite, size_t remainingBytes)
+static bool WriteOpeningBrace(const char* componentName, char** currentWrite, size_t* requiredBytes, size_t* remainingBytes)
 {
     int currentOutputBytes;
 

--- a/iothub_client/tests/iothubclient_mqtt_device_method_e2e/iothubclient_mqtt_device_method_e2e.c
+++ b/iothub_client/tests/iothubclient_mqtt_device_method_e2e/iothubclient_mqtt_device_method_e2e.c
@@ -32,11 +32,6 @@ BEGIN_TEST_SUITE(iothubclient_mqtt_device_method_e2e)
         device_command_subscribe_e2e_sas(MQTT_Protocol);
     }
 
-    TEST_FUNCTION(IotHub_Mqtt_Subscribe_Command_x509)
-    {
-        device_command_subscribe_e2e_x509(MQTT_Protocol);
-    }
-
     TEST_FUNCTION(IotHub_Mqtt_Method_Call_With_String_sas)
     {
         device_method_e2e_method_call_with_string_sas(MQTT_Protocol);
@@ -79,6 +74,11 @@ BEGIN_TEST_SUITE(iothubclient_mqtt_device_method_e2e)
         device_method_e2e_method_calls_upload_x509(MQTT_Protocol);
     }
 #endif // DONT_USE_UPLOADTOBLOB
+
+    TEST_FUNCTION(IotHub_Mqtt_Subscribe_Command_x509)
+    {
+        device_command_subscribe_e2e_x509(MQTT_Protocol);
+    }
 
     TEST_FUNCTION(IotHub_Mqtt_Method_Call_With_String_x509)
     {

--- a/iothub_client/tests/iothubclient_mqtt_mod_dm_e2e/iothubclient_mqtt_mod_dm_e2e.c
+++ b/iothub_client/tests/iothubclient_mqtt_mod_dm_e2e/iothubclient_mqtt_mod_dm_e2e.c
@@ -31,12 +31,7 @@ BEGIN_TEST_SUITE(iothubclient_mqtt_mod_dm_e2e)
     {
         device_command_subscribe_e2e_sas(MQTT_Protocol);
     }
-
-    TEST_FUNCTION(IotHub_Mqtt_Module_Subscribe_Command_x509)
-    {
-        device_command_subscribe_e2e_x509(MQTT_Protocol);
-    }
-    
+   
     TEST_FUNCTION(IotHub_Mqtt_Module_Method_Call_With_String_sas)
     {
         device_method_e2e_method_call_with_string_sas(MQTT_Protocol);
@@ -75,6 +70,11 @@ BEGIN_TEST_SUITE(iothubclient_mqtt_mod_dm_e2e)
 #endif
 
 #ifndef __APPLE__
+    TEST_FUNCTION(IotHub_Mqtt_Module_Subscribe_Command_x509)
+    {
+        device_command_subscribe_e2e_x509(MQTT_Protocol);
+    }
+
     TEST_FUNCTION(IotHub_Mqtt_Method_Call_With_String_x509)
     {
         device_method_e2e_method_call_with_string_x509(MQTT_Protocol);


### PR DESCRIPTION
`feature/iot_pnp_stage` was having issues building in gate.  Fix (and will require gate runs ongoing to make this not happen again.)

* Check correct value from `strtod`.
* Include parson.h in the build for iothub_client; remove conditional include.
  * Note that we *always* link to parson, so including a header shouldn't impact RAM|ROM impact.  
  * Analysis of gcc and clang ELF binaries created for `pnp_temperature_controller` using `nm` binutil, all parson references are already correctly optimized out.
* Correctly check `snprintf` error cases.  This impacted a fair amount of code but the gist of this is:
  * Use an `int` to store result so that the `< 0` check makes sense.
  * Check for case where sizeof(buffer passed in)== (# of bytes returned).  This implies truncation, which we treat as an error since app won't get properly formatted JSON.
* Don't run the command based x509 tests for `__APPLE__`, to keep inline with existing.