### PR TITLE
Remove prompt in TPM device provision tool

### DIFF
--- a/provisioning_client/tools/tpm_device_provision/tpm_device_provision.c
+++ b/provisioning_client/tools/tpm_device_provision/tpm_device_provision.c
@@ -98,7 +98,5 @@ int main(void)
         platform_deinit();
     }
 
-    (void)printf("\r\nPress any key to continue:\r\n");
-    (void)getchar();
     return result;
 }


### PR DESCRIPTION
Remove the need for user interaction in tool for gathering TPM-information on device.

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down). __NOTE__: I don't __think__ tests exist nor are needed for the code that changed. (Please, correct me if I'm wrong).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [X] This pull-request is submitted against the `main` branch. 
  - [ ] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback. 
  - [X] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
When running the tool for gathering TPM info, we experience automation difficulties when user interaction is needed.

# Description of the solution
We simply removed the prompt for user to press a key to continue