### PR TITLE
'verion' => 'version'

### DIFF
--- a/configs/azure_iot_sdksFunctions.cmake
+++ b/configs/azure_iot_sdksFunctions.cmake
@@ -15,10 +15,19 @@ function(getIoTSDKVersion)
         string(REGEX MATCH "^[\t ]*#[\t ]*define[\t ]*IOTHUB_SDK_VERSION[\t ]*\"([0-9]+)[\\.]([0-9]+)[\\.]([0-9]+)\"" temp "${iotsdkverstr}")
 
         if (NOT "${CMAKE_MATCH_3}" STREQUAL "")
-            set (IOT_SDK_VERION_MAJOR "${CMAKE_MATCH_1}" PARENT_SCOPE)
-            set (IOT_SDK_VERION_MINOR "${CMAKE_MATCH_2}" PARENT_SCOPE)
-            set (IOT_SDK_VERION_FIX "${CMAKE_MATCH_3}" PARENT_SCOPE)
+            set (_IOT_SDK_VERSION_MAJOR "${CMAKE_MATCH_1}")
+            set (_IOT_SDK_VERSION_MINOR "${CMAKE_MATCH_2}")
+            set (_IOT_SDK_VERSION_FIX "${CMAKE_MATCH_3}")
+            set (IOT_SDK_VERSION_MAJOR ${_IOT_SDK_VERSION_MAJOR} PARENT_SCOPE)
+            set (IOT_SDK_VERSION_MINOR ${_IOT_SDK_VERSION_MINOR} PARENT_SCOPE)
+            set (IOT_SDK_VERSION_FIX ${_IOT_SDK_VERSION_FIX} PARENT_SCOPE)
             set (IOT_SDK_VERSION "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}" PARENT_SCOPE)
+
+            # Keep the name "IOT_SDK_VERION_*" around because previous versions of this script
+            # had a mispelling and public scope means other projects may be relying on that.
+            set (IOT_SDK_VERION_MAJOR ${_IOT_SDK_VERSION_MAJOR} PARENT_SCOPE)
+            set (IOT_SDK_VERION_MINOR ${_IOT_SDK_VERSION_MINOR} PARENT_SCOPE)
+            set (IOT_SDK_VERION_FIX ${_IOT_SDK_VERSION_FIX} PARENT_SCOPE)
         else ()
             message(FATAL_ERROR "Unable to find version in ${iotsdkverstr}")
         endif()

--- a/iothub_client/CMakeLists.txt
+++ b/iothub_client/CMakeLists.txt
@@ -413,7 +413,7 @@ if (${build_as_dynamic})
         ARCHIVE_OUTPUT_NAME "iothub_client_dll_import"
         ENABLE_EXPORTS YES
         VERSION ${IOT_SDK_VERSION}
-        SOVERSION ${IOT_SDK_VERION_MAJOR}
+        SOVERSION ${IOT_SDK_VERSION_MAJOR}
         BUILD_WITH_INSTALL_RPATH TRUE
     )
     set(iothub_client_libs

--- a/iothub_service_client/CMakeLists.txt
+++ b/iothub_service_client/CMakeLists.txt
@@ -73,7 +73,7 @@ if (${build_as_dynamic})
         WINDOWS_EXPORT_ALL_SYMBOLS YES
         PDB_NAME "iothub_service_client_dll"
         VERSION ${IOT_SDK_VERSION}
-        SOVERSION ${IOT_SDK_VERION_MAJOR}
+        SOVERSION ${IOT_SDK_VERSION_MAJOR}
         BUILD_WITH_INSTALL_RPATH TRUE
     )
     set (install_libs ${install_libs} iothub_service_client_dll)

--- a/serializer/CMakeLists.txt
+++ b/serializer/CMakeLists.txt
@@ -94,7 +94,7 @@ if (${build_as_dynamic})
         WINDOWS_EXPORT_ALL_SYMBOLS YES
         PDB_NAME "serializer_dll"
         VERSION ${IOT_SDK_VERSION}
-        SOVERSION ${IOT_SDK_VERION_MAJOR}
+        SOVERSION ${IOT_SDK_VERSION_MAJOR}
         BUILD_WITH_INSTALL_RPATH TRUE
     )
     set (install_libs ${install_libs} serializer_dll)


### PR DESCRIPTION
We had places where we were spelling `verion` where we really meant `version`.

Unfortunately the fix isn't as easy as a simple search/replace, because some of variables ended up in PUBLIC scope.  So we continue to set the verion for back-compat though for our CMake referencing this we prefer the correct spelling.

Further complicating this is that PUBLIC scope variables are **only** in the public scope, so I need to use a temporary local variable to then assign to the PUBLIC variants.  (Thanks to SO author of [this](https://stackoverflow.com/questions/47036330/cant-access-cmake-variable-defined-inside-function-using-parent-scope).)

Tag @gtrevi who has given feedback on some preview changes where we had similar problems.

