### PR TITLE
Fix AMQP batching check of current payload size

### DIFF
--- a/iothub_client/src/iothubtransport_amqp_telemetry_messenger.c
+++ b/iothub_client/src/iothubtransport_amqp_telemetry_messenger.c
@@ -1217,7 +1217,7 @@ static int send_pending_events(TELEMETRY_MESSENGER_INSTANCE* instance)
         // The task is responsible for running through its callers for callbacks, even for errors in this function.
         // Similarly, responsibility for freeing this memory falls on the 'task' cleanup also.
 
-        if (body_binary_data.length + send_pending_events_state.bytes_pending > max_messagesize)
+        if ((body_binary_data.length + send_pending_events_state.bytes_pending) > max_messagesize)
         {
             // If we tried to add the current message, we would overflow.  Send what we've queued immediately.
             if (send_batched_message_and_reset_state(instance, &send_pending_events_state) != RESULT_OK)


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-c/issues/2233

# Description of the problem
Lack of parenthesis can cause AMQP batching to fail.

The lack of parenthesis causes the if statement to evaluate
`send_pending_events_state.bytes_pending > max_messagesize` before
`body_binary_data.length + send_pending_events_state.bytes_pending`,
which could cause the total size of the final AMQP TRANSFER to
exceed the Azure IoT Hub limit.

# Description of the solution
Properly group the members of the if statement. 