### PR TITLE
Test stabilization

### DIFF
--- a/iothub_client/tests/common_device_method_e2e/iothubclient_common_device_method_e2e.c
+++ b/iothub_client/tests/common_device_method_e2e/iothubclient_common_device_method_e2e.c
@@ -93,7 +93,7 @@ static const char *METHOD_NAME = "MethodName";
 static const int METHOD_RESPONSE_SUCCESS = 200;
 static const int METHOD_RESPONSE_ERROR = 401;
 static const unsigned int TIMEOUT = 60;
-static const unsigned int IOTHUB_CONNECT_TIMEOUT_SEC = 30;
+static const unsigned int IOTHUB_CONNECT_TIMEOUT_SEC = 120;
 
 static void connection_status_callback(IOTHUB_CLIENT_CONNECTION_STATUS result, IOTHUB_CLIENT_CONNECTION_STATUS_REASON reason, void* userContextCallback)
 {

--- a/provisioning_client/tests/prov_x509_client_e2e/prov_x509_client_e2e.c
+++ b/provisioning_client/tests/prov_x509_client_e2e/prov_x509_client_e2e.c
@@ -66,7 +66,10 @@ BEGIN_TEST_SUITE(prov_x509_client_e2e)
         // DPS fails when having multiple enrollments at the same time. 
         // Since we are running these tests on multiple machines with each test taking about 1 second, 
         // we randomize their start time to avoid collisions.
-        ThreadAPI_Sleep((rand() % TEST_PROV_RANDOMIZED_BACK_OFF_SEC) * 1000);
+        srand(time(0));
+        int random_back_off_sec = rand() % TEST_PROV_RANDOMIZED_BACK_OFF_SEC;
+        LogInfo("prov_x509_client_e2e: Random back-off = %ds", random_back_off_sec);
+        ThreadAPI_Sleep(random_back_off_sec * 1000);
 
         // Register device
         create_x509_individual_enrollment_device();


### PR DESCRIPTION
- Increasing DirectMethods E2E test timeout from 30s to 120s to decrease test faults caused by bad network.
- Adding RNG seed initialization for DPS E2E random back-off timer.