### PR TITLE
Adding retries to the DPS test.

### DIFF
--- a/provisioning_client/tests/common_prov_e2e/common_prov_e2e.c
+++ b/provisioning_client/tests/common_prov_e2e/common_prov_e2e.c
@@ -34,6 +34,8 @@
 
 #include "common_prov_e2e.h"
 
+const int TEST_PROV_RANDOMIZED_BACK_OFF_SEC = 60;
+
 #define MAX_CLOUD_TRAVEL_TIME       60.0
 #define DEVICE_GUID_SIZE            37
 
@@ -304,8 +306,9 @@ void remove_enrollment_device(const char* g_prov_conn_string)
     
 }
 
-void send_dps_test_registration(const char* global_uri, const char* scope_id, PROV_DEVICE_TRANSPORT_PROVIDER_FUNCTION protocol, bool g_enable_tracing)
+static REGISTRATION_RESULT send_dps_test_registration(const char* global_uri, const char* scope_id, PROV_DEVICE_TRANSPORT_PROVIDER_FUNCTION protocol, bool g_enable_tracing)
 {
+    REGISTRATION_RESULT result;
     PROV_CLIENT_E2E_INFO prov_info;
     memset(&prov_info, 0, sizeof(PROV_CLIENT_E2E_INFO));
 
@@ -341,11 +344,32 @@ void send_dps_test_registration(const char* global_uri, const char* scope_id, PR
 
     wait_for_dps_result(handle, &prov_info);
 
-    // Assert
-    ASSERT_ARE_EQUAL(int, REG_RESULT_COMPLETE, prov_info.reg_result, "Failure calling registering device x509 http");
+    result = prov_info.reg_result;
 
     free(prov_info.iothub_uri);
     free(prov_info.device_id);
 
     Prov_Device_LL_Destroy(handle);
+
+    return result;
+}
+
+void send_dps_test_registration_with_retry(const char* global_uri, const char* scope_id, PROV_DEVICE_TRANSPORT_PROVIDER_FUNCTION protocol, bool g_enable_tracing)
+{
+    if (send_dps_test_registration(global_uri, scope_id, protocol, g_enable_tracing) != REG_RESULT_COMPLETE)
+    {
+        // DPS fails when having multiple enrollments at the same time:
+        //  {"errorCode":409203,"trackingId":"e5490c1e-2528-4eb5-9cf6-e72e80c20268","message":"Precondition failed.","timestampUtc":"2022-02-28T10:11:31.1373215Z"}
+        // Since we are running these tests on multiple machines we retry with a randomized back-off timer.
+        srand(time(0));
+        int random_back_off_sec = rand() % TEST_PROV_RANDOMIZED_BACK_OFF_SEC;
+        LogInfo("prov_x509_client_e2e failed: Random back-off = %ds", random_back_off_sec);
+        ThreadAPI_Sleep(random_back_off_sec * 1000);
+
+        ASSERT_ARE_EQUAL(
+            int, 
+            REG_RESULT_COMPLETE, 
+            send_dps_test_registration(global_uri, scope_id, protocol, g_enable_tracing), 
+            "Failure during device provisioning");
+    }
 }

--- a/provisioning_client/tests/common_prov_e2e/common_prov_e2e.c
+++ b/provisioning_client/tests/common_prov_e2e/common_prov_e2e.c
@@ -358,7 +358,7 @@ void send_dps_test_registration_with_retry(const char* global_uri, const char* s
 {
     if (send_dps_test_registration(global_uri, scope_id, protocol, g_enable_tracing) != REG_RESULT_COMPLETE)
     {
-        // DPS fails when having multiple enrollments at the same time:
+        // DPS fails when having multiple enrollments of the same device ID at the same time:
         //  {"errorCode":409203,"trackingId":"e5490c1e-2528-4eb5-9cf6-e72e80c20268","message":"Precondition failed.","timestampUtc":"2022-02-28T10:11:31.1373215Z"}
         // Since we are running these tests on multiple machines we retry with a randomized back-off timer.
         srand(time(0));

--- a/provisioning_client/tests/common_prov_e2e/common_prov_e2e.h
+++ b/provisioning_client/tests/common_prov_e2e/common_prov_e2e.h
@@ -57,8 +57,10 @@ extern void remove_enrollment_device();
 extern void wait_for_dps_result(PROV_DEVICE_LL_HANDLE handle, PROV_CLIENT_E2E_INFO* prov_info);
 extern int construct_device_id(const char* prefix, char** device_name);
 
-extern void send_dps_test_registration(const char* global_uri, const char* scope_id, PROV_DEVICE_TRANSPORT_PROVIDER_FUNCTION protocol, bool use_tracing);
+extern void send_dps_test_registration_with_retry(const char* global_uri, const char* scope_id, PROV_DEVICE_TRANSPORT_PROVIDER_FUNCTION protocol, bool use_tracing);
 extern char* convert_base64_to_string(const char* base64_cert);
+
+extern const int TEST_PROV_RANDOMIZED_BACK_OFF_SEC;
 
 #ifdef __cplusplus
 }

--- a/provisioning_client/tests/prov_x509_client_e2e/prov_x509_client_e2e.c
+++ b/provisioning_client/tests/prov_x509_client_e2e/prov_x509_client_e2e.c
@@ -32,8 +32,6 @@ char* g_dps_x509_key_individual = NULL;
 char* g_dps_regid_individual = NULL;
 const bool g_enable_tracing = true;
 
-static const int TEST_PROV_RANDOMIZED_BACK_OFF_SEC = 60;
-
 BEGIN_TEST_SUITE(prov_x509_client_e2e)
 
     TEST_SUITE_INITIALIZE(TestClassInitialize)
@@ -99,31 +97,31 @@ BEGIN_TEST_SUITE(prov_x509_client_e2e)
 #if USE_HTTP
     TEST_FUNCTION(dps_register_x509_device_http_success)
     {
-        send_dps_test_registration(g_dps_uri, g_dps_scope_id, Prov_Device_HTTP_Protocol, g_enable_tracing);
+        send_dps_test_registration_with_retry(g_dps_uri, g_dps_scope_id, Prov_Device_HTTP_Protocol, g_enable_tracing);
     }
 #endif
 
 #if USE_AMQP
     TEST_FUNCTION(dps_register_x509_device_amqp_success)
     {
-        send_dps_test_registration(g_dps_uri, g_dps_scope_id, Prov_Device_AMQP_Protocol, g_enable_tracing);
+        send_dps_test_registration_with_retry(g_dps_uri, g_dps_scope_id, Prov_Device_AMQP_Protocol, g_enable_tracing);
     }
 
     TEST_FUNCTION(dps_register_x509_device_amqp_ws_success)
     {
-        send_dps_test_registration(g_dps_uri, g_dps_scope_id, Prov_Device_AMQP_WS_Protocol, g_enable_tracing);
+        send_dps_test_registration_with_retry(g_dps_uri, g_dps_scope_id, Prov_Device_AMQP_WS_Protocol, g_enable_tracing);
     }
 #endif
 
 #if USE_MQTT
     TEST_FUNCTION(dps_register_x509_device_mqtt_success)
     {
-        send_dps_test_registration(g_dps_uri, g_dps_scope_id, Prov_Device_MQTT_Protocol, g_enable_tracing);
+        send_dps_test_registration_with_retry(g_dps_uri, g_dps_scope_id, Prov_Device_MQTT_Protocol, g_enable_tracing);
     }
 
     TEST_FUNCTION(dps_register_x509_device_mqtt_ws_success)
     {
-        send_dps_test_registration(g_dps_uri, g_dps_scope_id, Prov_Device_MQTT_WS_Protocol, g_enable_tracing);
+        send_dps_test_registration_with_retry(g_dps_uri, g_dps_scope_id, Prov_Device_MQTT_WS_Protocol, g_enable_tracing);
     }
 #endif
 END_TEST_SUITE(prov_x509_client_e2e)

--- a/provisioning_client/tests/prov_x509_client_openssl_engine_e2e/prov_x509_client_openssl_engine_e2e.c
+++ b/provisioning_client/tests/prov_x509_client_openssl_engine_e2e/prov_x509_client_openssl_engine_e2e.c
@@ -57,7 +57,7 @@ BEGIN_TEST_SUITE(prov_x509_client_openssl_engine_e2e)
         g_dps_regid_individual = getenv(DPS_X509_INDIVIDUAL_REGISTRATION_ID);
         ASSERT_IS_NOT_NULL(g_dps_regid_individual, "DPS_X509_INDIVIDUAL_REGISTRATION_ID is NULL");
 
-        // DPS fails when having multiple enrollments at the same time. 
+        // DPS fails when having multiple enrollments of the same device ID at the same time: 
         // Since we are running these tests on multiple machines with each test taking about 1 second, 
         // we randomize their start time to avoid collisions.
         srand(time(0));

--- a/provisioning_client/tests/prov_x509_client_openssl_engine_e2e/prov_x509_client_openssl_engine_e2e.c
+++ b/provisioning_client/tests/prov_x509_client_openssl_engine_e2e/prov_x509_client_openssl_engine_e2e.c
@@ -57,6 +57,14 @@ BEGIN_TEST_SUITE(prov_x509_client_openssl_engine_e2e)
         g_dps_regid_individual = getenv(DPS_X509_INDIVIDUAL_REGISTRATION_ID);
         ASSERT_IS_NOT_NULL(g_dps_regid_individual, "DPS_X509_INDIVIDUAL_REGISTRATION_ID is NULL");
 
+        // DPS fails when having multiple enrollments at the same time. 
+        // Since we are running these tests on multiple machines with each test taking about 1 second, 
+        // we randomize their start time to avoid collisions.
+        srand(time(0));
+        int random_back_off_sec = rand() % TEST_PROV_RANDOMIZED_BACK_OFF_SEC;
+        LogInfo("prov_x509_client_e2e: Random back-off = %ds", random_back_off_sec);
+        ThreadAPI_Sleep(random_back_off_sec * 1000);
+
         // Register device
         create_x509_individual_enrollment_device();
     }
@@ -81,31 +89,31 @@ BEGIN_TEST_SUITE(prov_x509_client_openssl_engine_e2e)
 #if USE_HTTP
     TEST_FUNCTION(dps_register_x509_openssl_engine_device_http_success)
     {
-        send_dps_test_registration(g_dps_uri, g_dps_scope_id, Prov_Device_HTTP_Protocol, g_enable_tracing);
+        send_dps_test_registration_with_retry(g_dps_uri, g_dps_scope_id, Prov_Device_HTTP_Protocol, g_enable_tracing);
     }
 #endif
 
 #if USE_AMQP
     TEST_FUNCTION(dps_register_x509_openssl_engine_device_amqp_success)
     {
-        send_dps_test_registration(g_dps_uri, g_dps_scope_id, Prov_Device_AMQP_Protocol, g_enable_tracing);
+        send_dps_test_registration_with_retry(g_dps_uri, g_dps_scope_id, Prov_Device_AMQP_Protocol, g_enable_tracing);
     }
 
     TEST_FUNCTION(dps_register_x509_openssl_engine_device_amqp_ws_success)
     {
-        send_dps_test_registration(g_dps_uri, g_dps_scope_id, Prov_Device_AMQP_WS_Protocol, g_enable_tracing);
+        send_dps_test_registration_with_retry(g_dps_uri, g_dps_scope_id, Prov_Device_AMQP_WS_Protocol, g_enable_tracing);
     }
 #endif
 
 #if USE_MQTT
     TEST_FUNCTION(dps_register_x509_openssl_engine_device_mqtt_success)
     {
-        send_dps_test_registration(g_dps_uri, g_dps_scope_id, Prov_Device_MQTT_Protocol, g_enable_tracing);
+        send_dps_test_registration_with_retry(g_dps_uri, g_dps_scope_id, Prov_Device_MQTT_Protocol, g_enable_tracing);
     }
 
     TEST_FUNCTION(dps_register_x509_openssl_engine_device_mqtt_ws_success)
     {
-        send_dps_test_registration(g_dps_uri, g_dps_scope_id, Prov_Device_MQTT_WS_Protocol, g_enable_tracing);
+        send_dps_test_registration_with_retry(g_dps_uri, g_dps_scope_id, Prov_Device_MQTT_WS_Protocol, g_enable_tracing);
     }
 #endif
 END_TEST_SUITE(prov_x509_client_openssl_engine_e2e)


### PR DESCRIPTION
1. Adding one retry to DPS E2E test to avoid `Precondition failed.` server error caused by using the same identity on two test machines at the same time.
2. Adding random test start to the OpenSSL ENGINE test.

The provisioning tests failed 3 or 4 times over the weekend (~98% test pass rate over the last 7 days).