### PR TITLE
Rename iothub_client_properties.h header for better "namespacing"

### DIFF
--- a/iothub_client/inc/iothub_client_properties.h
+++ b/iothub_client/inc/iothub_client_properties.h
@@ -207,7 +207,7 @@ MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Properties_Writer_CreateW
 
 /**
 * @brief   Frees serialized properties that were initially allocated with IoTHubClient_Properties_Writer_CreateReported() 
-*          or IoTHubClient_Properties_Write_WritableResponse().
+*          or IoTHubClient_Properties_Writer_CreateWritableResponse().
 *
 * @param[in]  serializedProperties Properties to free.
 */
@@ -265,7 +265,7 @@ MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Properties_Parser_GetNext
 /**
 * @brief   Frees memory allocated by IoTHubClient_Properties_Parser_GetNext().
 *
-* @param   property  IOTHUB_CLIENT_PROPERTY_PARSED initially allocated by IoTHubClient_Deserialize_Properties() 
+* @param   property  IOTHUB_CLIENT_PROPERTY_PARSED initially allocated by IoTHubClient_Properties_Parser_Create() 
 *                    to be freed.
 * 
 */

--- a/iothub_client/inc/iothub_client_properties.h
+++ b/iothub_client/inc/iothub_client_properties.h
@@ -2,28 +2,28 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 /** @file    iothub_client_properties.h
-*   @brief   APIs that serialize and deserialize properties modeled with DTDLv2.
+*   @brief   APIs that create and parse properties modeled with DTDLv2.
 *
 *   @details Plug and Play devices are defined using the DTDLv2 modeling language described
 *            at https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/dtdlv2.md.
 *
-*            Azure IoT Hub defines a set of conventions for serializing and deserializing DTDLv2 
+*            Azure IoT Hub defines a set of conventions for parsing and creating DTDLv2 
 *            properties that can be sent between Azure IoT Hub and devices connected to the Hub.
 *
 *            The format is JSON based.  It is possible to manually serialize and deserialize
 *            this payload following the documented convention.  These APIs make this process easier.  
-*            When serializing a property to be sent to IoT Hub, your application provides a C structure and 
+*            When creating a property to be sent to IoT Hub, your application provides a C structure and 
 *            the API returns a byte stream to be sent.
 *
-*            When receiving properties form IoT Hub, the deserialization API converts a raw stream
+*            When receiving properties form IoT Hub, the parsing API converts a raw stream
 *            into an easier to process C structure with the JSON parsed out.
 *
 *            These APIs do not invoke any network I/O.  To actually send and receive data, these APIs 
 *            will typically be paired with a corresponding IoT Hub device or module client.  
 *  
-*            Pseudocode to demonstrate the relationship for serializing properties and device clients:
+*            Pseudocode to demonstrate the relationship for creating properties and device clients:
 *                   // Converts C structure into serialized stream.  
-*                   IoTHubClient_Serialize_ReportedProperties(yourApplicationsPropertiesInStruct, &serializedByteStream);
+*                   IoTHubClient_Properties_Writer_CreateReported(yourApplicationsPropertiesInStruct, &serializedByteStream);
 *                   // Send the data
 *                   IoTHubDeviceClient_LL_SendPropertiesAsync(deviceHandle, serializedByteStream);
 *
@@ -33,19 +33,24 @@
 *                   // Time passes as request is processed...
 *                   // ...
 *                   // Your application's IOTHUB_CLIENT_PROPERTIES_RECEIVED_CALLBACK is eventually invoked.  
-*                   // Your application then will setup the iterator based on the data from the network.
+*                   // Your application then will setup the parser handle based on the data from the network.
 *                   // rawDataFromIoTHub below corresponds to data your IOTHUB_CLIENT_PROPERTIES_RECEIVED_CALLBACK 
 *                   // receives.
 *
 *                   void yourAppCallback(rawDataFromIoTHub, ...) // your IOTHUB_CLIENT_PROPERTIES_RECEIVED_CALLBACK implementation
 *                   {
-*                     IoTHubClient_Deserialize_Properties_CreateIterator(rawDataFromIoTHub, &iteratorHandle)
+*                     IoTHubClient_Properties_Parser_Create(rawDataFromIoTHub, &parserHandle)
 *
 *                     // Enumerate each property that is in a component.  deserializedProperty will be of type
-*                     // IOTHUB_CLIENT_DESERIALIZED_PROPERTY and is much easier to process than raw JSON 
-*                     while (IoTHubClient_Deserialize_Properties_GetNextProperty(&iteratorHandle, &deserializedProperty)) {
+*                     // IOTHUB_CLIENT_PROPERTY_PARSED and is much easier to process than raw JSON 
+*                     while (IoTHubClient_Properties_Parser_GetNext(&parserHandle, &deserializedProperty)) {
 *                         // Application processes deserializedProperty according to modeling rules
+*                         // ...
+*                         // Frees memory allocated by IoTHubClient_Properties_Parser_GetNext
+*                         IoTHubClient_Properties_ParsedProperty_Destroy(&deserializedProperty);
 *                     }
+*                     // Frees memory allocated by IoTHubClient_Properties_Parser_Create
+*                     IoTHubClient_Properties_Parser_Destroy(parserHandle);
 *                   }
 */
 
@@ -58,30 +63,30 @@
 
 #include "iothub_client_core_common.h"
 
-/** @brief Current version of @p IOTHUB_CLIENT_REPORTED_PROPERTY structure.  */
-#define IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1 1
+/** @brief Current version of @p IOTHUB_CLIENT_PROPERTY_REPORTED structure.  */
+#define IOTHUB_CLIENT_PROPERTY_REPORTED_STRUCT_VERSION_1 1
 
 /** @brief    This struct defines properties reported from the device.  This corresponds to what DTDLv2 calls a 
 *             "read-only property."   This structure is filled out by the application and can be serialized into 
-*             a payload for IoT Hub via @p IoTHubClient_Serialize_ReportedProperties(). */
+*             a payload for IoT Hub via @p IoTHubClient_Properties_Writer_CreateReported(). */
 
-typedef struct IOTHUB_CLIENT_REPORTED_PROPERTY_TAG {
-    /** @brief   Version of the structure.  Currently must be IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1. */
+typedef struct IOTHUB_CLIENT_PROPERTY_REPORTED_TAG {
+    /** @brief   Version of the structure.  Currently must be IOTHUB_CLIENT_PROPERTY_REPORTED_STRUCT_VERSION_1. */
     int structVersion;
     /** @brief    Name of the property. */
     const char* name;
     /** @brief    Value of the property. */
     const char* value;
-} IOTHUB_CLIENT_REPORTED_PROPERTY;
+} IOTHUB_CLIENT_PROPERTY_REPORTED;
 
-/** @brief Current version of @p IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE structure.  */
-#define IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE_STRUCT_VERSION_1 1
+/** @brief Current version of @p IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE structure.  */
+#define IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE_STRUCT_VERSION_1 1
 
 /** @brief    This struct represents the response to a writable property that the device will return.  
 *             This structure is filled out by the application and can be serialized into a payload for IoT Hub via
-*             @p IoTHubClient_Serialize_WritablePropertyResponse(). */
-typedef struct IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE_TAG {
-    /** @brief   Version of the structure.  Currently must be IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE_STRUCT_VERSION_1. */
+*             @p IoTHubClient_Properties_Write_WritableResponse(). */
+typedef struct IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE_TAG {
+    /** @brief   Version of the structure.  Currently must be IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE_STRUCT_VERSION_1. */
     int structVersion;
     /** @brief Name of the property. */
     const char* name;
@@ -90,12 +95,12 @@ typedef struct IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE_TAG {
     /** @brief Result of the requested operation.  This maps to an HTTP status code.  */
     int result;
     /** @brief Acknowledgement version.  This corresponds to the version of the writable properties being responded to. */
-    /** @details If using @p IoTHubClient_Deserialize_Properties_CreateIterator() to deserialize initial property request
+    /** @details If using @p IoTHubClient_Properties_Parser_CreateIterator() to deserialize initial property request
     *            from IoT Hub, just set this field to what was returned in @p propertiesVersion. */
     int ackVersion;
     /** @brief Optional friendly description of the operation.  May be NULL. */
     const char* description;
-} IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE;
+} IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE;
 
 /** @brief Enumeration that indicates whether a given property from the service was originally reported from the device
            (and hence the device application sees what the last reported value IoT Hub has)
@@ -115,13 +120,13 @@ MU_DEFINE_ENUM_WITHOUT_INVALID(IOTHUB_CLIENT_PROPERTY_TYPE, IOTHUB_CLIENT_PROPER
 
 MU_DEFINE_ENUM_WITHOUT_INVALID(IOTHUB_CLIENT_PROPERTY_VALUE_TYPE, IOTHUB_CLIENT_PROPERTY_VALUE_TYPE_VALUES);
 
-/** @brief Current version of @p IOTHUB_CLIENT_DESERIALIZED_PROPERTY structure.  */
-#define IOTHUB_CLIENT_DESERIALIZED_PROPERTY_STRUCT_VERSION_1 1
+/** @brief Current version of @p IOTHUB_CLIENT_PROPERTY_PARSED structure.  */
+#define IOTHUB_CLIENT_PROPERTY_PARSED_STRUCT_VERSION_1 1
 
 /** @brief    This struct represents a property from IoT Hub.  
               It is generated by IoTHubClient_Deserialize_Properties() while deserializing a property payload. */
-typedef struct IOTHUB_CLIENT_DESERIALIZED_PROPERTY_TAG {
-    /** @brief   Version of the structure.  Currently must be IOTHUB_CLIENT_DESERIALIZED_PROPERTY_STRUCT_VERSION_1. */
+typedef struct IOTHUB_CLIENT_PROPERTY_PARSED_TAG {
+    /** @brief   Version of the structure.  Currently must be IOTHUB_CLIENT_PROPERTY_PARSED_STRUCT_VERSION_1. */
     int structVersion;
     /** @brief   Whether this is a property the device reported (and we're seeing what IoT Hub last received from 
          the device) or whether it's a writable property request from the device. */
@@ -142,76 +147,76 @@ typedef struct IOTHUB_CLIENT_DESERIALIZED_PROPERTY_TAG {
     /** @brief Number of bytes in valueLength.  Does not include null-terminator if IOTHUB_CLIENT_PROPERTY_VALUE_STRING 
     *          is set */
     size_t valueLength;
-} IOTHUB_CLIENT_DESERIALIZED_PROPERTY;
+} IOTHUB_CLIENT_PROPERTY_PARSED;
 
 /**
-* @brief   Serializes reported properties into the required format for sending to IoT Hub.
+* @brief   Writes the reported properties into bytes for sending to IoT Hub.
 *
-* @param[in]   properties                  Pointer to IOTHUB_CLIENT_REPORTED_PROPERTY to be serialized.
+* @param[in]   properties                  Pointer to IOTHUB_CLIENT_PROPERTY_REPORTED to be serialized.
 * @param[in]   numProperties               Number of elements contained in @p properties.
 * @param[in]   componentName               Optional component name these properties are part of.  May be NULL for default 
 *                                          component.
 * @param[out]  serializedProperties        Serialized output of @p properties for sending to IoT Hub.
 *                                          The application must release this memory using 
-*                                          IoTHubClient_Serialize_Properties_Destroy().
+*                                          IoTHubClient_Properties_Properties_Writer_Destroy().
 *                                          Note: This is NOT a null-terminated string.
 * @param[out]  serializedPropertiesLength  Length of serializedProperties.
 *
 * @remarks  Applications can also manually construct the payload based on the convention rules.  This API is an easier 
-*           to use alternative, so the application can use the more convenient IOTHUB_CLIENT_REPORTED_PROPERTY 
+*           to use alternative, so the application can use the more convenient IOTHUB_CLIENT_PROPERTY_REPORTED 
 *           structure instead of raw serialization.
 * 
-*           This API does not perform any network I/O.  It only translates IOTHUB_CLIENT_REPORTED_PROPERTY into a byte 
+*           This API does not perform any network I/O.  It only translates IOTHUB_CLIENT_PROPERTY_REPORTED into a byte 
 *           array.  Applications should use APIs such as IoTHubDeviceClient_LL_SendPropertiesAsync to send the 
 *           serialized data.
 * 
 * @return   IOTHUB_CLIENT_OK upon success or an error code upon failure.
 */
-MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Serialize_ReportedProperties, const IOTHUB_CLIENT_REPORTED_PROPERTY*, properties, size_t, numProperties, const char*, componentName, unsigned char**, serializedProperties, size_t*, serializedPropertiesLength);
+MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Properties_Writer_CreateReported, const IOTHUB_CLIENT_PROPERTY_REPORTED*, properties, size_t, numProperties, const char*, componentName, unsigned char**, serializedProperties, size_t*, serializedPropertiesLength);
 
 /**
-* @brief   Serializes the response to writable properties into the required format for sending to IoT Hub.  
+* @brief   Writes the response to writable properties into bytes for sending to IoT Hub.
 *
-* @param[in]   properties                 Pointer to IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE to be serialized.
+* @param[in]   properties                 Pointer to IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE to be serialized.
 * @param[in]   numProperties              Number of elements contained in @p properties.
 * @param[in]   componentName              Optional component name these properties are part of.  May be NULL for 
 *                                         default component.
 * @param[out]  serializedProperties       Serialized output of @p properties for sending to IoT Hub.
                                           The application must release this memory using 
-                                          IoTHubClient_Serialize_Properties_Destroy().
+                                          IoTHubClient_Properties_Properties_Writer_Destroy().
 *                                         Note: This is NOT a null-terminated string.
 * @param[out]  serializedPropertiesLength Length of serializedProperties
 * 
 * @remarks  Applications typically will invoke this API when processing a property from service 
 *           (IOTHUB_CLIENT_PROPERTIES_RECEIVED_CALLBACK) to indicate whether properties have been accepted or rejected 
 *           by the device.  For example, if the service requested DesiredTemp=50, then the application could fill out 
-*           the fields in an IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE structure indicating whether the request can be 
+*           the fields in an IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE structure indicating whether the request can be 
 *           processed or whether there was a failure.
 *
 *           Applications can also manually construct the payload based on the convention rules.  This API is an easier 
-*           to use alternative, so the application can use the more convenient IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE 
+*           to use alternative, so the application can use the more convenient IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE 
 *           structure instead of raw serialization.
 *
-*           This API does not perform any network I/O.  It only translates IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE into
+*           This API does not perform any network I/O.  It only translates IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE into
 *           a byte array.  Applications should use APIs such as IoTHubDeviceClient_LL_SendPropertiesAsync to send the 
 *           serialized data.
 *
 * @return   IOTHUB_CLIENT_OK upon success or an error code upon failure.
 */
-MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Serialize_WritablePropertyResponse, const IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE*, properties, size_t, numProperties, const char*, componentName, unsigned char**, serializedProperties, size_t*, serializedPropertiesLength);
+MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Properties_Writer_CreateWritableResponse, const IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE*, properties, size_t, numProperties, const char*, componentName, unsigned char**, serializedProperties, size_t*, serializedPropertiesLength);
 
 /**
-* @brief   Frees serialized properties that were initially allocated with IoTHubClient_Serialize_ReportedProperties() 
-*          or IoTHubClient_Serialize_WritablePropertyResponse().
+* @brief   Frees serialized properties that were initially allocated with IoTHubClient_Properties_Writer_CreateReported() 
+*          or IoTHubClient_Properties_Write_WritableResponse().
 *
 * @param[in]  serializedProperties Properties to free.
 */
-MOCKABLE_FUNCTION(, void, IoTHubClient_Serialize_Properties_Destroy, unsigned char*, serializedProperties);
+MOCKABLE_FUNCTION(, void, IoTHubClient_Properties_Properties_Writer_Destroy, unsigned char*, serializedProperties);
 
-typedef struct IOTHUB_CLIENT_PROPERTY_ITERATOR_TAG* IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE;
+typedef struct IOTHUB_CLIENT_PROPERTY_ITERATOR_TAG* IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE;
 
 /**
-* @brief   Setup an iterator to enumerate through Plug and Play properties.
+* @brief   Setup an iterator to parse through Plug and Play properties recevied from IoT Hub.
 *
 * @param[in]  payloadType              Whether the payload is a full set of properties or only a set of updated 
 *                                      writable properties.
@@ -223,59 +228,59 @@ typedef struct IOTHUB_CLIENT_PROPERTY_ITERATOR_TAG* IOTHUB_CLIENT_PROPERTY_ITERA
 *           implementation.  Many of the parameters this function takes should come directly from the 
 *           IOTHUB_CLIENT_PROPERTIES_RECEIVED_CALLBACK itself.
 *
-*           Applications must call @p IoTHubClient_Deserialize_Properties_DestroyIterator() to free @p 
+*           Applications must call @p IoTHubClient_Properties_Parser_Destroy() to free @p 
 *           propertyIteratorHandle on completion.
 *
 * @return   IOTHUB_CLIENT_OK upon success or an error code upon failure.
 */
-MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Deserialize_Properties_CreateIterator,  IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE, payloadType, const unsigned char*, payload, size_t, payloadLength, IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE*, propertyIteratorHandle);
+MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Properties_Parser_Create,  IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE, payloadType, const unsigned char*, payload, size_t, payloadLength, IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE*, propertyIteratorHandle);
 
 /**
 * @brief   Retrieves the version associated with the properties payload.
 *
-* @param[in]   propertyIteratorHandle   Iteration handle returned by @p IoTHubClient_Deserialize_Properties_CreateIterator().
+* @param[in]   propertyIteratorHandle   Iteration handle returned by @p IoTHubClient_Properties_Parser_Create().
 * @param[out]  propertiesVersion        Version of the writable properties received.  This is used when acknowledging a 
 *                                       writable property update.
 *
 * @return   IOTHUB_CLIENT_OK upon success or an error code upon failure.
 */
-MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Deserialize_Properties_GetVersion, IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE, propertyIteratorHandle, int*, propertiesVersion);
+MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Properties_Parser_GetVersion, IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE, propertyIteratorHandle, int*, propertiesVersion);
 
 /**
 * @brief   Gets the next property during iteration.
 *
-* @param[in]   propertyIteratorHandle   Iteration handle returned by @p IoTHubClient_Deserialize_Properties_CreateIterator().
-* @param[out]  property                 @p IOTHUB_CLIENT_DESERIALIZED_PROPERTY containing a deserialized representation 
+* @param[in]   propertyIteratorHandle   Iteration handle returned by @p IoTHubClient_Properties_Parser_Create().
+* @param[out]  property                 @p IOTHUB_CLIENT_PROPERTY_PARSED containing a deserialized representation 
 *                                       of the properties.
 * @param[out]  propertySpecified        Returned value indicating whether a property was found or not.  If false, this 
 *                                       indicates all components have been iterated over.
 *
-* @remarks  Applications must call @p IoTHubClient_Deserialize_Properties_DestroyProperty() to free the @p property returned by this call.
-*           The property structure becomes invalid in @p IoTHubClient_Deserialize_Properties_DestroyIterator once called.
+* @remarks  Applications must call @p IoTHubClient_Properties_ParsedProperty_Destroy() to free the @p property returned by this call.
+*           The property structure becomes invalid after @p IoTHubClient_Properties_ParsedProperty_Destroy has been called.
 *
 * @return   IOTHUB_CLIENT_OK upon success or an error code upon failure.
 */
-MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Deserialize_Properties_GetNextProperty, IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE, propertyIteratorHandle, IOTHUB_CLIENT_DESERIALIZED_PROPERTY*, property, bool*, propertySpecified);
+MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Properties_Parser_GetNext, IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE, propertyIteratorHandle, IOTHUB_CLIENT_PROPERTY_PARSED*, property, bool*, propertySpecified);
 
 /**
-* @brief   Frees memory allocated by IoTHubClient_Deserialize_Properties().
+* @brief   Frees memory allocated by IoTHubClient_Properties_Parser_GetNext().
 *
-* @param   property  IOTHUB_CLIENT_DESERIALIZED_PROPERTY initially allocated by IoTHubClient_Deserialize_Properties() 
+* @param   property  IOTHUB_CLIENT_PROPERTY_PARSED initially allocated by IoTHubClient_Deserialize_Properties() 
 *                    to be freed.
 * 
 */
-MOCKABLE_FUNCTION(, void, IoTHubClient_Deserialize_Properties_DestroyProperty,  IOTHUB_CLIENT_DESERIALIZED_PROPERTY*, property);
+MOCKABLE_FUNCTION(, void, IoTHubClient_Properties_ParsedProperty_Destroy,  IOTHUB_CLIENT_PROPERTY_PARSED*, property);
 
 /**
-* @brief   Frees memory allocated by IoTHubClient_Deserialize_Properties_CreateIterator().
+* @brief   Frees memory allocated by IoTHubClient_Properties_Parser_Create().
 *
-* @param   propertyIteratorHandle   IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE initially allocated by @p 
-*                                   IoTHubClient_Deserialize_Properties_CreateIterator() to be freed.
-* @remarks After an application calls IoTHubClient_Deserialize_Properties_DestroyIterator, any previous 
-*          IOTHUB_CLIENT_DESERIALIZED_PROPERTY structures that were retrieved via
-*          IoTHubClient_Deserialize_Properties_GetNextProperty become invalid.
+* @param   propertyIteratorHandle   IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE initially allocated by @p 
+*                                   IoTHubClient_Properties_Parser_Create() to be freed.
+* @remarks After an application calls IoTHubClient_Properties_Parser_Destroy, any previous 
+*          IOTHUB_CLIENT_PROPERTY_PARSED structures that were retrieved via
+*          IoTHubClient_Properties_Parser_GetNext become invalid.
 * 
 */
-MOCKABLE_FUNCTION(, void, IoTHubClient_Deserialize_Properties_DestroyIterator, IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE, propertyIteratorHandle);
+MOCKABLE_FUNCTION(, void, IoTHubClient_Properties_Parser_Destroy, IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE, propertyIteratorHandle);
 
 #endif /* IOTHUB_CLIENT_PROPERTIES_H */

--- a/iothub_client/inc/iothub_client_properties.h
+++ b/iothub_client/inc/iothub_client_properties.h
@@ -23,7 +23,7 @@
 *  
 *            Pseudocode to demonstrate the relationship for creating properties and device clients:
 *                   // Converts C structure into serialized stream.  
-*                   IoTHubClient_Properties_Writer_CreateReported(yourApplicationsPropertiesInStruct, &serializedByteStream);
+*                   IoTHubClient_Properties_Writer_CreateReported(&yourApplicationsPropertiesInStruct, &serializedByteStream);
 *                   // Send the data
 *                   IoTHubDeviceClient_LL_SendPropertiesAsync(deviceHandle, serializedByteStream);
 *
@@ -75,7 +75,7 @@ typedef struct IOTHUB_CLIENT_PROPERTY_REPORTED_TAG {
     int structVersion;
     /** @brief    Name of the property. */
     const char* name;
-    /** @brief    Value of the property. */
+    /** @brief    Value of the property.  This must be legal JSON.  Strings need to be escaped by the application, e.g. reported.value="\"MyValue\""; */
     const char* value;
 } IOTHUB_CLIENT_PROPERTY_REPORTED;
 
@@ -90,7 +90,7 @@ typedef struct IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE_TAG {
     int structVersion;
     /** @brief Name of the property. */
     const char* name;
-    /** @brief Value of the property. */
+    /** @brief Value of the property.   This must be legal JSON.  Strings need to be escaped by the application, e.g. writeableResponse.value="\"MyValue\""; */
     const char* value;
     /** @brief Result of the requested operation.  This maps to an HTTP status code.  */
     int result;

--- a/iothub_client/inc/iothub_client_properties.h
+++ b/iothub_client/inc/iothub_client_properties.h
@@ -33,24 +33,24 @@
 *                   // Time passes as request is processed...
 *                   // ...
 *                   // Your application's IOTHUB_CLIENT_PROPERTIES_RECEIVED_CALLBACK is eventually invoked.  
-*                   // Your application then will setup the parser handle based on the data from the network.
+*                   // Your application then will setup the reader handle based on the data from the network.
 *                   // rawDataFromIoTHub below corresponds to data your IOTHUB_CLIENT_PROPERTIES_RECEIVED_CALLBACK 
 *                   // receives.
 *
 *                   void yourAppCallback(rawDataFromIoTHub, ...) // your IOTHUB_CLIENT_PROPERTIES_RECEIVED_CALLBACK implementation
 *                   {
-*                     IoTHubClient_Properties_Parser_Create(rawDataFromIoTHub, &parserHandle)
+*                     IoTHubClient_Properties_Reader_Create(rawDataFromIoTHub, &readerHandle)
 *
 *                     // Enumerate each property that is in a component.  deserializedProperty will be of type
 *                     // IOTHUB_CLIENT_PROPERTY_PARSED and is much easier to process than raw JSON 
-*                     while (IoTHubClient_Properties_Parser_GetNext(&parserHandle, &deserializedProperty)) {
+*                     while (IoTHubClient_Properties_Reader_GetNext(&readerHandle, &deserializedProperty)) {
 *                         // Application processes deserializedProperty according to modeling rules
 *                         // ...
-*                         // Frees memory allocated by IoTHubClient_Properties_Parser_GetNext
-*                         IoTHubClient_Properties_ParsedProperty_Destroy(&deserializedProperty);
+*                         // Frees memory allocated by IoTHubClient_Properties_Reader_GetNext
+*                         IoTHubClient_Properties_ReaderProperty_Destroy(&deserializedProperty);
 *                     }
-*                     // Frees memory allocated by IoTHubClient_Properties_Parser_Create
-*                     IoTHubClient_Properties_Parser_Destroy(parserHandle);
+*                     // Frees memory allocated by IoTHubClient_Properties_Reader_Create
+*                     IoTHubClient_Properties_Reader_Destroy(readerHandle);
 *                   }
 */
 
@@ -95,7 +95,7 @@ typedef struct IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE_TAG {
     /** @brief Result of the requested operation.  This maps to an HTTP status code.  */
     int result;
     /** @brief Acknowledgement version.  This corresponds to the version of the writable properties being responded to. */
-    /** @details If using @p IoTHubClient_Properties_Parser_CreateIterator() to deserialize initial property request
+    /** @details If using @p IoTHubClient_Properties_Reader_Create() to deserialize initial property request
     *            from IoT Hub, just set this field to what was returned in @p propertiesVersion. */
     int ackVersion;
     /** @brief Optional friendly description of the operation.  May be NULL. */
@@ -158,7 +158,7 @@ typedef struct IOTHUB_CLIENT_PROPERTY_PARSED_TAG {
 *                                          component.
 * @param[out]  serializedProperties        Serialized output of @p properties for sending to IoT Hub.
 *                                          The application must release this memory using 
-*                                          IoTHubClient_Properties_Properties_Writer_Destroy().
+*                                          IoTHubClient_Properties_Writer_Destroy().
 *                                          Note: This is NOT a null-terminated string.
 * @param[out]  serializedPropertiesLength  Length of serializedProperties.
 *
@@ -183,7 +183,7 @@ MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Properties_Writer_CreateR
 *                                         default component.
 * @param[out]  serializedProperties       Serialized output of @p properties for sending to IoT Hub.
                                           The application must release this memory using 
-                                          IoTHubClient_Properties_Properties_Writer_Destroy().
+                                          IoTHubClient_Properties_Writer_Destroy().
 *                                         Note: This is NOT a null-terminated string.
 * @param[out]  serializedPropertiesLength Length of serializedProperties
 * 
@@ -211,76 +211,76 @@ MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Properties_Writer_CreateW
 *
 * @param[in]  serializedProperties Properties to free.
 */
-MOCKABLE_FUNCTION(, void, IoTHubClient_Properties_Properties_Writer_Destroy, unsigned char*, serializedProperties);
+MOCKABLE_FUNCTION(, void, IoTHubClient_Properties_Writer_Destroy, unsigned char*, serializedProperties);
 
-typedef struct IOTHUB_CLIENT_PROPERTY_ITERATOR_TAG* IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE;
+typedef struct IOTHUB_CLIENT_PROPERTIES_READER_TAG* IOTHUB_CLIENT_PROPERTIES_READER_HANDLE;
 
 /**
-* @brief   Setup an iterator to parse through Plug and Play properties recevied from IoT Hub.
+* @brief   Setup a reader handle to parse through Plug and Play properties received from IoT Hub.
 *
 * @param[in]  payloadType              Whether the payload is a full set of properties or only a set of updated 
 *                                      writable properties.
 * @param[in]  payload                  Payload containing properties from Azure IoT that is to be deserialized. 
 * @param[in]  payloadLength            Length of @p payload.
-* @param[out] propertyIteratorHandle   Returned handle used for subsequent iteration calls.
+* @param[out] propertiesReaderHandle   Returned handle used for subsequent iteration calls.
 * 
 * @remarks  Applications typically will invoke this API in their IOTHUB_CLIENT_PROPERTIES_RECEIVED_CALLBACK 
 *           implementation.  Many of the parameters this function takes should come directly from the 
 *           IOTHUB_CLIENT_PROPERTIES_RECEIVED_CALLBACK itself.
 *
-*           Applications must call @p IoTHubClient_Properties_Parser_Destroy() to free @p 
-*           propertyIteratorHandle on completion.
+*           Applications must call @p IoTHubClient_Properties_Reader_Destroy() to free @p 
+*           propertiesReaderHandle on completion.
 *
 * @return   IOTHUB_CLIENT_OK upon success or an error code upon failure.
 */
-MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Properties_Parser_Create,  IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE, payloadType, const unsigned char*, payload, size_t, payloadLength, IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE*, propertyIteratorHandle);
+MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Properties_Reader_Create,  IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE, payloadType, const unsigned char*, payload, size_t, payloadLength, IOTHUB_CLIENT_PROPERTIES_READER_HANDLE*, propertiesReaderHandle);
 
 /**
 * @brief   Retrieves the version associated with the properties payload.
 *
-* @param[in]   propertyIteratorHandle   Iteration handle returned by @p IoTHubClient_Properties_Parser_Create().
+* @param[in]   propertiesReaderHandle   Reader handle returned by @p IoTHubClient_Properties_Reader_Create().
 * @param[out]  propertiesVersion        Version of the writable properties received.  This is used when acknowledging a 
 *                                       writable property update.
 *
 * @return   IOTHUB_CLIENT_OK upon success or an error code upon failure.
 */
-MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Properties_Parser_GetVersion, IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE, propertyIteratorHandle, int*, propertiesVersion);
+MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Properties_Reader_GetVerion, IOTHUB_CLIENT_PROPERTIES_READER_HANDLE, propertiesReaderHandle, int*, propertiesVersion);
 
 /**
 * @brief   Gets the next property during iteration.
 *
-* @param[in]   propertyIteratorHandle   Iteration handle returned by @p IoTHubClient_Properties_Parser_Create().
+* @param[in]   propertiesReaderHandle   Reader handle returned by @p IoTHubClient_Properties_Reader_Create().
 * @param[out]  property                 @p IOTHUB_CLIENT_PROPERTY_PARSED containing a deserialized representation 
 *                                       of the properties.
 * @param[out]  propertySpecified        Returned value indicating whether a property was found or not.  If false, this 
 *                                       indicates all components have been iterated over.
 *
-* @remarks  Applications must call @p IoTHubClient_Properties_ParsedProperty_Destroy() to free the @p property returned by this call.
-*           The property structure becomes invalid after @p IoTHubClient_Properties_ParsedProperty_Destroy has been called.
+* @remarks  Applications must call @p IoTHubClient_Properties_ReaderProperty_Destroy() to free the @p property returned by this call.
+*           The property structure becomes invalid after @p IoTHubClient_Properties_ReaderProperty_Destroy has been called.
 *
 * @return   IOTHUB_CLIENT_OK upon success or an error code upon failure.
 */
-MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Properties_Parser_GetNext, IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE, propertyIteratorHandle, IOTHUB_CLIENT_PROPERTY_PARSED*, property, bool*, propertySpecified);
+MOCKABLE_FUNCTION(, IOTHUB_CLIENT_RESULT, IoTHubClient_Properties_Reader_GetNext, IOTHUB_CLIENT_PROPERTIES_READER_HANDLE, propertiesReaderHandle, IOTHUB_CLIENT_PROPERTY_PARSED*, property, bool*, propertySpecified);
 
 /**
-* @brief   Frees memory allocated by IoTHubClient_Properties_Parser_GetNext().
+* @brief   Frees memory allocated by IoTHubClient_Properties_Reader_GetNext().
 *
-* @param   property  IOTHUB_CLIENT_PROPERTY_PARSED initially allocated by IoTHubClient_Properties_Parser_Create() 
+* @param   property  IOTHUB_CLIENT_PROPERTY_PARSED initially allocated by IoTHubClient_Properties_Reader_Create() 
 *                    to be freed.
 * 
 */
-MOCKABLE_FUNCTION(, void, IoTHubClient_Properties_ParsedProperty_Destroy,  IOTHUB_CLIENT_PROPERTY_PARSED*, property);
+MOCKABLE_FUNCTION(, void, IoTHubClient_Properties_ReaderProperty_Destroy,  IOTHUB_CLIENT_PROPERTY_PARSED*, property);
 
 /**
-* @brief   Frees memory allocated by IoTHubClient_Properties_Parser_Create().
+* @brief   Frees memory allocated by IoTHubClient_Properties_Reader_Create().
 *
-* @param   propertyIteratorHandle   IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE initially allocated by @p 
-*                                   IoTHubClient_Properties_Parser_Create() to be freed.
-* @remarks After an application calls IoTHubClient_Properties_Parser_Destroy, any previous 
+* @param   propertiesReaderHandle   IOTHUB_CLIENT_PROPERTIES_READER_HANDLE initially allocated by @p 
+*                                   IoTHubClient_Properties_Reader_Create() to be freed.
+* @remarks After an application calls IoTHubClient_Properties_Reader_Destroy, any previous 
 *          IOTHUB_CLIENT_PROPERTY_PARSED structures that were retrieved via
-*          IoTHubClient_Properties_Parser_GetNext become invalid.
+*          IoTHubClient_Properties_Reader_GetNext become invalid.
 * 
 */
-MOCKABLE_FUNCTION(, void, IoTHubClient_Properties_Parser_Destroy, IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE, propertyIteratorHandle);
+MOCKABLE_FUNCTION(, void, IoTHubClient_Properties_Reader_Destroy, IOTHUB_CLIENT_PROPERTIES_READER_HANDLE, propertiesReaderHandle);
 
 #endif /* IOTHUB_CLIENT_PROPERTIES_H */

--- a/iothub_client/inc/iothub_device_client.h
+++ b/iothub_client/inc/iothub_device_client.h
@@ -414,8 +414,8 @@ extern "C"
     *
     * @param[in]  iotHubClientHandle            The handle created by a call to the create function.
     * @param[in]  properties                    Serialized property data to be sent to IoT Hub.  This buffer can either be
-    *                                           manually serialized created with IoTHubClient_Serialize_ReportedProperties() 
-    *                                           or IoTHubClient_Serialize_WritablePropertyResponse().
+    *                                           manually serialized created with IoTHubClient_Properties_Writer_CreateReported() 
+    *                                           or IoTHubClient_Properties_Writer_CreateWritableResponse().
     * @param[in]  propertiesLength              Number of bytes in the properties buffer.
     * @param[in]  propertyAcknowledgedCallback  Optional callback specified by the application to be called with the
     *                                           result of the transaction.

--- a/iothub_client/inc/iothub_device_client_ll.h
+++ b/iothub_client/inc/iothub_device_client_ll.h
@@ -441,8 +441,8 @@ typedef struct IOTHUB_CLIENT_CORE_LL_HANDLE_DATA_TAG* IOTHUB_DEVICE_CLIENT_LL_HA
     *
     * @param[in]  iotHubClientHandle           The handle created by a call to the create function.
     * @param[in]  properties                   Serialized property data to be sent to IoT Hub.  This buffer can either be
-    *                                          manually serialized created with IoTHubClient_Serialize_ReportedProperties() 
-    *                                          or IoTHubClient_Serialize_WritablePropertyResponse().
+    *                                          manually serialized created with IoTHubClient_Properties_Writer_CreateReported() 
+    *                                          or IoTHubClient_Properties_Writer_CreateWritableResponse().
     * @param[in]  propertiesLength             Number of bytes in the properties buffer.
     * @param[in]  propertyAcknowledgedCallback Optional callback specified by the application to be called with the
     *                                          result of the transaction.

--- a/iothub_client/inc/iothub_module_client.h
+++ b/iothub_client/inc/iothub_module_client.h
@@ -419,8 +419,8 @@ extern "C"
     *
     * @param[in]  iotHubModuleClientHandle     The handle created by a call to the create function.
     * @param[in]  properties                   Serialized property data to be sent to IoT Hub.  This buffer can either be
-    *                                          manually serialized created with IoTHubClient_Serialize_ReportedProperties() 
-    *                                          or IoTHubClient_Serialize_WritablePropertyResponse().
+    *                                          manually serialized created with IoTHubClient_Properties_Writer_CreateReported() 
+    *                                          or IoTHubClient_Properties_Writer_CreateWritableResponse().
     * @param[in]  propertiesLength             Number of bytes in the properties buffer.
     * @param[in]  propertyAcknowledgedCallback Optional callback specified by the application to be called with the
     *                                          result of the transaction.

--- a/iothub_client/inc/iothub_module_client_ll.h
+++ b/iothub_client/inc/iothub_module_client_ll.h
@@ -454,8 +454,8 @@ extern "C"
     *
     * @param[in]  iotHubModuleClientHandle     The handle created by a call to the create function.
     * @param[in]  properties                   Serialized property data to be sent to IoT Hub.  This buffer can either be
-    *                                          manually serialized created with IoTHubClient_Serialize_ReportedProperties() 
-    *                                          or IoTHubClient_Serialize_WritablePropertyResponse().
+    *                                          manually serialized created with IoTHubClient_Properties_Writer_CreateReported() 
+    *                                          or IoTHubClient_Properties_Writer_CreateWritableResponse().
     * @param[in]  propertiesLength             Number of bytes in the properties buffer.
     * @param[in]  propertyAcknowledgedCallback Optional callback specified by the application to be called with the
     *                                          result of the transaction.

--- a/iothub_client/samples/pnp/pnp_simple_thermostat/pnp_simple_thermostat.c
+++ b/iothub_client/samples/pnp/pnp_simple_thermostat/pnp_simple_thermostat.c
@@ -358,7 +358,7 @@ static void SendTargetTemperatureResponse(IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceC
     {
         LogInfo("Sending acknowledgement of property to IoTHub");
     }
-    IoTHubClient_Properties_Properties_Writer_Destroy(propertySerialized);
+    IoTHubClient_Properties_Writer_Destroy(propertySerialized);
 }
 
 //
@@ -397,7 +397,7 @@ static void SendMaxTemperatureSinceReboot(IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceC
         {
             LogInfo("Sending %s property to IoTHub for component", g_maxTempSinceLastRebootPropertyName);
         }
-        IoTHubClient_Properties_Properties_Writer_Destroy(propertySerialized);
+        IoTHubClient_Properties_Writer_Destroy(propertySerialized);
     }
 }
 
@@ -437,27 +437,27 @@ static void Thermostat_ProcessTargetTemperature(IOTHUB_DEVICE_CLIENT_LL_HANDLE d
 static void Thermostat_PropertiesCallback(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE payloadType,  const unsigned char* payload, size_t payloadLength, void* userContextCallback)
 {
     IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient = (IOTHUB_DEVICE_CLIENT_LL_HANDLE)userContextCallback;
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE propertyIterator = NULL;
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE propertiesReader = NULL;
     IOTHUB_CLIENT_PROPERTY_PARSED property;
     int propertiesVersion;
     IOTHUB_CLIENT_RESULT clientResult;
 
-    // The properties arrive as a raw JSON buffer (which is not null-terminated).  IoTHubClient_Properties_Parser_Create parses 
+    // The properties arrive as a raw JSON buffer (which is not null-terminated).  IoTHubClient_Properties_Reader_Create parses 
     // this into a more convenient form to allow property-by-property enumeration over the updated properties.
-    if ((clientResult = IoTHubClient_Properties_Parser_Create(payloadType, payload, payloadLength, &propertyIterator)) != IOTHUB_CLIENT_OK)
+    if ((clientResult = IoTHubClient_Properties_Reader_Create(payloadType, payload, payloadLength, &propertiesReader)) != IOTHUB_CLIENT_OK)
     {
         LogError("IoTHubClient_Deserialize_Properties failed, error=%d", clientResult);
     }
-    else if ((clientResult = IoTHubClient_Properties_Parser_GetVersion(propertyIterator, &propertiesVersion)) != IOTHUB_CLIENT_OK)
+    else if ((clientResult = IoTHubClient_Properties_Reader_GetVerion(propertiesReader, &propertiesVersion)) != IOTHUB_CLIENT_OK)
     {
-        LogError("IoTHubClient_Properties_Parser_GetVersion failed, error=%d", clientResult);
+        LogError("IoTHubClient_Properties_Reader_GetVerion failed, error=%d", clientResult);
     }
     else
     {
         bool propertySpecified;
         property.structVersion = IOTHUB_CLIENT_PROPERTY_PARSED_STRUCT_VERSION_1;
 
-        while ((clientResult = IoTHubClient_Properties_Parser_GetNext(propertyIterator, &property, &propertySpecified)) == IOTHUB_CLIENT_OK)
+        while ((clientResult = IoTHubClient_Properties_Reader_GetNext(propertiesReader, &property, &propertySpecified)) == IOTHUB_CLIENT_OK)
         {
             if (propertySpecified == false)
             {
@@ -493,11 +493,11 @@ static void Thermostat_PropertiesCallback(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE pa
                 LogError("Property %s is not part of the thermostat model and will be ignored", property.name);
             }
             
-            IoTHubClient_Properties_ParsedProperty_Destroy(&property);
+            IoTHubClient_Properties_ReaderProperty_Destroy(&property);
         }
     }
 
-    IoTHubClient_Properties_Parser_Destroy(propertyIterator);
+    IoTHubClient_Properties_Reader_Destroy(propertiesReader);
 }
 
 //

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_deviceinfo_component.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_deviceinfo_component.c
@@ -44,29 +44,29 @@ void PnP_DeviceInfoComponent_Report_All_Properties(const char* componentName, IO
     IOTHUB_CLIENT_RESULT iothubClientResult;
     unsigned char* propertiesSerialized = NULL;
     size_t propertiesSerializedLength;
-    IOTHUB_CLIENT_REPORTED_PROPERTY properties[] =  {
-        {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_SoftwareVersionPropertyName, PnPDeviceInfo_SoftwareVersionPropertyValue},
-        {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_ManufacturerPropertyName, PnPDeviceInfo_ManufacturerPropertyValue},
-        {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_ModelPropertyName, PnPDeviceInfo_ModelPropertyValue},
-        {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_OsNamePropertyName, PnPDeviceInfo_OsNamePropertyValue},
-        {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_ProcessorArchitecturePropertyName, PnPDeviceInfo_ProcessorArchitecturePropertyValue},
-        {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_ProcessorManufacturerPropertyName, PnPDeviceInfo_ProcessorManufacturerPropertyValue},
-        {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_TotalStoragePropertyName, PnPDeviceInfo_TotalStoragePropertyValue},
-        {IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, PnPDeviceInfo_TotalMemoryPropertyName, PnPDeviceInfo_TotalMemoryPropertyValue}
+    IOTHUB_CLIENT_PROPERTY_REPORTED properties[] =  {
+        {IOTHUB_CLIENT_PROPERTY_REPORTED_STRUCT_VERSION_1, PnPDeviceInfo_SoftwareVersionPropertyName, PnPDeviceInfo_SoftwareVersionPropertyValue},
+        {IOTHUB_CLIENT_PROPERTY_REPORTED_STRUCT_VERSION_1, PnPDeviceInfo_ManufacturerPropertyName, PnPDeviceInfo_ManufacturerPropertyValue},
+        {IOTHUB_CLIENT_PROPERTY_REPORTED_STRUCT_VERSION_1, PnPDeviceInfo_ModelPropertyName, PnPDeviceInfo_ModelPropertyValue},
+        {IOTHUB_CLIENT_PROPERTY_REPORTED_STRUCT_VERSION_1, PnPDeviceInfo_OsNamePropertyName, PnPDeviceInfo_OsNamePropertyValue},
+        {IOTHUB_CLIENT_PROPERTY_REPORTED_STRUCT_VERSION_1, PnPDeviceInfo_ProcessorArchitecturePropertyName, PnPDeviceInfo_ProcessorArchitecturePropertyValue},
+        {IOTHUB_CLIENT_PROPERTY_REPORTED_STRUCT_VERSION_1, PnPDeviceInfo_ProcessorManufacturerPropertyName, PnPDeviceInfo_ProcessorManufacturerPropertyValue},
+        {IOTHUB_CLIENT_PROPERTY_REPORTED_STRUCT_VERSION_1, PnPDeviceInfo_TotalStoragePropertyName, PnPDeviceInfo_TotalStoragePropertyValue},
+        {IOTHUB_CLIENT_PROPERTY_REPORTED_STRUCT_VERSION_1, PnPDeviceInfo_TotalMemoryPropertyName, PnPDeviceInfo_TotalMemoryPropertyValue}
     };
 
     const size_t numProperties = sizeof(properties) / sizeof(properties[0]);
 
-    // The first step of reporting properties is to serialize IOTHUB_CLIENT_REPORTED_PROPERTY into JSON for sending.
-    if ((iothubClientResult = IoTHubClient_Serialize_ReportedProperties(properties, numProperties, componentName, &propertiesSerialized, &propertiesSerializedLength)) != IOTHUB_CLIENT_OK)
+    // The first step of reporting properties is to serialize IOTHUB_CLIENT_PROPERTY_REPORTED into JSON for sending.
+    if ((iothubClientResult = IoTHubClient_Properties_Writer_CreateReported(properties, numProperties, componentName, &propertiesSerialized, &propertiesSerializedLength)) != IOTHUB_CLIENT_OK)
     {
         LogError("Unable to serialize reported state, error=%d", iothubClientResult);
     }
-    // The output of IoTHubClient_Serialize_ReportedProperties is sent to IoTHubDeviceClient_LL_SendPropertiesAsync to perform network I/O.
+    // The output of IoTHubClient_Properties_Writer_CreateReported is sent to IoTHubDeviceClient_LL_SendPropertiesAsync to perform network I/O.
     else if ((iothubClientResult = IoTHubDeviceClient_LL_SendPropertiesAsync(deviceClient, propertiesSerialized, propertiesSerializedLength, NULL, NULL)) != IOTHUB_CLIENT_OK)
     {
         LogError("Unable to send reported state, error=%d", iothubClientResult);
     }
 
-    IoTHubClient_Serialize_Properties_Destroy(propertiesSerialized);
+    IoTHubClient_Properties_Properties_Writer_Destroy(propertiesSerialized);
 }

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_deviceinfo_component.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_deviceinfo_component.c
@@ -68,5 +68,5 @@ void PnP_DeviceInfoComponent_Report_All_Properties(const char* componentName, IO
         LogError("Unable to send reported state, error=%d", iothubClientResult);
     }
 
-    IoTHubClient_Properties_Properties_Writer_Destroy(propertiesSerialized);
+    IoTHubClient_Properties_Writer_Destroy(propertiesSerialized);
 }

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_temperature_controller.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_temperature_controller.c
@@ -234,27 +234,27 @@ static void PnP_TempControlComponent_UpdatedPropertyCallback(
     void* userContextCallback)
 {
     IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient = (IOTHUB_DEVICE_CLIENT_LL_HANDLE)userContextCallback;
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE propertyIterator = NULL;
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE propertiesReader = NULL;
     IOTHUB_CLIENT_PROPERTY_PARSED property;
     int propertiesVersion;
     IOTHUB_CLIENT_RESULT clientResult;
 
-    // The properties arrive as a raw JSON buffer (which is not null-terminated).  IoTHubClient_Properties_Parser_Create parses 
+    // The properties arrive as a raw JSON buffer (which is not null-terminated).  IoTHubClient_Properties_Reader_Create parses 
     // this into a more convenient form to allow property-by-property enumeration over the updated properties.
-    if ((clientResult = IoTHubClient_Properties_Parser_Create(payloadType, payload, payloadLength, &propertyIterator)) != IOTHUB_CLIENT_OK)
+    if ((clientResult = IoTHubClient_Properties_Reader_Create(payloadType, payload, payloadLength, &propertiesReader)) != IOTHUB_CLIENT_OK)
     {
         LogError("IoTHubClient_Deserialize_Properties failed, error=%d", clientResult);
     }
-    else if ((clientResult = IoTHubClient_Properties_Parser_GetVersion(propertyIterator, &propertiesVersion)) != IOTHUB_CLIENT_OK)
+    else if ((clientResult = IoTHubClient_Properties_Reader_GetVerion(propertiesReader, &propertiesVersion)) != IOTHUB_CLIENT_OK)
     {
-        LogError("IoTHubClient_Properties_Parser_GetVersion failed, error=%d", clientResult);
+        LogError("IoTHubClient_Properties_Reader_GetVerion failed, error=%d", clientResult);
     }
     else
     {
         bool propertySpecified;
         property.structVersion = IOTHUB_CLIENT_PROPERTY_PARSED_STRUCT_VERSION_1;
 
-        while ((clientResult = IoTHubClient_Properties_Parser_GetNext(propertyIterator, &property, &propertySpecified)) == IOTHUB_CLIENT_OK)
+        while ((clientResult = IoTHubClient_Properties_Reader_GetNext(propertiesReader, &property, &propertySpecified)) == IOTHUB_CLIENT_OK)
         {
             if (propertySpecified == false)
             {
@@ -295,11 +295,11 @@ static void PnP_TempControlComponent_UpdatedPropertyCallback(
                 LogError("Component %s is not implemented by the TemperatureController", property.componentName);
             }
             
-            IoTHubClient_Properties_ParsedProperty_Destroy(&property);
+            IoTHubClient_Properties_ReaderProperty_Destroy(&property);
         }
     }
 
-    IoTHubClient_Properties_Parser_Destroy(propertyIterator);
+    IoTHubClient_Properties_Reader_Destroy(propertiesReader);
 }
 
 //
@@ -365,7 +365,7 @@ static void PnP_TempControlComponent_ReportSerialNumber_Property(IOTHUB_DEVICE_C
         LogError("Unable to send reported state, error=%d", clientResult);
     }
 
-    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
+    IoTHubClient_Properties_Writer_Destroy(serializedProperties);
 }
 
 //

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.c
@@ -300,7 +300,7 @@ static void SendTargetTemperatureResponse(PNP_THERMOSTAT_COMPONENT* pnpThermosta
     {
         LogInfo("Sending acknowledgement of property to IoTHub for component %s", pnpThermostatComponent->componentName);
     }
-    IoTHubClient_Properties_Properties_Writer_Destroy(propertySerialized);
+    IoTHubClient_Properties_Writer_Destroy(propertySerialized);
 }
 
 void PnP_TempControlComponent_Report_MaxTempSinceLastReboot_Property(PNP_THERMOSTAT_COMPONENT_HANDLE pnpThermostatComponentHandle, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient)
@@ -337,7 +337,7 @@ void PnP_TempControlComponent_Report_MaxTempSinceLastReboot_Property(PNP_THERMOS
         {
             LogInfo("Sending %s property to IoTHub for component %s", g_maxTempSinceLastRebootPropertyName, pnpThermostatComponent->componentName);
         }
-        IoTHubClient_Properties_Properties_Writer_Destroy(propertySerialized);
+        IoTHubClient_Properties_Writer_Destroy(propertySerialized);
     }
 }
 

--- a/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.c
+++ b/iothub_client/samples/pnp/pnp_temperature_controller/pnp_thermostat_component.c
@@ -268,11 +268,11 @@ static void SendTargetTemperatureResponse(PNP_THERMOSTAT_COMPONENT* pnpThermosta
 {
     IOTHUB_CLIENT_RESULT iothubClientResult;
 
-    // IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE in this case specifies the response to a desired temperature.
-    IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE temperatureProperty;
+    // IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE in this case specifies the response to a desired temperature.
+    IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE temperatureProperty;
     memset(&temperatureProperty, 0, sizeof(temperatureProperty));
     // Specify the structure version (not to be confused with the $version on IoT Hub) to protect back-compat in case the structure adds fields.
-    temperatureProperty.structVersion= IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE_STRUCT_VERSION_1;
+    temperatureProperty.structVersion= IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE_STRUCT_VERSION_1;
     // This represents the version of the request from IoT Hub.  It needs to be returned so service applications can determine
     // what current version of the writable property the device is currently using, as the server may update the property even when the device
     // is offline.
@@ -286,12 +286,12 @@ static void SendTargetTemperatureResponse(PNP_THERMOSTAT_COMPONENT* pnpThermosta
     unsigned char* propertySerialized = NULL;
     size_t propertySerializedLength;
 
-    // The first step of reporting properties is to serialize IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE into JSON for sending.
-    if ((iothubClientResult = IoTHubClient_Serialize_WritablePropertyResponse(&temperatureProperty, 1, pnpThermostatComponent->componentName, &propertySerialized, &propertySerializedLength)) != IOTHUB_CLIENT_OK)
+    // The first step of reporting properties is to serialize IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE into JSON for sending.
+    if ((iothubClientResult = IoTHubClient_Properties_Writer_CreateWritableResponse(&temperatureProperty, 1, pnpThermostatComponent->componentName, &propertySerialized, &propertySerializedLength)) != IOTHUB_CLIENT_OK)
     {
         LogError("Unable to serialize updated property, error=%d", iothubClientResult);
     }
-    // The output of IoTHubClient_Serialize_WritablePropertyResponse is sent to IoTHubDeviceClient_LL_SendPropertiesAsync to perform network I/O.
+    // The output of IoTHubClient_Properties_Writer_CreateWritableResponse is sent to IoTHubDeviceClient_LL_SendPropertiesAsync to perform network I/O.
     else if ((iothubClientResult = IoTHubDeviceClient_LL_SendPropertiesAsync(deviceClient, propertySerialized, propertySerializedLength, NULL, NULL)) != IOTHUB_CLIENT_OK)
     {
         LogError("Unable to send updated property, error=%d", iothubClientResult);
@@ -300,7 +300,7 @@ static void SendTargetTemperatureResponse(PNP_THERMOSTAT_COMPONENT* pnpThermosta
     {
         LogInfo("Sending acknowledgement of property to IoTHub for component %s", pnpThermostatComponent->componentName);
     }
-    IoTHubClient_Serialize_Properties_Destroy(propertySerialized);
+    IoTHubClient_Properties_Properties_Writer_Destroy(propertySerialized);
 }
 
 void PnP_TempControlComponent_Report_MaxTempSinceLastReboot_Property(PNP_THERMOSTAT_COMPONENT_HANDLE pnpThermostatComponentHandle, IOTHUB_DEVICE_CLIENT_LL_HANDLE deviceClient)
@@ -315,20 +315,20 @@ void PnP_TempControlComponent_Report_MaxTempSinceLastReboot_Property(PNP_THERMOS
     }
     else
     {
-        IOTHUB_CLIENT_REPORTED_PROPERTY maxTempProperty;
-        maxTempProperty.structVersion = IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1;
+        IOTHUB_CLIENT_PROPERTY_REPORTED maxTempProperty;
+        maxTempProperty.structVersion = IOTHUB_CLIENT_PROPERTY_REPORTED_STRUCT_VERSION_1;
         maxTempProperty.name = g_maxTempSinceLastRebootPropertyName;
         maxTempProperty.value =  maximumTemperatureAsString;
 
         unsigned char* propertySerialized = NULL;
         size_t propertySerializedLength;
 
-        // The first step of reporting properties is to serialize IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE into JSON for sending.
-        if ((iothubClientResult = IoTHubClient_Serialize_ReportedProperties(&maxTempProperty, 1, pnpThermostatComponent->componentName, &propertySerialized, &propertySerializedLength)) != IOTHUB_CLIENT_OK)
+        // The first step of reporting properties is to serialize IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE into JSON for sending.
+        if ((iothubClientResult = IoTHubClient_Properties_Writer_CreateReported(&maxTempProperty, 1, pnpThermostatComponent->componentName, &propertySerialized, &propertySerializedLength)) != IOTHUB_CLIENT_OK)
         {
             LogError("Unable to serialize reported state, error=%d", iothubClientResult);
         }
-        // The output of IoTHubClient_Serialize_ReportedProperties is sent to IoTHubDeviceClient_LL_SendPropertiesAsync to perform network I/O.
+        // The output of IoTHubClient_Properties_Writer_CreateReported is sent to IoTHubDeviceClient_LL_SendPropertiesAsync to perform network I/O.
         else if ((iothubClientResult = IoTHubDeviceClient_LL_SendPropertiesAsync(deviceClient, propertySerialized, propertySerializedLength,  NULL, NULL)) != IOTHUB_CLIENT_OK)
         {
             LogError("Unable to send reported state, error=%d", iothubClientResult);
@@ -337,7 +337,7 @@ void PnP_TempControlComponent_Report_MaxTempSinceLastReboot_Property(PNP_THERMOS
         {
             LogInfo("Sending %s property to IoTHub for component %s", g_maxTempSinceLastRebootPropertyName, pnpThermostatComponent->componentName);
         }
-        IoTHubClient_Serialize_Properties_Destroy(propertySerialized);
+        IoTHubClient_Properties_Properties_Writer_Destroy(propertySerialized);
     }
 }
 

--- a/iothub_client/src/iothub_client_dll.def
+++ b/iothub_client/src/iothub_client_dll.def
@@ -167,13 +167,14 @@ EXPORTS
     IoTHubMessage_SetAsSecurityMessage
     IoTHubMessage_IsSecurityMessage
 
-    IoTHubClient_Serialize_ReportedProperties
-    IoTHubClient_Serialize_WritablePropertyResponse
-    IoTHubClient_Deserialize_Properties_CreateIterator
-    IoTHubClient_Deserialize_Properties_GetVersion
-    IoTHubClient_Deserialize_Properties_GetNextProperty
-    IoTHubClient_Deserialize_Properties_DestroyProperty
-    IoTHubClient_Deserialize_Properties_DestroyIterator
+    IoTHubClient_Properties_Writer_CreateReported
+    IoTHubClient_Properties_Writer_CreateWritableResponse
+    IoTHubClient_Properties_Properties_Writer_Destroy
+    IoTHubClient_Properties_Parser_Create
+    IoTHubClient_Properties_Parser_GetVersion
+    IoTHubClient_Properties_Parser_GetNext
+    IoTHubClient_Properties_ParsedProperty_Destroy
+    IoTHubClient_Properties_Parser_Destroy
  
     IOTHUB_CLIENT_CONFIRMATION_RESULTStrings
     IOTHUB_CLIENT_FILE_UPLOAD_RESULTStrings

--- a/iothub_client/src/iothub_client_dll.def
+++ b/iothub_client/src/iothub_client_dll.def
@@ -169,12 +169,12 @@ EXPORTS
 
     IoTHubClient_Properties_Writer_CreateReported
     IoTHubClient_Properties_Writer_CreateWritableResponse
-    IoTHubClient_Properties_Properties_Writer_Destroy
-    IoTHubClient_Properties_Parser_Create
-    IoTHubClient_Properties_Parser_GetVersion
-    IoTHubClient_Properties_Parser_GetNext
-    IoTHubClient_Properties_ParsedProperty_Destroy
-    IoTHubClient_Properties_Parser_Destroy
+    IoTHubClient_Properties_Writer_Destroy
+    IoTHubClient_Properties_Reader_Create
+    IoTHubClient_Properties_Reader_GetVerion
+    IoTHubClient_Properties_Reader_GetNext
+    IoTHubClient_Properties_ReaderProperty_Destroy
+    IoTHubClient_Properties_Reader_Destroy
  
     IOTHUB_CLIENT_CONFIRMATION_RESULTStrings
     IOTHUB_CLIENT_FILE_UPLOAD_RESULTStrings

--- a/iothub_client/tests/iothub_client_properties_ut/iothub_client_properties_ut.c
+++ b/iothub_client/tests/iothub_client_properties_ut/iothub_client_properties_ut.c
@@ -121,7 +121,7 @@ static const int TEST_DEFAULT_PROPERTIES_VERSION = 119;
 //
 // The tests make extensive use of macros to build up test JSON, both the expected results 
 // of serialization APIs such as IoTHubClient_Properties_Writer_CreateReported and the test
-// data for IoTHubClient_Properties_Parser_Create.
+// data for IoTHubClient_Properties_Reader_Create.
 //
 
 // BUILD_JSON_NAME_VALUE creates a JSON style "name": value with required C escaping of all this.
@@ -256,7 +256,7 @@ static const IOTHUB_CLIENT_PROPERTY_PARSED TEST_EXPECTED_PROPERTY6 = {
     (sizeof(TEST_PROP_VALUE6) / sizeof(TEST_PROP_VALUE6[0]) - 1)
 };
 
-// For error cases, make sure IoTHubClient_Properties_Parser_GetNext does not change any members
+// For error cases, make sure IoTHubClient_Properties_Reader_GetNext does not change any members
 // of the passed in structure
 static IOTHUB_CLIENT_PROPERTY_PARSED unfilledProperty = {
     IOTHUB_CLIENT_PROPERTY_PARSED_STRUCT_VERSION_1,
@@ -269,7 +269,7 @@ static IOTHUB_CLIENT_PROPERTY_PARSED unfilledProperty = {
 };
 
 //
-// JSON to be used as input during tests to IoTHubClient_Properties_Parser_Create/IoTHubClient_Properties_Parser_GetNext.
+// JSON to be used as input during tests to IoTHubClient_Properties_Reader_Create/IoTHubClient_Properties_Reader_GetNext.
 // 
 // Builds up the most common name / value pairs so they're more convenient for later use.  
 // For instance, TEST_JSON_NAME_VALUE1, after preprocessing, turns into "name1":1234
@@ -303,7 +303,7 @@ static IOTHUB_CLIENT_PROPERTY_PARSED unfilledProperty = {
 #define TEST_JSON_COMPONENT1_NAME_VALUE4_5 TEST_COMPONENT_JSON(TEST_COMPONENT_NAME_4, TEST_JSON_NAME_VALUE4_5)
 #define TEST_JSON_COMPONENT1_NAME_VALUE4_5_6 TEST_COMPONENT_JSON(TEST_COMPONENT_NAME_4, TEST_JSON_NAME_VALUE4_5_6)
 
-// Build up the actual JSON for IoTHubClient_Properties_Parser_Create/IoTHubClient_Properties_Parser_GetNext tests.
+// Build up the actual JSON for IoTHubClient_Properties_Reader_Create/IoTHubClient_Properties_Reader_GetNext tests.
 static unsigned const char TEST_JSON_ONE_PROPERTY_ALL[] = TEST_BUILD_DESIRED_ALL(TEST_JSON_NAME_VALUE1, TEST_JSON_TWIN_VER_1);
 static const size_t TEST_JSON_ONE_PROPERTY_ALL_LEN = sizeof(TEST_JSON_ONE_PROPERTY_ALL) - 1;
 static unsigned const char TEST_JSON_ONE_PROPERTY_WRITABLE[] = TEST_BUILD_DESIRED_UPDATE(TEST_JSON_NAME_VALUE1, TEST_JSON_TWIN_VER_2);
@@ -339,12 +339,12 @@ static unsigned const char TEST_JSON_THREE_REPORTED_PROPERTIES_THREE_COMPONENTS_
 // This tests 3 reported properties, 3 writable, each in a separate component.
 static unsigned const char TEST_JSON_THREE_WRITABLE_REPORTED_IN_SEPARATE_COMPONENTS[] = TEST_BUILD_REPORTED_AND_DESIRED(TEST_JSON_ALL_REPORTED, TEST_JSON_ALL_WRITABLE, TEST_JSON_TWIN_VER_1);
 
-// Invalid JSON.  IoTHubClient_Properties_Parser_Create will fail trying to deserialize this.
+// Invalid JSON.  IoTHubClient_Properties_Reader_Create will fail trying to deserialize this.
 static unsigned const char TEST_INVALID_JSON[] = "}{-not-valid";
-// Legal JSON but no $version.  IoTHubClient_Properties_Parser_Create will fail trying to deserialize this.
+// Legal JSON but no $version.  IoTHubClient_Properties_Reader_Create will fail trying to deserialize this.
 static unsigned const char TEST_JSON_NO_VERSION[] = "44";
-// Legal JSON including $version, but for an "all properties" json its missing the desired.  IoTHubClient_Properties_Parser_Create 
-// will succeed but IoTHubClient_Properties_Parser_GetNext won't have anything to enumerate.
+// Legal JSON including $version, but for an "all properties" json its missing the desired.  IoTHubClient_Properties_Reader_Create 
+// will succeed but IoTHubClient_Properties_Reader_GetNext won't have anything to enumerate.
 static unsigned const char TEST_JSON_NO_DESIRED[] = "{ " TEST_JSON_TWIN_VER_1 " }";
 
 BEGIN_TEST_SUITE(iothub_client_properties_ut)
@@ -530,7 +530,7 @@ TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_one_property_success
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
+    IoTHubClient_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_two_properties_success)
@@ -553,7 +553,7 @@ TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_two_properties_succe
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
+    IoTHubClient_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_three_properties_success)
@@ -576,7 +576,7 @@ TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_three_properties_suc
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
+    IoTHubClient_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_one_property_with_component_success)
@@ -597,7 +597,7 @@ TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_one_property_with_co
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
+    IoTHubClient_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_two_properties_with_component_success)
@@ -620,7 +620,7 @@ TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_two_properties_with_
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
+    IoTHubClient_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_three_properties_with_component_success)
@@ -643,7 +643,7 @@ TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_three_properties_wit
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
+    IoTHubClient_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_fail)
@@ -802,7 +802,7 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_one_property_success)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
+    IoTHubClient_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_one_property_with_description_success)
@@ -823,7 +823,7 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_one_property_with_descri
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
+    IoTHubClient_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_two_properties_success)
@@ -846,7 +846,7 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_two_properties_success)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
+    IoTHubClient_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_three_properties_success)
@@ -869,7 +869,7 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_three_properties_success
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
+    IoTHubClient_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_one_property_with_component_success)
@@ -890,7 +890,7 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_one_property_with_compon
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
+    IoTHubClient_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_one_property_with_description_with_component_success)
@@ -911,7 +911,7 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_one_property_with_descri
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
+    IoTHubClient_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_two_properties_with_component_success)
@@ -934,7 +934,7 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_two_properties_with_comp
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
+    IoTHubClient_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_three_properties_with_component_success)
@@ -957,7 +957,7 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_three_properties_with_co
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
+    IoTHubClient_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_fail)
@@ -994,14 +994,14 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_fail)
 }
 
 //
-// IoTHubClient_Properties_Properties_Writer_Destroy tests
+// IoTHubClient_Properties_Writer_Destroy tests
 // 
-static void set_expected_calls_for_IoTHubClient_Properties_Properties_Writer_Destroy(void)
+static void set_expected_calls_for_IoTHubClient_Properties_Writer_Destroy(void)
 {
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Properties_Writer_Destroy_success)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_Destroy_success)
 {
     // arrange
     unsigned char* serializedProperties = NULL;
@@ -1012,28 +1012,28 @@ TEST_FUNCTION(IoTHubClient_Properties_Properties_Writer_Destroy_success)
     ASSERT_IS_NOT_NULL(serializedPropertiesLength);
 
     umock_c_reset_all_calls();
-    set_expected_calls_for_IoTHubClient_Properties_Properties_Writer_Destroy();
+    set_expected_calls_for_IoTHubClient_Properties_Writer_Destroy();
 
     // act
-    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
+    IoTHubClient_Properties_Writer_Destroy(serializedProperties);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Properties_Writer_Destroy_null)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_Destroy_null)
 {
     // act
-    IoTHubClient_Properties_Properties_Writer_Destroy(NULL);
+    IoTHubClient_Properties_Writer_Destroy(NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
 //
-// IoTHubClient_Properties_Parser_Create tests
+// IoTHubClient_Properties_Reader_Create tests
 //
-static void set_expected_calls_for_IoTHubClient_Properties_Parser_Create(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE payloadType)
+static void set_expected_calls_for_IoTHubClient_Properties_Reader_Create(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE payloadType)
 {
     STRICT_EXPECTED_CALL(gballoc_calloc(IGNORED_NUM_ARG, IGNORED_NUM_ARG));
     STRICT_EXPECTED_CALL(gballoc_calloc(IGNORED_NUM_ARG, IGNORED_NUM_ARG));
@@ -1049,15 +1049,15 @@ static void set_expected_calls_for_IoTHubClient_Properties_Parser_Create(IOTHUB_
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 }
 
-static IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE payloadType, const unsigned char* payload)
+static IOTHUB_CLIENT_PROPERTIES_READER_HANDLE TestAllocatePropertiesReader(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE payloadType, const unsigned char* payload)
 {
     umock_c_reset_all_calls();
 
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = NULL;
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = NULL;
     size_t payloadLength = strlen((const char*)payload);
-    set_expected_calls_for_IoTHubClient_Properties_Parser_Create(payloadType);
+    set_expected_calls_for_IoTHubClient_Properties_Reader_Create(payloadType);
 
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_Create(payloadType, payload, payloadLength, &h);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Reader_Create(payloadType, payload, payloadLength, &h);
 
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
     ASSERT_IS_NOT_NULL(h);
@@ -1068,131 +1068,131 @@ static IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE TestAllocatePropertyIterator(IOTHU
     return h;
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_invalid_payload_type)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_Create_invalid_payload_type)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = NULL;
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = NULL;
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_Create((IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE)1234, TEST_JSON_ONE_PROPERTY_ALL, TEST_JSON_ONE_PROPERTY_ALL_LEN,  &h);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Reader_Create((IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE)1234, TEST_JSON_ONE_PROPERTY_ALL, TEST_JSON_ONE_PROPERTY_ALL_LEN,  &h);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
     ASSERT_IS_NULL(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_NULL_payload)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_Create_NULL_payload)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = NULL;
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = NULL;
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_Create(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, NULL, TEST_JSON_ONE_PROPERTY_ALL_LEN, &h);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Reader_Create(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, NULL, TEST_JSON_ONE_PROPERTY_ALL_LEN, &h);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
     ASSERT_IS_NULL(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_zero_payloadLength)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_Create_zero_payloadLength)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = NULL;
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = NULL;
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_Create(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL, 0, &h);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Reader_Create(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL, 0, &h);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
     ASSERT_IS_NULL(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_NULL_handle)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_Create_NULL_handle)
 {
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_Create(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL, TEST_JSON_ONE_PROPERTY_ALL_LEN, NULL);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Reader_Create(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL, TEST_JSON_ONE_PROPERTY_ALL_LEN, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_all_success)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_Create_all_success)
 {
     // act
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = TestAllocatePropertiesReader(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
 
     // cleanup
-    IoTHubClient_Properties_Parser_Destroy(h);
+    IoTHubClient_Properties_Reader_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_all_with_components_success)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_Create_all_with_components_success)
 {
     // act
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = TestAllocatePropertiesReader(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
 
     // cleanup
-    IoTHubClient_Properties_Parser_Destroy(h);
+    IoTHubClient_Properties_Reader_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_writable_success)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_Create_writable_success)
 {
     // act
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_WRITABLE);
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = TestAllocatePropertiesReader(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_WRITABLE);
 
     // cleanup
-    IoTHubClient_Properties_Parser_Destroy(h);
+    IoTHubClient_Properties_Reader_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_no_properties_success)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_Create_no_properties_success)
 {
     // act
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_NO_DESIRED);
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = TestAllocatePropertiesReader(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_NO_DESIRED);
 
     // cleanup
-    IoTHubClient_Properties_Parser_Destroy(h);
+    IoTHubClient_Properties_Reader_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_writable_with_components_success)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_Create_writable_with_components_success)
 {
     // act
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_WRITABLE);
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = TestAllocatePropertiesReader(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_WRITABLE);
 
     // cleanup
-    IoTHubClient_Properties_Parser_Destroy(h);
+    IoTHubClient_Properties_Reader_Destroy(h);
 }
 
-static void test_IoTHubClient_Properties_Parser_Create_invalid_json(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE payloadType, const unsigned char* invalidJson)
+static void test_IoTHubClient_Properties_Reader_Create_invalid_json(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE payloadType, const unsigned char* invalidJson)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = NULL;
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = NULL;
     size_t invalidJsonLen = strlen((const char*)invalidJson);
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_Create(payloadType, invalidJson, invalidJsonLen, &h);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Reader_Create(payloadType, invalidJson, invalidJsonLen, &h);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_ERROR, result);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_writable_invalid_JSON_fail)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_Create_writable_invalid_JSON_fail)
 {
-    test_IoTHubClient_Properties_Parser_Create_invalid_json(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_INVALID_JSON);
+    test_IoTHubClient_Properties_Reader_Create_invalid_json(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_INVALID_JSON);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_writable_missing_version_fail)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_Create_writable_missing_version_fail)
 {
-    test_IoTHubClient_Properties_Parser_Create_invalid_json(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_NO_VERSION);
+    test_IoTHubClient_Properties_Reader_Create_invalid_json(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_NO_VERSION);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_fail)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_Create_fail)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = NULL;
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = NULL;
 
     int negativeTestsInitResult = umock_c_negative_tests_init();
     ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
-    set_expected_calls_for_IoTHubClient_Properties_Parser_Create(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL);
+    set_expected_calls_for_IoTHubClient_Properties_Reader_Create(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL);
     umock_c_negative_tests_snapshot();
 
     // act
@@ -1204,7 +1204,7 @@ TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_fail)
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
 
-            IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_Create(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL, TEST_JSON_ONE_PROPERTY_ALL_LEN, &h);
+            IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Reader_Create(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL, TEST_JSON_ONE_PROPERTY_ALL_LEN, &h);
 
             //assert
             ASSERT_ARE_NOT_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -1214,15 +1214,15 @@ TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_fail)
 }
 
 //
-// IoTHubClient_Properties_Parser_GetVersion tests
+// IoTHubClient_Properties_Reader_GetVerion tests
 //
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetVersion_NULL_handle)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetVerion_NULL_handle)
 {
     // arrange
     int propertiesVersion = TEST_DEFAULT_PROPERTIES_VERSION;
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetVersion(NULL, &propertiesVersion);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Reader_GetVerion(NULL, &propertiesVersion);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
@@ -1230,55 +1230,55 @@ TEST_FUNCTION(IoTHubClient_Properties_Parser_GetVersion_NULL_handle)
     ASSERT_ARE_EQUAL(int, TEST_DEFAULT_PROPERTIES_VERSION, propertiesVersion);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetVersion_NULL_version)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetVerion_NULL_version)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_WRITABLE);
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = TestAllocatePropertiesReader(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_WRITABLE);
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetVersion(h, NULL);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Reader_GetVerion(h, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
 
     // cleanup
-    IoTHubClient_Properties_Parser_Destroy(h);    
+    IoTHubClient_Properties_Reader_Destroy(h);    
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetVersion_writable_update_success)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetVerion_writable_update_success)
 {
     // arrange
     int propertiesVersion;
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_WRITABLE);
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = TestAllocatePropertiesReader(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_WRITABLE);
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetVersion(h, &propertiesVersion);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Reader_GetVerion(h, &propertiesVersion);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
     ASSERT_ARE_EQUAL(int, TEST_TWIN_VER_2, propertiesVersion);
 
     // cleanup
-    IoTHubClient_Properties_Parser_Destroy(h);
+    IoTHubClient_Properties_Reader_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetVersion_full_twin_success)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetVerion_full_twin_success)
 {
     // arrange
     int propertiesVersion;
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = TestAllocatePropertiesReader(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetVersion(h, &propertiesVersion);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Reader_GetVerion(h, &propertiesVersion);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
     ASSERT_ARE_EQUAL(int, TEST_TWIN_VER_1, propertiesVersion);
 
     // cleanup
-    IoTHubClient_Properties_Parser_Destroy(h);
+    IoTHubClient_Properties_Reader_Destroy(h);
 }
 
 //
-// IoTHubClient_Properties_Parser_GetNext tests
+// IoTHubClient_Properties_Reader_GetNext tests
 //
 static void ResetTestProperty(IOTHUB_CLIENT_PROPERTY_PARSED* property)
 {
@@ -1300,7 +1300,7 @@ static void CompareProperties(const IOTHUB_CLIENT_PROPERTY_PARSED* expectedPrope
 static void TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE payloadType, const unsigned char* payload, const IOTHUB_CLIENT_PROPERTY_PARSED* expectedProperties, size_t numExpectedProperties)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(payloadType, payload);
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = TestAllocatePropertiesReader(payloadType, payload);
     size_t numPropertiesVisited = 0;
 
     // act|assert
@@ -1311,7 +1311,7 @@ static void TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE paylo
         bool propertySpecified;
         ResetTestProperty(&property);
 
-        IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetNext(h, &property, &propertySpecified);
+        IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Reader_GetNext(h, &property, &propertySpecified);
         ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
 
         if (numPropertiesVisited == numExpectedProperties)
@@ -1325,15 +1325,15 @@ static void TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE paylo
 
         CompareProperties(expectedProperties + numPropertiesVisited, &property);
 
-        IoTHubClient_Properties_ParsedProperty_Destroy(&property);
+        IoTHubClient_Properties_ReaderProperty_Destroy(&property);
         numPropertiesVisited++;
     }
 
     // cleanup
-    IoTHubClient_Properties_Parser_Destroy(h);
+    IoTHubClient_Properties_Reader_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_NULL_handle)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_NULL_handle)
 {
     // arrange
     IOTHUB_CLIENT_PROPERTY_PARSED property;
@@ -1341,7 +1341,7 @@ TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_NULL_handle)
     bool propertySpecified = false;
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetNext(NULL, &property, &propertySpecified);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Reader_GetNext(NULL, &property, &propertySpecified);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
@@ -1349,45 +1349,45 @@ TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_NULL_handle)
     CompareProperties(&unfilledProperty, &property);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_NULL_property)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_NULL_property)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = TestAllocatePropertiesReader(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
     bool propertySpecified = false;
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetNext(h, NULL, &propertySpecified);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Reader_GetNext(h, NULL, &propertySpecified);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
     ASSERT_IS_FALSE(propertySpecified);
 
     // cleanup
-    IoTHubClient_Properties_Parser_Destroy(h);
+    IoTHubClient_Properties_Reader_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_NULL_propertySpecified)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_NULL_propertySpecified)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = TestAllocatePropertiesReader(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
     IOTHUB_CLIENT_PROPERTY_PARSED property;
     ResetTestProperty(&property);
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetNext(h, &property, NULL);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Reader_GetNext(h, &property, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
     CompareProperties(&unfilledProperty, &property);
 
     // cleanup
-    IoTHubClient_Properties_Parser_Destroy(h);
+    IoTHubClient_Properties_Reader_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_wrong_struct_version)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_wrong_struct_version)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = TestAllocatePropertiesReader(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
     IOTHUB_CLIENT_PROPERTY_PARSED wrongVersion;
     IOTHUB_CLIENT_PROPERTY_PARSED property;
     bool propertySpecified = false;
@@ -1397,111 +1397,111 @@ TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_wrong_struct_version)
     memcpy(&property, &wrongVersion, sizeof(property));
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetNext(h, &property, &propertySpecified);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Reader_GetNext(h, &property, &propertySpecified);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
-    // Make sure IoTHubClient_Properties_Parser_GetNext didn't modify property in error case
+    // Make sure IoTHubClient_Properties_Reader_GetNext didn't modify property in error case
     ASSERT_IS_TRUE(0 == memcmp(&wrongVersion, &property, sizeof(property)));
     ASSERT_IS_FALSE(propertySpecified);
 
     // cleanup
-    IoTHubClient_Properties_Parser_Destroy(h);
+    IoTHubClient_Properties_Reader_Destroy(h);
 }
 
 // Test only to just skip STRICT_EXPECT work
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_all_one_property_success)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_all_one_property_success)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL, expectedPropList, 1);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_writable_one_property_success)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_writable_one_property_success)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_WRITABLE, expectedPropList, 1);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_no_properties_success)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_no_properties_success)
 {
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_NO_DESIRED, NULL, 0);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_all_two_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_all_two_properties)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_TWO_PROPERTIES_ALL, expectedPropList, 2);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_writable_two_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_writable_two_properties)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_TWO_PROPERTIES_WRITABLE, expectedPropList, 2);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_all_three_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_all_three_properties)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY3 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_THREE_PROPERTIES_ALL, expectedPropList, 3);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_writable_three_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_writable_three_properties)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY3 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_THREE_PROPERTIES_WRITABLE, expectedPropList, 3);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_reported_one_property)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_reported_one_property)
 {
      IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY4 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_REPORTED_PROPERTY_ALL, expectedPropList, 1);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_reported_two_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_reported_two_properties)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_TWO_REPORTED_PROPERTIES_ALL, expectedPropList, 2);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_reported_three_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_reported_three_properties)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5, TEST_EXPECTED_PROPERTY6 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_THREE_REPORTED_PROPERTIES_ALL, expectedPropList, 3);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_one_reported_update_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_one_reported_update_properties)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY4  };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_REPORTED_UPDATE_PROPERTY_ALL, expectedPropList, 2);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_two_reported_update_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_two_reported_update_properties)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_TWO_REPORTED_UPDATE_PROPERTIES_ALL, expectedPropList, 4);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_reported_update_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_three_reported_update_properties)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY3, TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5, TEST_EXPECTED_PROPERTY6 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_THREE_REPORTED_UPDATE_PROPERTIES_ALL, expectedPropList, 6);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_one_writable_all_component)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_one_writable_all_component)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1 };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_1;
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_COMPONENT_ALL, expectedPropList, 1);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_one_writable_update_component)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_one_writable_update_component)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1 };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_1;
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_COMPONENT_WRITABLE, expectedPropList, 1);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_two_writable_all_component)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_two_writable_all_component)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2  };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_1;
@@ -1509,7 +1509,7 @@ TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_two_writable_all_component)
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_TWO_PROPERTIES_COMPONENT_ALL, expectedPropList, 2);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_writable_all_component)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_three_writable_all_component)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY3  };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_1;
@@ -1518,14 +1518,14 @@ TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_writable_all_componen
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_THREE_PROPERTIES_COMPONENT_ALL, expectedPropList, 3);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_one_reported_all_component)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_one_reported_all_component)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY4 };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_4;
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_REPORTED_PROPERTY_COMPONENT_ALL, expectedPropList, 1);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_two_reported_all_component)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_two_reported_all_component)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5  };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_4;
@@ -1533,7 +1533,7 @@ TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_two_reported_all_component)
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_TWO_REPORTED_PROPERTIES_COMPONENT_ALL, expectedPropList, 2);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_reported_all_component)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_three_reported_all_component)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5, TEST_EXPECTED_PROPERTY6  };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_4;
@@ -1542,7 +1542,7 @@ TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_reported_all_componen
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_THREE_REPORTED_PROPERTIES_COMPONENT_ALL, expectedPropList, 3);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_two_components_writable_all)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_two_components_writable_all)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2 };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_1;
@@ -1550,7 +1550,7 @@ TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_two_components_writable_all
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_TWO_UDPATE_PROPERTIES_TWO_COMPONENTS_ALL, expectedPropList, 2);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_components_writable_all)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_three_components_writable_all)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY3 };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_1;
@@ -1559,7 +1559,7 @@ TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_components_writable_a
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_TWO_UDPATE_PROPERTIES_THREE_COMPONENTS_ALL, expectedPropList, 3);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_two_components_reported)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_two_components_reported)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5 };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_4;
@@ -1567,7 +1567,7 @@ TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_two_components_reported)
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_TWO_REPORTED_PROPERTIES_TWO_COMPONENTS_ALL, expectedPropList, 2);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_components_reported)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_three_components_reported)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5, TEST_EXPECTED_PROPERTY6 };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_4;
@@ -1576,7 +1576,7 @@ TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_components_reported)
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_THREE_REPORTED_PROPERTIES_THREE_COMPONENTS_ALL, expectedPropList, 3);
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_writable_and_reported_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_three_writable_and_reported_properties)
 {
     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY3, TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5, TEST_EXPECTED_PROPERTY6 };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_1;
@@ -1589,7 +1589,7 @@ TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_writable_and_reported
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_THREE_WRITABLE_REPORTED_IN_SEPARATE_COMPONENTS, expectedPropList, 6);
 }
 
-static void set_expected_calls_for_IoTHubClient_Properties_Parser_GetNext_fail_tests(void)
+static void set_expected_calls_for_IoTHubClient_Properties_Reader_GetNext_fail_tests(void)
 {
     STRICT_EXPECTED_CALL(json_object_get_count(IGNORED_PTR_ARG)).CallCannotFail();
     STRICT_EXPECTED_CALL(json_object_get_name(IGNORED_PTR_ARG,IGNORED_NUM_ARG)).CallCannotFail();
@@ -1606,14 +1606,14 @@ static void set_expected_calls_for_IoTHubClient_Properties_Parser_GetNext_fail_t
     STRICT_EXPECTED_CALL(json_serialize_to_string(IGNORED_PTR_ARG));
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_writable_and_reported_fail)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_GetNext_three_writable_and_reported_fail)
 {
     int negativeTestsInitResult = umock_c_negative_tests_init();
     ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
-    set_expected_calls_for_IoTHubClient_Properties_Parser_GetNext_fail_tests();
+    set_expected_calls_for_IoTHubClient_Properties_Reader_GetNext_fail_tests();
     // We take the initial snapshot to get the count of tests, but then immediately de-init.  We don't follow
-    // the standard convention of other _fail() tests here.  Because we do an iterator, it makes
+    // the standard convention of other _fail() tests here.  Because we do an iterator approach, it makes
     // changes to the state of the underlying reader.  So we create a new handle on each pass.
     umock_c_negative_tests_snapshot();
 
@@ -1627,14 +1627,14 @@ TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_writable_and_reported
             continue;
         }
 
-        IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_COMPONENT_ALL);
+        IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = TestAllocatePropertiesReader(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_COMPONENT_ALL);
 
         // Reset up the negative test framework for this specific run.  Needed inside this for() loop
         // because of all the state changes GetNextProperty causes.
         umock_c_negative_tests_deinit();
         negativeTestsInitResult = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
-        set_expected_calls_for_IoTHubClient_Properties_Parser_GetNext_fail_tests();
+        set_expected_calls_for_IoTHubClient_Properties_Reader_GetNext_fail_tests();
         umock_c_negative_tests_snapshot();
 
         umock_c_negative_tests_reset();
@@ -1644,99 +1644,99 @@ TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_writable_and_reported
         bool propertySpecified = false;
         ResetTestProperty(&property);
 
-        IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetNext(h, &property, &propertySpecified);
+        IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Reader_GetNext(h, &property, &propertySpecified);
 
         ASSERT_ARE_NOT_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result, "Unexpected success on test run  %lu", (unsigned long)index);
         ASSERT_IS_FALSE(propertySpecified, "Unexpected property=TRUE on test run %lu", (unsigned long)index);
 
-        IoTHubClient_Properties_Parser_Destroy(h);
+        IoTHubClient_Properties_Reader_Destroy(h);
     }
 }
 
 //
-// IoTHubClient_Properties_ParsedProperty_Destroy tests
+// IoTHubClient_Properties_ReaderProperty_Destroy tests
 //
-static void set_expected_calls_for_IoTHubClient_Properties_ParsedProperty_Destroy(void)
+static void set_expected_calls_for_IoTHubClient_Properties_ReaderProperty_Destroy(void)
 {
     STRICT_EXPECTED_CALL(json_free_serialized_string(IGNORED_PTR_ARG));
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_ParsedProperty_Destroy_ok)
+TEST_FUNCTION(IoTHubClient_Properties_ReaderProperty_Destroy_ok)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = TestAllocatePropertiesReader(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
     IOTHUB_CLIENT_PROPERTY_PARSED property;
     bool propertySpecified;
     ResetTestProperty(&property);
 
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetNext(h, &property, &propertySpecified);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Reader_GetNext(h, &property, &propertySpecified);
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
     ASSERT_IS_TRUE(propertySpecified);
     umock_c_reset_all_calls();
 
-    set_expected_calls_for_IoTHubClient_Properties_ParsedProperty_Destroy();
+    set_expected_calls_for_IoTHubClient_Properties_ReaderProperty_Destroy();
 
     // act
-    IoTHubClient_Properties_ParsedProperty_Destroy(&property);
+    IoTHubClient_Properties_ReaderProperty_Destroy(&property);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // cleanup
-    IoTHubClient_Properties_Parser_Destroy(h);
+    IoTHubClient_Properties_Reader_Destroy(h);
 
 }
 
 
-TEST_FUNCTION(IoTHubClient_Properties_ParsedProperty_Destroy_null)
+TEST_FUNCTION(IoTHubClient_Properties_ReaderProperty_Destroy_null)
 {
     // act
-    IoTHubClient_Properties_ParsedProperty_Destroy(NULL);
+    IoTHubClient_Properties_ReaderProperty_Destroy(NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
 //
-// IoTHubClient_Properties_Parser_Destroy tests
+// IoTHubClient_Properties_Reader_Destroy tests
 //
-static void set_expected_calls_for_IoTHubClient_Properties_Parser_Destroy(void)
+static void set_expected_calls_for_IoTHubClient_Properties_Reader_Destroy(void)
 {
     STRICT_EXPECTED_CALL(json_value_free(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_Destroy_success)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_Destroy_success)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
-    set_expected_calls_for_IoTHubClient_Properties_Parser_Destroy();
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = TestAllocatePropertiesReader(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
+    set_expected_calls_for_IoTHubClient_Properties_Reader_Destroy();
 
     // act
-    IoTHubClient_Properties_Parser_Destroy(h);
+    IoTHubClient_Properties_Reader_Destroy(h);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_Destroy_multiple_components_success)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_Destroy_multiple_components_success)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
-    set_expected_calls_for_IoTHubClient_Properties_Parser_Destroy();
+    IOTHUB_CLIENT_PROPERTIES_READER_HANDLE h = TestAllocatePropertiesReader(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
+    set_expected_calls_for_IoTHubClient_Properties_Reader_Destroy();
 
     // act
-    IoTHubClient_Properties_Parser_Destroy(h);
+    IoTHubClient_Properties_Reader_Destroy(h);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
 
-TEST_FUNCTION(IoTHubClient_Properties_Parser_Destroy_null)
+TEST_FUNCTION(IoTHubClient_Properties_Reader_Destroy_null)
 {
     // act
-    IoTHubClient_Properties_Parser_Destroy(NULL);
+    IoTHubClient_Properties_Reader_Destroy(NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());

--- a/iothub_client/tests/iothub_client_properties_ut/iothub_client_properties_ut.c
+++ b/iothub_client/tests/iothub_client_properties_ut/iothub_client_properties_ut.c
@@ -120,8 +120,8 @@ static const int TEST_DEFAULT_PROPERTIES_VERSION = 119;
 
 //
 // The tests make extensive use of macros to build up test JSON, both the expected results 
-// of serialization APIs such as IoTHubClient_Serialize_ReportedProperties and the test
-// data for IoTHubClient_Deserialize_Properties_CreateIterator.
+// of serialization APIs such as IoTHubClient_Properties_Writer_CreateReported and the test
+// data for IoTHubClient_Properties_Parser_Create.
 //
 
 // BUILD_JSON_NAME_VALUE creates a JSON style "name": value with required C escaping of all this.
@@ -145,16 +145,16 @@ static const int TEST_DEFAULT_PROPERTIES_VERSION = 119;
 #define TEST_BUILD_REPORTED(reportedNameValuePairs, twinVersion) "{ \"reported\": {" reportedNameValuePairs "},  \"desired\": { " twinVersion "} }"
 #define TEST_BUILD_REPORTED_AND_DESIRED(reportedNameValuePairs, desiredNameValuePairs, twinVersion) "{ \"reported\": {" reportedNameValuePairs "},  \"desired\": { " desiredNameValuePairs "," twinVersion "} }"
 
-// Test reported properties to serialize during calls to IoTHubClient_Serialize_ReportedProperties (valid structures).
-static const IOTHUB_CLIENT_REPORTED_PROPERTY TEST_REPORTED_PROP1 = { IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, TEST_PROP_NAME1, TEST_PROP_VALUE1 };
-static const IOTHUB_CLIENT_REPORTED_PROPERTY TEST_REPORTED_PROP2 = { IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, TEST_PROP_NAME2, TEST_PROP_VALUE2 };
-static const IOTHUB_CLIENT_REPORTED_PROPERTY TEST_REPORTED_PROP3 = { IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, TEST_PROP_NAME3, TEST_PROP_VALUE3 };
-// Test reported properties to serialize (invalid structures, IoTHubClient_Serialize_ReportedProperties should fail when passed these).
-static const IOTHUB_CLIENT_REPORTED_PROPERTY TEST_REPORTED_PROP_WRONG_VERSION = { 2, TEST_PROP_NAME1, TEST_PROP_VALUE1 };
-static const IOTHUB_CLIENT_REPORTED_PROPERTY TEST_REPORTED_PROP_NULL_NAME = { IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, NULL, TEST_PROP_VALUE1 };
-static const IOTHUB_CLIENT_REPORTED_PROPERTY TEST_REPORTED_PROP_NULL_VALUE = { IOTHUB_CLIENT_REPORTED_PROPERTY_STRUCT_VERSION_1, TEST_PROP_NAME1, NULL };
+// Test reported properties to serialize during calls to IoTHubClient_Properties_Writer_CreateReported (valid structures).
+static const IOTHUB_CLIENT_PROPERTY_REPORTED TEST_REPORTED_PROP1 = { IOTHUB_CLIENT_PROPERTY_REPORTED_STRUCT_VERSION_1, TEST_PROP_NAME1, TEST_PROP_VALUE1 };
+static const IOTHUB_CLIENT_PROPERTY_REPORTED TEST_REPORTED_PROP2 = { IOTHUB_CLIENT_PROPERTY_REPORTED_STRUCT_VERSION_1, TEST_PROP_NAME2, TEST_PROP_VALUE2 };
+static const IOTHUB_CLIENT_PROPERTY_REPORTED TEST_REPORTED_PROP3 = { IOTHUB_CLIENT_PROPERTY_REPORTED_STRUCT_VERSION_1, TEST_PROP_NAME3, TEST_PROP_VALUE3 };
+// Test reported properties to serialize (invalid structures, IoTHubClient_Properties_Writer_CreateReported should fail when passed these).
+static const IOTHUB_CLIENT_PROPERTY_REPORTED TEST_REPORTED_PROP_WRONG_VERSION = { 2, TEST_PROP_NAME1, TEST_PROP_VALUE1 };
+static const IOTHUB_CLIENT_PROPERTY_REPORTED TEST_REPORTED_PROP_NULL_NAME = { IOTHUB_CLIENT_PROPERTY_REPORTED_STRUCT_VERSION_1, NULL, TEST_PROP_VALUE1 };
+static const IOTHUB_CLIENT_PROPERTY_REPORTED TEST_REPORTED_PROP_NULL_VALUE = { IOTHUB_CLIENT_PROPERTY_REPORTED_STRUCT_VERSION_1, TEST_PROP_NAME1, NULL };
 
-// JSON expected to be serialized during IoTHubClient_Serialize_ReportedProperties tests.
+// JSON expected to be serialized during IoTHubClient_Properties_Writer_CreateReported tests.
 #define TEST_REPORTED_PROP1_JSON_NO_BRACE BUILD_JSON_NAME_VALUE(TEST_PROP_NAME1, TEST_PROP_VALUE1)
 #define TEST_REPORTED_PROP_JSON1 "{" TEST_REPORTED_PROP1_JSON_NO_BRACE "}"
 #define TEST_REPORTED_PROP1_2_JSON_NO_BRACE BUILD_JSON_NAME_VALUE(TEST_PROP_NAME1, TEST_PROP_VALUE1) "," BUILD_JSON_NAME_VALUE(TEST_PROP_NAME2, TEST_PROP_VALUE2)
@@ -165,20 +165,20 @@ static const IOTHUB_CLIENT_REPORTED_PROPERTY TEST_REPORTED_PROP_NULL_VALUE = { I
 #define TEST_REPORTED_PROP1_2_JSON_COMPONENT1 TEST_COMPONENT_JSON_WITH_BRACE(TEST_COMPONENT_NAME_1, TEST_REPORTED_PROP1_2_JSON_NO_BRACE)
 #define TEST_REPORTED_PROP1_2_3_JSON_COMPONENT1 TEST_COMPONENT_JSON_WITH_BRACE(TEST_COMPONENT_NAME_1, TEST_REPORTED_PROP1_2_3_JSON_NO_BRACE)
 
-// Test reported properties to serialize during calls to IoTHubClient_Serialize_WritablePropertyResponse (valid structures).
-static const IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE TEST_WRITABLE_PROP1 = { IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE_STRUCT_VERSION_1, TEST_PROP_NAME1, TEST_PROP_VALUE1, TEST_STATUS_CODE_1, TEST_ACK_CODE_1, NULL };
-static const IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE TEST_WRITABLE_PROP2 = { IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE_STRUCT_VERSION_1, TEST_PROP_NAME2, TEST_PROP_VALUE2, TEST_STATUS_CODE_2, TEST_ACK_CODE_2, TEST_DESCRIPTION_2 };
-static const IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE TEST_WRITABLE_PROP3 = { IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE_STRUCT_VERSION_1, TEST_PROP_NAME3, TEST_PROP_VALUE3, TEST_STATUS_CODE_3, TEST_ACK_CODE_3, TEST_DESCRIPTION_3 };
-// Test reported properties to serialize (invalid structures, IoTHubClient_Serialize_WritablePropertyResponse should fail when passed these).
-static const IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE TEST_WRITABLE_WRONG_VERSION = { 2, TEST_PROP_NAME1, TEST_PROP_VALUE1, TEST_STATUS_CODE_1, TEST_ACK_CODE_1, NULL};
-static const IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE TEST_WRITABLE_PROP_NULL_NAME =  { IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE_STRUCT_VERSION_1, NULL, TEST_PROP_VALUE1, TEST_STATUS_CODE_1, TEST_ACK_CODE_1, NULL };
-static const IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE TEST_WRITABLE_PROP_NULL_VALUE = { IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE_STRUCT_VERSION_1, TEST_PROP_NAME1, NULL, TEST_STATUS_CODE_1, TEST_ACK_CODE_1, NULL };
+// Test reported properties to serialize during calls to IoTHubClient_Properties_Writer_CreateWritableResponse (valid structures).
+static const IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE TEST_WRITABLE_PROP1 = { IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE_STRUCT_VERSION_1, TEST_PROP_NAME1, TEST_PROP_VALUE1, TEST_STATUS_CODE_1, TEST_ACK_CODE_1, NULL };
+static const IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE TEST_WRITABLE_PROP2 = { IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE_STRUCT_VERSION_1, TEST_PROP_NAME2, TEST_PROP_VALUE2, TEST_STATUS_CODE_2, TEST_ACK_CODE_2, TEST_DESCRIPTION_2 };
+static const IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE TEST_WRITABLE_PROP3 = { IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE_STRUCT_VERSION_1, TEST_PROP_NAME3, TEST_PROP_VALUE3, TEST_STATUS_CODE_3, TEST_ACK_CODE_3, TEST_DESCRIPTION_3 };
+// Test reported properties to serialize (invalid structures, IoTHubClient_Properties_Writer_CreateWritableResponse should fail when passed these).
+static const IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE TEST_WRITABLE_WRONG_VERSION = { 2, TEST_PROP_NAME1, TEST_PROP_VALUE1, TEST_STATUS_CODE_1, TEST_ACK_CODE_1, NULL};
+static const IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE TEST_WRITABLE_PROP_NULL_NAME =  { IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE_STRUCT_VERSION_1, NULL, TEST_PROP_VALUE1, TEST_STATUS_CODE_1, TEST_ACK_CODE_1, NULL };
+static const IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE TEST_WRITABLE_PROP_NULL_VALUE = { IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE_STRUCT_VERSION_1, TEST_PROP_NAME1, NULL, TEST_STATUS_CODE_1, TEST_ACK_CODE_1, NULL };
 
-// Helpers to build expected JSON when calling IoTHubClient_Serialize_WritablePropertyResponse.
+// Helpers to build expected JSON when calling IoTHubClient_Properties_Writer_CreateWritableResponse.
 #define BUILD_EXPECTED_WRITABLE_JSON(name, val, code, version) "\""name"\":{\"value\":"val",\"ac\":" #code ",\"av\":" #version "}"
 #define BUILD_EXPECTED_WRITABLE_JSON_DESCRIPTION(name, val, code, version, description) "\""name"\":{\"value\":"val",\"ac\":" #code ",\"av\":" #version ",\"ad\":\"" description "\"}"
 
-// JSON expected to be serialized during IoTHubClient_Serialize_WritablePropertyResponse tests.
+// JSON expected to be serialized during IoTHubClient_Properties_Writer_CreateWritableResponse tests.
 #define TEST_WRITABLE_PROP1_JSON_NO_BRACE BUILD_EXPECTED_WRITABLE_JSON(TEST_PROP_NAME1, TEST_PROP_VALUE1, 200, 1)
 #define TEST_WRITABLE_PROP1_JSON "{" TEST_WRITABLE_PROP1_JSON_NO_BRACE "}"
 #define TEST_WRITABLE_PROP2_JSON_NO_BRACE BUILD_EXPECTED_WRITABLE_JSON_DESCRIPTION(TEST_PROP_NAME2, TEST_PROP_VALUE2, 400, 19, TEST_DESCRIPTION_2)
@@ -195,9 +195,9 @@ static const IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE TEST_WRITABLE_PROP_NULL_VA
 
 // Expected results deserialization tests.  The componentName is alway NULL in the test data below.  Tests that 
 // expect a component to be set will make a copy of the needed structure(s) and then set 
-// IOTHUB_CLIENT_DESERIALIZED_PROPERTY::componentName in the copied version.
-static const IOTHUB_CLIENT_DESERIALIZED_PROPERTY TEST_EXPECTED_PROPERTY1 = {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY_STRUCT_VERSION_1,
+// IOTHUB_CLIENT_PROPERTY_PARSED::componentName in the copied version.
+static const IOTHUB_CLIENT_PROPERTY_PARSED TEST_EXPECTED_PROPERTY1 = {
+    IOTHUB_CLIENT_PROPERTY_PARSED_STRUCT_VERSION_1,
     IOTHUB_CLIENT_PROPERTY_TYPE_WRITABLE,
     NULL,
     TEST_PROP_NAME1,
@@ -206,8 +206,8 @@ static const IOTHUB_CLIENT_DESERIALIZED_PROPERTY TEST_EXPECTED_PROPERTY1 = {
     (sizeof(TEST_PROP_VALUE1) / sizeof(TEST_PROP_VALUE1[0]) - 1)
 };
 
-static const IOTHUB_CLIENT_DESERIALIZED_PROPERTY TEST_EXPECTED_PROPERTY2 = {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY_STRUCT_VERSION_1,
+static const IOTHUB_CLIENT_PROPERTY_PARSED TEST_EXPECTED_PROPERTY2 = {
+    IOTHUB_CLIENT_PROPERTY_PARSED_STRUCT_VERSION_1,
     IOTHUB_CLIENT_PROPERTY_TYPE_WRITABLE,
     NULL,
     TEST_PROP_NAME2,
@@ -216,8 +216,8 @@ static const IOTHUB_CLIENT_DESERIALIZED_PROPERTY TEST_EXPECTED_PROPERTY2 = {
     (sizeof(TEST_PROP_VALUE2) / sizeof(TEST_PROP_VALUE2[0]) - 1)
 };
 
-static const IOTHUB_CLIENT_DESERIALIZED_PROPERTY TEST_EXPECTED_PROPERTY3 = {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY_STRUCT_VERSION_1,
+static const IOTHUB_CLIENT_PROPERTY_PARSED TEST_EXPECTED_PROPERTY3 = {
+    IOTHUB_CLIENT_PROPERTY_PARSED_STRUCT_VERSION_1,
     IOTHUB_CLIENT_PROPERTY_TYPE_WRITABLE,
     NULL,
     TEST_PROP_NAME3,
@@ -226,8 +226,8 @@ static const IOTHUB_CLIENT_DESERIALIZED_PROPERTY TEST_EXPECTED_PROPERTY3 = {
     (sizeof(TEST_PROP_VALUE3) / sizeof(TEST_PROP_VALUE3[0]) - 1)
 };
 
-static const IOTHUB_CLIENT_DESERIALIZED_PROPERTY TEST_EXPECTED_PROPERTY4 = {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY_STRUCT_VERSION_1,
+static const IOTHUB_CLIENT_PROPERTY_PARSED TEST_EXPECTED_PROPERTY4 = {
+    IOTHUB_CLIENT_PROPERTY_PARSED_STRUCT_VERSION_1,
     IOTHUB_CLIENT_PROPERTY_TYPE_REPORTED_FROM_DEVICE,
     NULL,
     TEST_PROP_NAME4,
@@ -236,8 +236,8 @@ static const IOTHUB_CLIENT_DESERIALIZED_PROPERTY TEST_EXPECTED_PROPERTY4 = {
     (sizeof(TEST_PROP_VALUE4) / sizeof(TEST_PROP_VALUE4[0]) - 1)
 };
 
-static const IOTHUB_CLIENT_DESERIALIZED_PROPERTY TEST_EXPECTED_PROPERTY5 = {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY_STRUCT_VERSION_1,
+static const IOTHUB_CLIENT_PROPERTY_PARSED TEST_EXPECTED_PROPERTY5 = {
+    IOTHUB_CLIENT_PROPERTY_PARSED_STRUCT_VERSION_1,
     IOTHUB_CLIENT_PROPERTY_TYPE_REPORTED_FROM_DEVICE,
     NULL,
     TEST_PROP_NAME5,
@@ -246,8 +246,8 @@ static const IOTHUB_CLIENT_DESERIALIZED_PROPERTY TEST_EXPECTED_PROPERTY5 = {
     (sizeof(TEST_PROP_VALUE5) / sizeof(TEST_PROP_VALUE5[0]) - 1)
 };
 
-static const IOTHUB_CLIENT_DESERIALIZED_PROPERTY TEST_EXPECTED_PROPERTY6 = {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY_STRUCT_VERSION_1,
+static const IOTHUB_CLIENT_PROPERTY_PARSED TEST_EXPECTED_PROPERTY6 = {
+    IOTHUB_CLIENT_PROPERTY_PARSED_STRUCT_VERSION_1,
     IOTHUB_CLIENT_PROPERTY_TYPE_REPORTED_FROM_DEVICE,
     NULL,
     TEST_PROP_NAME6,
@@ -256,10 +256,10 @@ static const IOTHUB_CLIENT_DESERIALIZED_PROPERTY TEST_EXPECTED_PROPERTY6 = {
     (sizeof(TEST_PROP_VALUE6) / sizeof(TEST_PROP_VALUE6[0]) - 1)
 };
 
-// For error cases, make sure IoTHubClient_Deserialize_Properties_GetNextProperty does not change any members
+// For error cases, make sure IoTHubClient_Properties_Parser_GetNext does not change any members
 // of the passed in structure
-static IOTHUB_CLIENT_DESERIALIZED_PROPERTY unfilledProperty = {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY_STRUCT_VERSION_1,
+static IOTHUB_CLIENT_PROPERTY_PARSED unfilledProperty = {
+    IOTHUB_CLIENT_PROPERTY_PARSED_STRUCT_VERSION_1,
     0,
     NULL,
     NULL,
@@ -269,7 +269,7 @@ static IOTHUB_CLIENT_DESERIALIZED_PROPERTY unfilledProperty = {
 };
 
 //
-// JSON to be used as input during tests to IoTHubClient_Deserialize_Properties_CreateIterator/IoTHubClient_Deserialize_Properties_GetNextProperty.
+// JSON to be used as input during tests to IoTHubClient_Properties_Parser_Create/IoTHubClient_Properties_Parser_GetNext.
 // 
 // Builds up the most common name / value pairs so they're more convenient for later use.  
 // For instance, TEST_JSON_NAME_VALUE1, after preprocessing, turns into "name1":1234
@@ -303,7 +303,7 @@ static IOTHUB_CLIENT_DESERIALIZED_PROPERTY unfilledProperty = {
 #define TEST_JSON_COMPONENT1_NAME_VALUE4_5 TEST_COMPONENT_JSON(TEST_COMPONENT_NAME_4, TEST_JSON_NAME_VALUE4_5)
 #define TEST_JSON_COMPONENT1_NAME_VALUE4_5_6 TEST_COMPONENT_JSON(TEST_COMPONENT_NAME_4, TEST_JSON_NAME_VALUE4_5_6)
 
-// Build up the actual JSON for IoTHubClient_Deserialize_Properties_CreateIterator/IoTHubClient_Deserialize_Properties_GetNextProperty tests.
+// Build up the actual JSON for IoTHubClient_Properties_Parser_Create/IoTHubClient_Properties_Parser_GetNext tests.
 static unsigned const char TEST_JSON_ONE_PROPERTY_ALL[] = TEST_BUILD_DESIRED_ALL(TEST_JSON_NAME_VALUE1, TEST_JSON_TWIN_VER_1);
 static const size_t TEST_JSON_ONE_PROPERTY_ALL_LEN = sizeof(TEST_JSON_ONE_PROPERTY_ALL) - 1;
 static unsigned const char TEST_JSON_ONE_PROPERTY_WRITABLE[] = TEST_BUILD_DESIRED_UPDATE(TEST_JSON_NAME_VALUE1, TEST_JSON_TWIN_VER_2);
@@ -339,12 +339,12 @@ static unsigned const char TEST_JSON_THREE_REPORTED_PROPERTIES_THREE_COMPONENTS_
 // This tests 3 reported properties, 3 writable, each in a separate component.
 static unsigned const char TEST_JSON_THREE_WRITABLE_REPORTED_IN_SEPARATE_COMPONENTS[] = TEST_BUILD_REPORTED_AND_DESIRED(TEST_JSON_ALL_REPORTED, TEST_JSON_ALL_WRITABLE, TEST_JSON_TWIN_VER_1);
 
-// Invalid JSON.  IoTHubClient_Deserialize_Properties_CreateIterator will fail trying to deserialize this.
+// Invalid JSON.  IoTHubClient_Properties_Parser_Create will fail trying to deserialize this.
 static unsigned const char TEST_INVALID_JSON[] = "}{-not-valid";
-// Legal JSON but no $version.  IoTHubClient_Deserialize_Properties_CreateIterator will fail trying to deserialize this.
+// Legal JSON but no $version.  IoTHubClient_Properties_Parser_Create will fail trying to deserialize this.
 static unsigned const char TEST_JSON_NO_VERSION[] = "44";
-// Legal JSON including $version, but for an "all properties" json its missing the desired.  IoTHubClient_Deserialize_Properties_CreateIterator 
-// will succeed but IoTHubClient_Deserialize_Properties_GetNextProperty won't have anything to enumerate.
+// Legal JSON including $version, but for an "all properties" json its missing the desired.  IoTHubClient_Properties_Parser_Create 
+// will succeed but IoTHubClient_Properties_Parser_GetNext won't have anything to enumerate.
 static unsigned const char TEST_JSON_NO_DESIRED[] = "{ " TEST_JSON_TWIN_VER_1 " }";
 
 BEGIN_TEST_SUITE(iothub_client_properties_ut)
@@ -408,21 +408,21 @@ TEST_FUNCTION_CLEANUP(TestMethodCleanup)
 }
 
 //
-// IoTHubClient_Serialize_ReportedProperties tests
+// IoTHubClient_Properties_Writer_CreateReported tests
 //
-static void set_expected_calls_for_IoTHubClient_Serialize_ReportedProperties(void)
+static void set_expected_calls_for_IoTHubClient_Properties_Writer_CreateReported(void)
 {
     STRICT_EXPECTED_CALL(gballoc_calloc(IGNORED_NUM_ARG, IGNORED_NUM_ARG));
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_NULL_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_NULL_properties)
 {
     // arrange
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
     
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_ReportedProperties(NULL, 1, NULL, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateReported(NULL, 1, NULL, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
@@ -431,13 +431,13 @@ TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_NULL_properties)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_NULL_serializedProperties)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_NULL_serializedProperties)
 {
     // arrange
     size_t serializedPropertiesLength = 0;
     
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_ReportedProperties(&TEST_REPORTED_PROP1, 1, NULL, NULL, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateReported(&TEST_REPORTED_PROP1, 1, NULL, NULL, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
@@ -445,13 +445,13 @@ TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_NULL_serializedPropertie
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_NULL_serializedPropertiesLength)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_NULL_serializedPropertiesLength)
 {
     // arrange
     unsigned char* serializedProperties = NULL;
     
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_ReportedProperties(&TEST_REPORTED_PROP1, 1, NULL, &serializedProperties, NULL);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateReported(&TEST_REPORTED_PROP1, 1, NULL, &serializedProperties, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
@@ -460,14 +460,14 @@ TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_NULL_serializedPropertie
 
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_wrong_struct_version)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_wrong_struct_version)
 {
     // arrange
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
     
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_ReportedProperties(&TEST_REPORTED_PROP_WRONG_VERSION, 1, NULL, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateReported(&TEST_REPORTED_PROP_WRONG_VERSION, 1, NULL, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
@@ -476,16 +476,16 @@ TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_wrong_struct_version)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_NULL_propname)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_NULL_propname)
 {
     // arrange
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    IOTHUB_CLIENT_REPORTED_PROPERTY testReportedNullNameThirdIndex[3] = { TEST_REPORTED_PROP1, TEST_REPORTED_PROP2, TEST_REPORTED_PROP_NULL_NAME};
+    IOTHUB_CLIENT_PROPERTY_REPORTED testReportedNullNameThirdIndex[3] = { TEST_REPORTED_PROP1, TEST_REPORTED_PROP2, TEST_REPORTED_PROP_NULL_NAME};
     
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_ReportedProperties(testReportedNullNameThirdIndex, 3, NULL, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateReported(testReportedNullNameThirdIndex, 3, NULL, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
@@ -494,16 +494,16 @@ TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_NULL_propname)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_NULL_propvalue)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_NULL_propvalue)
 {
     // arrange
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    const IOTHUB_CLIENT_REPORTED_PROPERTY testReportedNullValueThirdIndex[] = { TEST_REPORTED_PROP1, TEST_REPORTED_PROP2, TEST_REPORTED_PROP_NULL_VALUE};
+    const IOTHUB_CLIENT_PROPERTY_REPORTED testReportedNullValueThirdIndex[] = { TEST_REPORTED_PROP1, TEST_REPORTED_PROP2, TEST_REPORTED_PROP_NULL_VALUE};
     
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_ReportedProperties(testReportedNullValueThirdIndex, 3, NULL, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateReported(testReportedNullValueThirdIndex, 3, NULL, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
@@ -512,16 +512,16 @@ TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_NULL_propvalue)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_one_property_success)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_one_property_success)
 {
     // arrange
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    set_expected_calls_for_IoTHubClient_Serialize_ReportedProperties();
+    set_expected_calls_for_IoTHubClient_Properties_Writer_CreateReported();
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_ReportedProperties(&TEST_REPORTED_PROP1, 1, NULL, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateReported(&TEST_REPORTED_PROP1, 1, NULL, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -530,21 +530,21 @@ TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_one_property_success)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Serialize_Properties_Destroy(serializedProperties);
+    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_two_properties_success)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_two_properties_success)
 {
     // arrange
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    const IOTHUB_CLIENT_REPORTED_PROPERTY testReportedTwoProperties[] = { TEST_REPORTED_PROP1, TEST_REPORTED_PROP2};
+    const IOTHUB_CLIENT_PROPERTY_REPORTED testReportedTwoProperties[] = { TEST_REPORTED_PROP1, TEST_REPORTED_PROP2};
 
-    set_expected_calls_for_IoTHubClient_Serialize_ReportedProperties();
+    set_expected_calls_for_IoTHubClient_Properties_Writer_CreateReported();
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_ReportedProperties(testReportedTwoProperties, 2, NULL, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateReported(testReportedTwoProperties, 2, NULL, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -553,21 +553,21 @@ TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_two_properties_success)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Serialize_Properties_Destroy(serializedProperties);
+    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_three_properties_success)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_three_properties_success)
 {
     // arrange
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    const IOTHUB_CLIENT_REPORTED_PROPERTY testReportedTwoProperties[] = { TEST_REPORTED_PROP1, TEST_REPORTED_PROP2, TEST_REPORTED_PROP3};
+    const IOTHUB_CLIENT_PROPERTY_REPORTED testReportedTwoProperties[] = { TEST_REPORTED_PROP1, TEST_REPORTED_PROP2, TEST_REPORTED_PROP3};
 
-    set_expected_calls_for_IoTHubClient_Serialize_ReportedProperties();
+    set_expected_calls_for_IoTHubClient_Properties_Writer_CreateReported();
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_ReportedProperties(testReportedTwoProperties, 3, NULL, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateReported(testReportedTwoProperties, 3, NULL, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -576,19 +576,19 @@ TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_three_properties_success
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Serialize_Properties_Destroy(serializedProperties);
+    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_one_property_with_component_success)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_one_property_with_component_success)
 {
     // arrange
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    set_expected_calls_for_IoTHubClient_Serialize_ReportedProperties();
+    set_expected_calls_for_IoTHubClient_Properties_Writer_CreateReported();
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_ReportedProperties(&TEST_REPORTED_PROP1, 1, TEST_COMPONENT_NAME_1, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateReported(&TEST_REPORTED_PROP1, 1, TEST_COMPONENT_NAME_1, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -597,21 +597,21 @@ TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_one_property_with_compon
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Serialize_Properties_Destroy(serializedProperties);
+    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_two_properties_with_component_success)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_two_properties_with_component_success)
 {
     // arrange
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    const IOTHUB_CLIENT_REPORTED_PROPERTY testReportedTwoProperties[] = { TEST_REPORTED_PROP1, TEST_REPORTED_PROP2};
+    const IOTHUB_CLIENT_PROPERTY_REPORTED testReportedTwoProperties[] = { TEST_REPORTED_PROP1, TEST_REPORTED_PROP2};
 
-    set_expected_calls_for_IoTHubClient_Serialize_ReportedProperties();
+    set_expected_calls_for_IoTHubClient_Properties_Writer_CreateReported();
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_ReportedProperties(testReportedTwoProperties, 2, TEST_COMPONENT_NAME_1, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateReported(testReportedTwoProperties, 2, TEST_COMPONENT_NAME_1, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -620,21 +620,21 @@ TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_two_properties_with_comp
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Serialize_Properties_Destroy(serializedProperties);
+    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_three_properties_with_component_success)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_three_properties_with_component_success)
 {
     // arrange
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    const IOTHUB_CLIENT_REPORTED_PROPERTY testReportedThreeProperties[] = { TEST_REPORTED_PROP1, TEST_REPORTED_PROP2, TEST_REPORTED_PROP3};
+    const IOTHUB_CLIENT_PROPERTY_REPORTED testReportedThreeProperties[] = { TEST_REPORTED_PROP1, TEST_REPORTED_PROP2, TEST_REPORTED_PROP3};
 
-    set_expected_calls_for_IoTHubClient_Serialize_ReportedProperties();
+    set_expected_calls_for_IoTHubClient_Properties_Writer_CreateReported();
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_ReportedProperties(testReportedThreeProperties, 3, TEST_COMPONENT_NAME_1, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateReported(testReportedThreeProperties, 3, TEST_COMPONENT_NAME_1, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -643,10 +643,10 @@ TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_three_properties_with_co
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Serialize_Properties_Destroy(serializedProperties);
+    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_fail)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateReported_fail)
 {
     // arrange
     int negativeTestsInitResult = umock_c_negative_tests_init();
@@ -655,9 +655,9 @@ TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_fail)
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    const IOTHUB_CLIENT_REPORTED_PROPERTY testReportedThreeProperties[] = { TEST_REPORTED_PROP1, TEST_REPORTED_PROP2, TEST_REPORTED_PROP3};
+    const IOTHUB_CLIENT_PROPERTY_REPORTED testReportedThreeProperties[] = { TEST_REPORTED_PROP1, TEST_REPORTED_PROP2, TEST_REPORTED_PROP3};
 
-    set_expected_calls_for_IoTHubClient_Serialize_ReportedProperties();
+    set_expected_calls_for_IoTHubClient_Properties_Writer_CreateReported();
     umock_c_negative_tests_snapshot();
 
     // act
@@ -669,7 +669,7 @@ TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_fail)
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
             
-            IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_ReportedProperties(testReportedThreeProperties, 3, TEST_COMPONENT_NAME_1, &serializedProperties, &serializedPropertiesLength);
+            IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateReported(testReportedThreeProperties, 3, TEST_COMPONENT_NAME_1, &serializedProperties, &serializedPropertiesLength);
 
             //assert
             ASSERT_ARE_NOT_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -680,21 +680,21 @@ TEST_FUNCTION(IoTHubClient_Serialize_ReportedProperties_fail)
 }
 
 //
-// IoTHubClient_Serialize_WritablePropertyResponse tests
+// IoTHubClient_Properties_Writer_CreateWritableResponse tests
 // 
-static void set_expected_calls_for_IoTHubClient_Serialize_WritablePropertyResponse(void)
+static void set_expected_calls_for_IoTHubClient_Properties_Writer_CreateWritableResponse(void)
 {
     STRICT_EXPECTED_CALL(gballoc_calloc(IGNORED_NUM_ARG, IGNORED_NUM_ARG));
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_WritablePropertyResponse_NULL_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateWritableResponse_NULL_properties)
 {
     // arrange
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
     
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_WritablePropertyResponse(NULL, 1, NULL, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateWritableResponse(NULL, 1, NULL, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
@@ -703,13 +703,13 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritablePropertyResponse_NULL_properties)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_WritablePropertyResponse_NULL_serializedProperties)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateWritableResponse_NULL_serializedProperties)
 {
     // arrange
     size_t serializedPropertiesLength = 0;
     
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_WritablePropertyResponse(&TEST_WRITABLE_PROP1, 1, NULL, NULL, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateWritableResponse(&TEST_WRITABLE_PROP1, 1, NULL, NULL, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
@@ -717,13 +717,13 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritablePropertyResponse_NULL_serializedPro
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_WritablePropertyResponse_NULL_serializedPropertiesLength)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateWritableResponse_NULL_serializedPropertiesLength)
 {
     // arrange
     unsigned char* serializedProperties = NULL;
     
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_WritablePropertyResponse(&TEST_WRITABLE_PROP1, 1, NULL, &serializedProperties, NULL);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateWritableResponse(&TEST_WRITABLE_PROP1, 1, NULL, &serializedProperties, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
@@ -732,14 +732,14 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritablePropertyResponse_NULL_serializedPro
 
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_WritablePropertyResponse_wrong_struct_version)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateWritableResponse_wrong_struct_version)
 {
     // arrange
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
     
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_WritablePropertyResponse(&TEST_WRITABLE_WRONG_VERSION, 1, NULL, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateWritableResponse(&TEST_WRITABLE_WRONG_VERSION, 1, NULL, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
@@ -748,16 +748,16 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritablePropertyResponse_wrong_struct_versi
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_WritablePropertyResponse_NULL_propname)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateWritableResponse_NULL_propname)
 {
     // arrange
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    const IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE testWritableNullValueThirdIndex[] = { TEST_WRITABLE_PROP1, TEST_WRITABLE_PROP1, TEST_WRITABLE_PROP_NULL_NAME };
+    const IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE testWritableNullValueThirdIndex[] = { TEST_WRITABLE_PROP1, TEST_WRITABLE_PROP1, TEST_WRITABLE_PROP_NULL_NAME };
     
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_WritablePropertyResponse(testWritableNullValueThirdIndex, 3, NULL, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateWritableResponse(testWritableNullValueThirdIndex, 3, NULL, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
@@ -766,16 +766,16 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritablePropertyResponse_NULL_propname)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_WritablePropertyResponse_NULL_propvalue)
+TEST_FUNCTION(IoTHubClient_Properties_Writer_CreateWritableResponse_NULL_propvalue)
 {
     // arrange
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    const IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE testWritableNullValueThirdIndex[] = { TEST_WRITABLE_PROP1, TEST_WRITABLE_PROP1, TEST_WRITABLE_PROP_NULL_VALUE };
+    const IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE testWritableNullValueThirdIndex[] = { TEST_WRITABLE_PROP1, TEST_WRITABLE_PROP1, TEST_WRITABLE_PROP_NULL_VALUE };
     
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_WritablePropertyResponse(testWritableNullValueThirdIndex, 3, NULL, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateWritableResponse(testWritableNullValueThirdIndex, 3, NULL, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
@@ -790,10 +790,10 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_one_property_success)
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    set_expected_calls_for_IoTHubClient_Serialize_WritablePropertyResponse();
+    set_expected_calls_for_IoTHubClient_Properties_Writer_CreateWritableResponse();
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_WritablePropertyResponse(&TEST_WRITABLE_PROP1, 1, NULL, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateWritableResponse(&TEST_WRITABLE_PROP1, 1, NULL, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -802,7 +802,7 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_one_property_success)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Serialize_Properties_Destroy(serializedProperties);
+    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_one_property_with_description_success)
@@ -811,10 +811,10 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_one_property_with_descri
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    set_expected_calls_for_IoTHubClient_Serialize_WritablePropertyResponse();
+    set_expected_calls_for_IoTHubClient_Properties_Writer_CreateWritableResponse();
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_WritablePropertyResponse(&TEST_WRITABLE_PROP2, 1, NULL, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateWritableResponse(&TEST_WRITABLE_PROP2, 1, NULL, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -823,7 +823,7 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_one_property_with_descri
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Serialize_Properties_Destroy(serializedProperties);
+    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_two_properties_success)
@@ -832,12 +832,12 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_two_properties_success)
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    const IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE testWritableTwoProperties[] = { TEST_WRITABLE_PROP1, TEST_WRITABLE_PROP2 };
+    const IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE testWritableTwoProperties[] = { TEST_WRITABLE_PROP1, TEST_WRITABLE_PROP2 };
 
-    set_expected_calls_for_IoTHubClient_Serialize_WritablePropertyResponse();
+    set_expected_calls_for_IoTHubClient_Properties_Writer_CreateWritableResponse();
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_WritablePropertyResponse(testWritableTwoProperties, 2, NULL, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateWritableResponse(testWritableTwoProperties, 2, NULL, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -846,7 +846,7 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_two_properties_success)
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Serialize_Properties_Destroy(serializedProperties);
+    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_three_properties_success)
@@ -855,12 +855,12 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_three_properties_success
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    const IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE testWritableThreeProperties[] = { TEST_WRITABLE_PROP1, TEST_WRITABLE_PROP2, TEST_WRITABLE_PROP3 };
+    const IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE testWritableThreeProperties[] = { TEST_WRITABLE_PROP1, TEST_WRITABLE_PROP2, TEST_WRITABLE_PROP3 };
 
-    set_expected_calls_for_IoTHubClient_Serialize_WritablePropertyResponse();
+    set_expected_calls_for_IoTHubClient_Properties_Writer_CreateWritableResponse();
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_WritablePropertyResponse(testWritableThreeProperties, 3, NULL, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateWritableResponse(testWritableThreeProperties, 3, NULL, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -869,7 +869,7 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_three_properties_success
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Serialize_Properties_Destroy(serializedProperties);
+    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_one_property_with_component_success)
@@ -878,10 +878,10 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_one_property_with_compon
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    set_expected_calls_for_IoTHubClient_Serialize_WritablePropertyResponse();
+    set_expected_calls_for_IoTHubClient_Properties_Writer_CreateWritableResponse();
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_WritablePropertyResponse(&TEST_WRITABLE_PROP1, 1, TEST_COMPONENT_NAME_1, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateWritableResponse(&TEST_WRITABLE_PROP1, 1, TEST_COMPONENT_NAME_1, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -890,7 +890,7 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_one_property_with_compon
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Serialize_Properties_Destroy(serializedProperties);
+    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_one_property_with_description_with_component_success)
@@ -899,10 +899,10 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_one_property_with_descri
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    set_expected_calls_for_IoTHubClient_Serialize_WritablePropertyResponse();
+    set_expected_calls_for_IoTHubClient_Properties_Writer_CreateWritableResponse();
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_WritablePropertyResponse(&TEST_WRITABLE_PROP2, 1, TEST_COMPONENT_NAME_1, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateWritableResponse(&TEST_WRITABLE_PROP2, 1, TEST_COMPONENT_NAME_1, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -911,7 +911,7 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_one_property_with_descri
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Serialize_Properties_Destroy(serializedProperties);
+    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_two_properties_with_component_success)
@@ -920,12 +920,12 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_two_properties_with_comp
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    const IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE testWritableTwoProperties[] = { TEST_WRITABLE_PROP1, TEST_WRITABLE_PROP2 };
+    const IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE testWritableTwoProperties[] = { TEST_WRITABLE_PROP1, TEST_WRITABLE_PROP2 };
 
-    set_expected_calls_for_IoTHubClient_Serialize_WritablePropertyResponse();
+    set_expected_calls_for_IoTHubClient_Properties_Writer_CreateWritableResponse();
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_WritablePropertyResponse(testWritableTwoProperties, 2, TEST_COMPONENT_NAME_1, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateWritableResponse(testWritableTwoProperties, 2, TEST_COMPONENT_NAME_1, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -934,7 +934,7 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_two_properties_with_comp
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Serialize_Properties_Destroy(serializedProperties);
+    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_three_properties_with_component_success)
@@ -943,12 +943,12 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_three_properties_with_co
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    const IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE testWritableThreeProperties[] = { TEST_WRITABLE_PROP1, TEST_WRITABLE_PROP2, TEST_WRITABLE_PROP3 };
+    const IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE testWritableThreeProperties[] = { TEST_WRITABLE_PROP1, TEST_WRITABLE_PROP2, TEST_WRITABLE_PROP3 };
 
-    set_expected_calls_for_IoTHubClient_Serialize_WritablePropertyResponse();
+    set_expected_calls_for_IoTHubClient_Properties_Writer_CreateWritableResponse();
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_WritablePropertyResponse(testWritableThreeProperties, 3, TEST_COMPONENT_NAME_1, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateWritableResponse(testWritableThreeProperties, 3, TEST_COMPONENT_NAME_1, &serializedProperties, &serializedPropertiesLength);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -957,7 +957,7 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_three_properties_with_co
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // free
-    IoTHubClient_Serialize_Properties_Destroy(serializedProperties);
+    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
 }
 
 TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_fail)
@@ -969,9 +969,9 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_fail)
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    const IOTHUB_CLIENT_WRITABLE_PROPERTY_RESPONSE testWritableThreeProperties[] = { TEST_WRITABLE_PROP1, TEST_WRITABLE_PROP2, TEST_WRITABLE_PROP3 };
+    const IOTHUB_CLIENT_PROPERTY_WRITABLE_RESPONSE testWritableThreeProperties[] = { TEST_WRITABLE_PROP1, TEST_WRITABLE_PROP2, TEST_WRITABLE_PROP3 };
 
-    set_expected_calls_for_IoTHubClient_Serialize_WritablePropertyResponse();
+    set_expected_calls_for_IoTHubClient_Properties_Writer_CreateWritableResponse();
     umock_c_negative_tests_snapshot();
 
     // act
@@ -983,7 +983,7 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_fail)
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
             
-            IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_WritablePropertyResponse(testWritableThreeProperties, 3, NULL, &serializedProperties, &serializedPropertiesLength);
+            IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateWritableResponse(testWritableThreeProperties, 3, NULL, &serializedProperties, &serializedPropertiesLength);
 
             //assert
             ASSERT_ARE_NOT_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -994,46 +994,46 @@ TEST_FUNCTION(IoTHubClient_Serialize_WritableProperties_fail)
 }
 
 //
-// IoTHubClient_Serialize_Properties_Destroy tests
+// IoTHubClient_Properties_Properties_Writer_Destroy tests
 // 
-static void set_expected_calls_for_IoTHubClient_Serialize_Properties_Destroy(void)
+static void set_expected_calls_for_IoTHubClient_Properties_Properties_Writer_Destroy(void)
 {
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_Properties_Destroy_success)
+TEST_FUNCTION(IoTHubClient_Properties_Properties_Writer_Destroy_success)
 {
     // arrange
     unsigned char* serializedProperties = NULL;
     size_t serializedPropertiesLength = 0;
 
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Serialize_ReportedProperties(&TEST_REPORTED_PROP1, 1, TEST_COMPONENT_NAME_1, &serializedProperties, &serializedPropertiesLength);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Writer_CreateReported(&TEST_REPORTED_PROP1, 1, TEST_COMPONENT_NAME_1, &serializedProperties, &serializedPropertiesLength);
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
     ASSERT_IS_NOT_NULL(serializedPropertiesLength);
 
     umock_c_reset_all_calls();
-    set_expected_calls_for_IoTHubClient_Serialize_Properties_Destroy();
+    set_expected_calls_for_IoTHubClient_Properties_Properties_Writer_Destroy();
 
     // act
-    IoTHubClient_Serialize_Properties_Destroy(serializedProperties);
+    IoTHubClient_Properties_Properties_Writer_Destroy(serializedProperties);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-TEST_FUNCTION(IoTHubClient_Serialize_Properties_Destroy_null)
+TEST_FUNCTION(IoTHubClient_Properties_Properties_Writer_Destroy_null)
 {
     // act
-    IoTHubClient_Serialize_Properties_Destroy(NULL);
+    IoTHubClient_Properties_Properties_Writer_Destroy(NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
 //
-// IoTHubClient_Deserialize_Properties_CreateIterator tests
+// IoTHubClient_Properties_Parser_Create tests
 //
-static void set_expected_calls_for_IoTHubClient_Deserialize_Properties_CreateIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE payloadType)
+static void set_expected_calls_for_IoTHubClient_Properties_Parser_Create(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE payloadType)
 {
     STRICT_EXPECTED_CALL(gballoc_calloc(IGNORED_NUM_ARG, IGNORED_NUM_ARG));
     STRICT_EXPECTED_CALL(gballoc_calloc(IGNORED_NUM_ARG, IGNORED_NUM_ARG));
@@ -1049,15 +1049,15 @@ static void set_expected_calls_for_IoTHubClient_Deserialize_Properties_CreateIte
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 }
 
-static IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE payloadType, const unsigned char* payload)
+static IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE payloadType, const unsigned char* payload)
 {
     umock_c_reset_all_calls();
 
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = NULL;
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = NULL;
     size_t payloadLength = strlen((const char*)payload);
-    set_expected_calls_for_IoTHubClient_Deserialize_Properties_CreateIterator(payloadType);
+    set_expected_calls_for_IoTHubClient_Properties_Parser_Create(payloadType);
 
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Deserialize_Properties_CreateIterator(payloadType, payload, payloadLength, &h);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_Create(payloadType, payload, payloadLength, &h);
 
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
     ASSERT_IS_NOT_NULL(h);
@@ -1068,131 +1068,131 @@ static IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE TestAllocatePropertyIterator(IOTHU
     return h;
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_CreateIterator_invalid_payload_type)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_invalid_payload_type)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = NULL;
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = NULL;
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Deserialize_Properties_CreateIterator((IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE)1234, TEST_JSON_ONE_PROPERTY_ALL, TEST_JSON_ONE_PROPERTY_ALL_LEN,  &h);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_Create((IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE)1234, TEST_JSON_ONE_PROPERTY_ALL, TEST_JSON_ONE_PROPERTY_ALL_LEN,  &h);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
     ASSERT_IS_NULL(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_CreateIterator_NULL_payload)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_NULL_payload)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = NULL;
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = NULL;
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Deserialize_Properties_CreateIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, NULL, TEST_JSON_ONE_PROPERTY_ALL_LEN, &h);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_Create(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, NULL, TEST_JSON_ONE_PROPERTY_ALL_LEN, &h);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
     ASSERT_IS_NULL(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_CreateIterator_zero_payloadLength)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_zero_payloadLength)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = NULL;
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = NULL;
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Deserialize_Properties_CreateIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL, 0, &h);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_Create(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL, 0, &h);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
     ASSERT_IS_NULL(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_CreateIterator_NULL_handle)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_NULL_handle)
 {
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Deserialize_Properties_CreateIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL, TEST_JSON_ONE_PROPERTY_ALL_LEN, NULL);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_Create(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL, TEST_JSON_ONE_PROPERTY_ALL_LEN, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_CreateIterator_all_success)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_all_success)
 {
     // act
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
 
     // cleanup
-    IoTHubClient_Deserialize_Properties_DestroyIterator(h);
+    IoTHubClient_Properties_Parser_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_CreateIterator_all_with_components_success)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_all_with_components_success)
 {
     // act
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
 
     // cleanup
-    IoTHubClient_Deserialize_Properties_DestroyIterator(h);
+    IoTHubClient_Properties_Parser_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_CreateIterator_writable_success)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_writable_success)
 {
     // act
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_WRITABLE);
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_WRITABLE);
 
     // cleanup
-    IoTHubClient_Deserialize_Properties_DestroyIterator(h);
+    IoTHubClient_Properties_Parser_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_CreateIterator_no_properties_success)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_no_properties_success)
 {
     // act
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_NO_DESIRED);
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_NO_DESIRED);
 
     // cleanup
-    IoTHubClient_Deserialize_Properties_DestroyIterator(h);
+    IoTHubClient_Properties_Parser_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_CreateIterator_writable_with_components_success)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_writable_with_components_success)
 {
     // act
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_WRITABLE);
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_WRITABLE);
 
     // cleanup
-    IoTHubClient_Deserialize_Properties_DestroyIterator(h);
+    IoTHubClient_Properties_Parser_Destroy(h);
 }
 
-static void test_IoTHubClient_Deserialize_Properties_CreateIterator_invalid_json(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE payloadType, const unsigned char* invalidJson)
+static void test_IoTHubClient_Properties_Parser_Create_invalid_json(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE payloadType, const unsigned char* invalidJson)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = NULL;
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = NULL;
     size_t invalidJsonLen = strlen((const char*)invalidJson);
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Deserialize_Properties_CreateIterator(payloadType, invalidJson, invalidJsonLen, &h);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_Create(payloadType, invalidJson, invalidJsonLen, &h);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_ERROR, result);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_CreateIterator_writable_invalid_JSON_fail)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_writable_invalid_JSON_fail)
 {
-    test_IoTHubClient_Deserialize_Properties_CreateIterator_invalid_json(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_INVALID_JSON);
+    test_IoTHubClient_Properties_Parser_Create_invalid_json(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_INVALID_JSON);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_CreateIterator_writable_missing_version_fail)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_writable_missing_version_fail)
 {
-    test_IoTHubClient_Deserialize_Properties_CreateIterator_invalid_json(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_NO_VERSION);
+    test_IoTHubClient_Properties_Parser_Create_invalid_json(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_NO_VERSION);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_CreateIterator_fail)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_Create_fail)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = NULL;
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = NULL;
 
     int negativeTestsInitResult = umock_c_negative_tests_init();
     ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
-    set_expected_calls_for_IoTHubClient_Deserialize_Properties_CreateIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL);
+    set_expected_calls_for_IoTHubClient_Properties_Parser_Create(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL);
     umock_c_negative_tests_snapshot();
 
     // act
@@ -1204,7 +1204,7 @@ TEST_FUNCTION(IoTHubClient_Deserialize_Properties_CreateIterator_fail)
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
 
-            IOTHUB_CLIENT_RESULT result = IoTHubClient_Deserialize_Properties_CreateIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL, TEST_JSON_ONE_PROPERTY_ALL_LEN, &h);
+            IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_Create(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL, TEST_JSON_ONE_PROPERTY_ALL_LEN, &h);
 
             //assert
             ASSERT_ARE_NOT_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
@@ -1214,15 +1214,15 @@ TEST_FUNCTION(IoTHubClient_Deserialize_Properties_CreateIterator_fail)
 }
 
 //
-// IoTHubClient_Deserialize_Properties_GetVersion tests
+// IoTHubClient_Properties_Parser_GetVersion tests
 //
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetVersion_NULL_handle)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetVersion_NULL_handle)
 {
     // arrange
     int propertiesVersion = TEST_DEFAULT_PROPERTIES_VERSION;
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Deserialize_Properties_GetVersion(NULL, &propertiesVersion);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetVersion(NULL, &propertiesVersion);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
@@ -1230,63 +1230,63 @@ TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetVersion_NULL_handle)
     ASSERT_ARE_EQUAL(int, TEST_DEFAULT_PROPERTIES_VERSION, propertiesVersion);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetVersion_NULL_version)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetVersion_NULL_version)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_WRITABLE);
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_WRITABLE);
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Deserialize_Properties_GetVersion(h, NULL);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetVersion(h, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
 
     // cleanup
-    IoTHubClient_Deserialize_Properties_DestroyIterator(h);    
+    IoTHubClient_Properties_Parser_Destroy(h);    
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetVersion_writable_update_success)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetVersion_writable_update_success)
 {
     // arrange
     int propertiesVersion;
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_WRITABLE);
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_WRITABLE);
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Deserialize_Properties_GetVersion(h, &propertiesVersion);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetVersion(h, &propertiesVersion);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
     ASSERT_ARE_EQUAL(int, TEST_TWIN_VER_2, propertiesVersion);
 
     // cleanup
-    IoTHubClient_Deserialize_Properties_DestroyIterator(h);
+    IoTHubClient_Properties_Parser_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetVersion_full_twin_success)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetVersion_full_twin_success)
 {
     // arrange
     int propertiesVersion;
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Deserialize_Properties_GetVersion(h, &propertiesVersion);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetVersion(h, &propertiesVersion);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
     ASSERT_ARE_EQUAL(int, TEST_TWIN_VER_1, propertiesVersion);
 
     // cleanup
-    IoTHubClient_Deserialize_Properties_DestroyIterator(h);
+    IoTHubClient_Properties_Parser_Destroy(h);
 }
 
 //
-// IoTHubClient_Deserialize_Properties_GetNextProperty tests
+// IoTHubClient_Properties_Parser_GetNext tests
 //
-static void ResetTestProperty(IOTHUB_CLIENT_DESERIALIZED_PROPERTY* property)
+static void ResetTestProperty(IOTHUB_CLIENT_PROPERTY_PARSED* property)
 {
     memset(property, 0, sizeof(*property));
-    property->structVersion = IOTHUB_CLIENT_DESERIALIZED_PROPERTY_STRUCT_VERSION_1;
+    property->structVersion = IOTHUB_CLIENT_PROPERTY_PARSED_STRUCT_VERSION_1;
 }
 
-static void CompareProperties(const IOTHUB_CLIENT_DESERIALIZED_PROPERTY* expectedProperty, IOTHUB_CLIENT_DESERIALIZED_PROPERTY* actualProperty)
+static void CompareProperties(const IOTHUB_CLIENT_PROPERTY_PARSED* expectedProperty, IOTHUB_CLIENT_PROPERTY_PARSED* actualProperty)
 {
     ASSERT_ARE_EQUAL(int, expectedProperty->structVersion, actualProperty->structVersion);
     ASSERT_ARE_EQUAL(int, expectedProperty->propertyType, actualProperty->propertyType);
@@ -1297,21 +1297,21 @@ static void CompareProperties(const IOTHUB_CLIENT_DESERIALIZED_PROPERTY* expecte
     ASSERT_ARE_EQUAL(int, expectedProperty->valueLength, actualProperty->valueLength);
 }
 
-static void TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE payloadType, const unsigned char* payload, const IOTHUB_CLIENT_DESERIALIZED_PROPERTY* expectedProperties, size_t numExpectedProperties)
+static void TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE payloadType, const unsigned char* payload, const IOTHUB_CLIENT_PROPERTY_PARSED* expectedProperties, size_t numExpectedProperties)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = TestAllocatePropertyIterator(payloadType, payload);
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(payloadType, payload);
     size_t numPropertiesVisited = 0;
 
     // act|assert
 
     while (true)
     {
-        IOTHUB_CLIENT_DESERIALIZED_PROPERTY property;
+        IOTHUB_CLIENT_PROPERTY_PARSED property;
         bool propertySpecified;
         ResetTestProperty(&property);
 
-        IOTHUB_CLIENT_RESULT result = IoTHubClient_Deserialize_Properties_GetNextProperty(h, &property, &propertySpecified);
+        IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetNext(h, &property, &propertySpecified);
         ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
 
         if (numPropertiesVisited == numExpectedProperties)
@@ -1325,23 +1325,23 @@ static void TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_TYPE paylo
 
         CompareProperties(expectedProperties + numPropertiesVisited, &property);
 
-        IoTHubClient_Deserialize_Properties_DestroyProperty(&property);
+        IoTHubClient_Properties_ParsedProperty_Destroy(&property);
         numPropertiesVisited++;
     }
 
     // cleanup
-    IoTHubClient_Deserialize_Properties_DestroyIterator(h);
+    IoTHubClient_Properties_Parser_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_NULL_handle)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_NULL_handle)
 {
     // arrange
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY property;
+    IOTHUB_CLIENT_PROPERTY_PARSED property;
     ResetTestProperty(&property);
     bool propertySpecified = false;
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Deserialize_Properties_GetNextProperty(NULL, &property, &propertySpecified);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetNext(NULL, &property, &propertySpecified);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
@@ -1349,47 +1349,47 @@ TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_NULL_handle)
     CompareProperties(&unfilledProperty, &property);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_NULL_property)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_NULL_property)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
     bool propertySpecified = false;
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Deserialize_Properties_GetNextProperty(h, NULL, &propertySpecified);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetNext(h, NULL, &propertySpecified);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
     ASSERT_IS_FALSE(propertySpecified);
 
     // cleanup
-    IoTHubClient_Deserialize_Properties_DestroyIterator(h);
+    IoTHubClient_Properties_Parser_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_NULL_propertySpecified)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_NULL_propertySpecified)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY property;
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
+    IOTHUB_CLIENT_PROPERTY_PARSED property;
     ResetTestProperty(&property);
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Deserialize_Properties_GetNextProperty(h, &property, NULL);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetNext(h, &property, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
     CompareProperties(&unfilledProperty, &property);
 
     // cleanup
-    IoTHubClient_Deserialize_Properties_DestroyIterator(h);
+    IoTHubClient_Properties_Parser_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_wrong_struct_version)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_wrong_struct_version)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY wrongVersion;
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY property;
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
+    IOTHUB_CLIENT_PROPERTY_PARSED wrongVersion;
+    IOTHUB_CLIENT_PROPERTY_PARSED property;
     bool propertySpecified = false;
 
     memset(&wrongVersion, 0, sizeof(wrongVersion));
@@ -1397,188 +1397,188 @@ TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_wrong_struct_v
     memcpy(&property, &wrongVersion, sizeof(property));
 
     // act
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Deserialize_Properties_GetNextProperty(h, &property, &propertySpecified);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetNext(h, &property, &propertySpecified);
 
     // assert
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_INVALID_ARG, result);
-    // Make sure IoTHubClient_Deserialize_Properties_GetNextProperty didn't modify property in error case
+    // Make sure IoTHubClient_Properties_Parser_GetNext didn't modify property in error case
     ASSERT_IS_TRUE(0 == memcmp(&wrongVersion, &property, sizeof(property)));
     ASSERT_IS_FALSE(propertySpecified);
 
     // cleanup
-    IoTHubClient_Deserialize_Properties_DestroyIterator(h);
+    IoTHubClient_Properties_Parser_Destroy(h);
 }
 
 // Test only to just skip STRICT_EXPECT work
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_all_one_property_success)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_all_one_property_success)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY1 };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL, expectedPropList, 1);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_writable_one_property_success)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_writable_one_property_success)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY1 };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_WRITABLE, expectedPropList, 1);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_no_properties_success)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_no_properties_success)
 {
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_NO_DESIRED, NULL, 0);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_all_two_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_all_two_properties)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2 };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_TWO_PROPERTIES_ALL, expectedPropList, 2);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_writable_two_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_writable_two_properties)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2 };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_TWO_PROPERTIES_WRITABLE, expectedPropList, 2);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_all_three_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_all_three_properties)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY3 };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY3 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_THREE_PROPERTIES_ALL, expectedPropList, 3);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_writable_three_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_writable_three_properties)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY3 };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY3 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_THREE_PROPERTIES_WRITABLE, expectedPropList, 3);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_reported_one_property)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_reported_one_property)
 {
-     IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY4 };
+     IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY4 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_REPORTED_PROPERTY_ALL, expectedPropList, 1);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_reported_two_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_reported_two_properties)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5 };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_TWO_REPORTED_PROPERTIES_ALL, expectedPropList, 2);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_reported_three_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_reported_three_properties)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5, TEST_EXPECTED_PROPERTY6 };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5, TEST_EXPECTED_PROPERTY6 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_THREE_REPORTED_PROPERTIES_ALL, expectedPropList, 3);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_one_reported_update_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_one_reported_update_properties)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY4  };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY4  };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_REPORTED_UPDATE_PROPERTY_ALL, expectedPropList, 2);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_two_reported_update_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_two_reported_update_properties)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5 };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_TWO_REPORTED_UPDATE_PROPERTIES_ALL, expectedPropList, 4);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_three_reported_update_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_reported_update_properties)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY3, TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5, TEST_EXPECTED_PROPERTY6 };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY3, TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5, TEST_EXPECTED_PROPERTY6 };
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_THREE_REPORTED_UPDATE_PROPERTIES_ALL, expectedPropList, 6);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_one_writable_all_component)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_one_writable_all_component)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY1 };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1 };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_1;
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_COMPONENT_ALL, expectedPropList, 1);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_one_writable_update_component)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_one_writable_update_component)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY1 };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1 };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_1;
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_WRITABLE_UPDATES, TEST_JSON_ONE_PROPERTY_COMPONENT_WRITABLE, expectedPropList, 1);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_two_writable_all_component)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_two_writable_all_component)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2  };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2  };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_1;
     expectedPropList[1].componentName = TEST_COMPONENT_NAME_1;
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_TWO_PROPERTIES_COMPONENT_ALL, expectedPropList, 2);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_three_writable_all_component)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_writable_all_component)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY3  };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY3  };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_1;
     expectedPropList[1].componentName = TEST_COMPONENT_NAME_1;
     expectedPropList[2].componentName = TEST_COMPONENT_NAME_1;
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_THREE_PROPERTIES_COMPONENT_ALL, expectedPropList, 3);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_one_reported_all_component)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_one_reported_all_component)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY4 };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY4 };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_4;
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_REPORTED_PROPERTY_COMPONENT_ALL, expectedPropList, 1);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_two_reported_all_component)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_two_reported_all_component)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5  };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5  };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_4;
     expectedPropList[1].componentName = TEST_COMPONENT_NAME_4;
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_TWO_REPORTED_PROPERTIES_COMPONENT_ALL, expectedPropList, 2);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_three_reported_all_component)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_reported_all_component)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5, TEST_EXPECTED_PROPERTY6  };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5, TEST_EXPECTED_PROPERTY6  };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_4;
     expectedPropList[1].componentName = TEST_COMPONENT_NAME_4;
     expectedPropList[2].componentName = TEST_COMPONENT_NAME_4;
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_THREE_REPORTED_PROPERTIES_COMPONENT_ALL, expectedPropList, 3);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_two_components_writable_all)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_two_components_writable_all)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2 };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2 };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_1;
     expectedPropList[1].componentName = TEST_COMPONENT_NAME_2;
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_TWO_UDPATE_PROPERTIES_TWO_COMPONENTS_ALL, expectedPropList, 2);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_three_components_writable_all)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_components_writable_all)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY3 };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY3 };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_1;
     expectedPropList[1].componentName = TEST_COMPONENT_NAME_2;
     expectedPropList[2].componentName = TEST_COMPONENT_NAME_3;
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_TWO_UDPATE_PROPERTIES_THREE_COMPONENTS_ALL, expectedPropList, 3);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_two_components_reported)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_two_components_reported)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5 };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5 };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_4;
     expectedPropList[1].componentName = TEST_COMPONENT_NAME_5;
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_TWO_REPORTED_PROPERTIES_TWO_COMPONENTS_ALL, expectedPropList, 2);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_three_components_reported)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_components_reported)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5, TEST_EXPECTED_PROPERTY6 };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5, TEST_EXPECTED_PROPERTY6 };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_4;
     expectedPropList[1].componentName = TEST_COMPONENT_NAME_5;
     expectedPropList[2].componentName = TEST_COMPONENT_NAME_6;
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_THREE_REPORTED_PROPERTIES_THREE_COMPONENTS_ALL, expectedPropList, 3);
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_three_writable_and_reported_properties)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_writable_and_reported_properties)
 {
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY3, TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5, TEST_EXPECTED_PROPERTY6 };
+    IOTHUB_CLIENT_PROPERTY_PARSED expectedPropList[] = { TEST_EXPECTED_PROPERTY1, TEST_EXPECTED_PROPERTY2, TEST_EXPECTED_PROPERTY3, TEST_EXPECTED_PROPERTY4, TEST_EXPECTED_PROPERTY5, TEST_EXPECTED_PROPERTY6 };
     expectedPropList[0].componentName = TEST_COMPONENT_NAME_1;
     expectedPropList[1].componentName = TEST_COMPONENT_NAME_2;
     expectedPropList[2].componentName = TEST_COMPONENT_NAME_3;
@@ -1589,7 +1589,7 @@ TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_three_writable
     TestDeserializedProperties(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_THREE_WRITABLE_REPORTED_IN_SEPARATE_COMPONENTS, expectedPropList, 6);
 }
 
-static void set_expected_calls_for_IoTHubClient_Deserialize_Properties_GetNextProperty_fail_tests(void)
+static void set_expected_calls_for_IoTHubClient_Properties_Parser_GetNext_fail_tests(void)
 {
     STRICT_EXPECTED_CALL(json_object_get_count(IGNORED_PTR_ARG)).CallCannotFail();
     STRICT_EXPECTED_CALL(json_object_get_name(IGNORED_PTR_ARG,IGNORED_NUM_ARG)).CallCannotFail();
@@ -1606,12 +1606,12 @@ static void set_expected_calls_for_IoTHubClient_Deserialize_Properties_GetNextPr
     STRICT_EXPECTED_CALL(json_serialize_to_string(IGNORED_PTR_ARG));
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_three_writable_and_reported_fail)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_GetNext_three_writable_and_reported_fail)
 {
     int negativeTestsInitResult = umock_c_negative_tests_init();
     ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
 
-    set_expected_calls_for_IoTHubClient_Deserialize_Properties_GetNextProperty_fail_tests();
+    set_expected_calls_for_IoTHubClient_Properties_Parser_GetNext_fail_tests();
     // We take the initial snapshot to get the count of tests, but then immediately de-init.  We don't follow
     // the standard convention of other _fail() tests here.  Because we do an iterator, it makes
     // changes to the state of the underlying reader.  So we create a new handle on each pass.
@@ -1627,116 +1627,116 @@ TEST_FUNCTION(IoTHubClient_Deserialize_Properties_GetNextProperty_three_writable
             continue;
         }
 
-        IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_COMPONENT_ALL);
+        IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_COMPONENT_ALL);
 
         // Reset up the negative test framework for this specific run.  Needed inside this for() loop
         // because of all the state changes GetNextProperty causes.
         umock_c_negative_tests_deinit();
         negativeTestsInitResult = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, negativeTestsInitResult);
-        set_expected_calls_for_IoTHubClient_Deserialize_Properties_GetNextProperty_fail_tests();
+        set_expected_calls_for_IoTHubClient_Properties_Parser_GetNext_fail_tests();
         umock_c_negative_tests_snapshot();
 
         umock_c_negative_tests_reset();
         umock_c_negative_tests_fail_call(index);
    
-        IOTHUB_CLIENT_DESERIALIZED_PROPERTY property;
+        IOTHUB_CLIENT_PROPERTY_PARSED property;
         bool propertySpecified = false;
         ResetTestProperty(&property);
 
-        IOTHUB_CLIENT_RESULT result = IoTHubClient_Deserialize_Properties_GetNextProperty(h, &property, &propertySpecified);
+        IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetNext(h, &property, &propertySpecified);
 
         ASSERT_ARE_NOT_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result, "Unexpected success on test run  %lu", (unsigned long)index);
         ASSERT_IS_FALSE(propertySpecified, "Unexpected property=TRUE on test run %lu", (unsigned long)index);
 
-        IoTHubClient_Deserialize_Properties_DestroyIterator(h);
+        IoTHubClient_Properties_Parser_Destroy(h);
     }
 }
 
 //
-// IoTHubClient_Deserialize_Properties_DestroyProperty tests
+// IoTHubClient_Properties_ParsedProperty_Destroy tests
 //
-static void set_expected_calls_for_IoTHubClient_Deserialize_Properties_DestroyProperty(void)
+static void set_expected_calls_for_IoTHubClient_Properties_ParsedProperty_Destroy(void)
 {
     STRICT_EXPECTED_CALL(json_free_serialized_string(IGNORED_PTR_ARG));
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_DestroyProperty_ok)
+TEST_FUNCTION(IoTHubClient_Properties_ParsedProperty_Destroy_ok)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
-    IOTHUB_CLIENT_DESERIALIZED_PROPERTY property;
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
+    IOTHUB_CLIENT_PROPERTY_PARSED property;
     bool propertySpecified;
     ResetTestProperty(&property);
 
-    IOTHUB_CLIENT_RESULT result = IoTHubClient_Deserialize_Properties_GetNextProperty(h, &property, &propertySpecified);
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_Properties_Parser_GetNext(h, &property, &propertySpecified);
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
     ASSERT_IS_TRUE(propertySpecified);
     umock_c_reset_all_calls();
 
-    set_expected_calls_for_IoTHubClient_Deserialize_Properties_DestroyProperty();
+    set_expected_calls_for_IoTHubClient_Properties_ParsedProperty_Destroy();
 
     // act
-    IoTHubClient_Deserialize_Properties_DestroyProperty(&property);
+    IoTHubClient_Properties_ParsedProperty_Destroy(&property);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // cleanup
-    IoTHubClient_Deserialize_Properties_DestroyIterator(h);
+    IoTHubClient_Properties_Parser_Destroy(h);
 
 }
 
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_DestroyProperty_null)
+TEST_FUNCTION(IoTHubClient_Properties_ParsedProperty_Destroy_null)
 {
     // act
-    IoTHubClient_Deserialize_Properties_DestroyProperty(NULL);
+    IoTHubClient_Properties_ParsedProperty_Destroy(NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
 //
-// IoTHubClient_Deserialize_Properties_DestroyIterator tests
+// IoTHubClient_Properties_Parser_Destroy tests
 //
-static void set_expected_calls_for_IoTHubClient_Deserialize_Properties_DestroyIterator(void)
+static void set_expected_calls_for_IoTHubClient_Properties_Parser_Destroy(void)
 {
     STRICT_EXPECTED_CALL(json_value_free(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_DestroyIterator_success)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_Destroy_success)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
-    set_expected_calls_for_IoTHubClient_Deserialize_Properties_DestroyIterator();
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
+    set_expected_calls_for_IoTHubClient_Properties_Parser_Destroy();
 
     // act
-    IoTHubClient_Deserialize_Properties_DestroyIterator(h);
+    IoTHubClient_Properties_Parser_Destroy(h);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_DestroyIterator_multiple_components_success)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_Destroy_multiple_components_success)
 {
     // arrange
-    IOTHUB_CLIENT_PROPERTY_ITERATOR_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
-    set_expected_calls_for_IoTHubClient_Deserialize_Properties_DestroyIterator();
+    IOTHUB_CLIENT_PROPERTIES_PARSER_HANDLE h = TestAllocatePropertyIterator(IOTHUB_CLIENT_PROPERTY_PAYLOAD_ALL, TEST_JSON_ONE_PROPERTY_ALL);
+    set_expected_calls_for_IoTHubClient_Properties_Parser_Destroy();
 
     // act
-    IoTHubClient_Deserialize_Properties_DestroyIterator(h);
+    IoTHubClient_Properties_Parser_Destroy(h);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
 
-TEST_FUNCTION(IoTHubClient_Deserialize_Properties_DestroyIterator_null)
+TEST_FUNCTION(IoTHubClient_Properties_Parser_Destroy_null)
 {
     // act
-    IoTHubClient_Deserialize_Properties_DestroyIterator(NULL);
+    IoTHubClient_Properties_Parser_Destroy(NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());


### PR DESCRIPTION
First shoutout to @cipop for thoughtful feedback that motivates this change.

Renaming the `iothub_client_properties.h` header for PnP SDK so that it's trying to build a C99-ish namespace, specifically around the `IoTHubClient_Properties`.  And using parser and writer instead of the (de)serialize language as I think parse and write are more natural.

One thing specifically I'd appreciate feedback on is that the structures tend to use "property" singular.  `IOTHUB_CLIENT_PROPERTY_REPORTED`.  But then the functions use "properties" plural.  `IoTHubClient_Properties_Writer_CreateReported` e.g.  I think this is OK because the struct is about one property, whereas many of the "properties" API's are all about handling potentially >1 property.  I *think* this is best I can do but would appreciate 2nd opinions.

Thanks