### PR TITLE
Add E2E test to verify AMQP telemetry batching against IoT Hub GWv2

### DIFF
--- a/iothub_client/tests/common_e2e/iothubclient_common_e2e.h
+++ b/iothub_client/tests/common_e2e/iothubclient_common_e2e.h
@@ -39,6 +39,7 @@ extern void e2e_init(TEST_PROTOCOL_TYPE protocol_type, bool testing_modules);
 extern void e2e_deinit(void);
 
 extern void e2e_send_event_test_sas(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol);
+extern void e2e_send_events_test_sas(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol, int count);
 extern void e2e_send_event_test_x509(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol);
 extern void e2e_recv_message_test_sas(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol);
 extern void e2e_recv_message_test_x509(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol);

--- a/iothub_client/tests/iothubclient_amqp_e2e/iothubclient_amqp_e2e.c
+++ b/iothub_client/tests/iothubclient_amqp_e2e/iothubclient_amqp_e2e.c
@@ -5,6 +5,8 @@
 #include "iothubclient_common_e2e.h"
 #include "iothubtransportamqp.h"
 
+#define TELEMETRY_BATCH_SIZE 3500
+
 BEGIN_TEST_SUITE(iothubclient_amqp_e2e)
 
     TEST_SUITE_INITIALIZE(TestClassInitialize)
@@ -23,6 +25,25 @@ BEGIN_TEST_SUITE(iothubclient_amqp_e2e)
         g_e2e_test_options.set_mac_address = true;
 #endif
         e2e_send_event_test_sas(AMQP_Protocol);
+    }
+
+    TEST_FUNCTION(IoTHub_AMQP_SendBatchEvents_e2e_sas)
+    {
+#ifdef AZIOT_LINUX
+        g_e2e_test_options.set_mac_address = true;
+#endif
+        IOTHUB_GATEWAY_VERSION iotHubVersion = IoTHubAccount_GetIoTHubVersion(g_iothubAcctInfo);
+
+        ASSERT_ARE_NOT_EQUAL(int, IOTHUB_GATEWAY_VERSION_UNDEFINED, iotHubVersion);
+
+        if (iotHubVersion == IOTHUB_GATEWAY_VERSION_2)
+        {
+            e2e_send_events_test_sas(AMQP_Protocol, TELEMETRY_BATCH_SIZE);
+        }
+        else
+        {
+            // Skipping the test if not running against IoT Hub Gateway V2.
+        }
     }
 
     TEST_FUNCTION(IoTHub_AMQP_RecvMessage_E2ETest_sas)

--- a/testtools/iothub_test/inc/iothub_account.h
+++ b/testtools/iothub_test/inc/iothub_account.h
@@ -21,6 +21,13 @@ extern "C"
 
 MU_DEFINE_ENUM(IOTHUB_ACCOUNT_AUTH_METHOD, IOTHUB_ACCOUNT_AUTH_METHOD_VALUES);
 
+#define IOTHUB_GATEWAY_VERSION_VALUES    \
+    IOTHUB_GATEWAY_VERSION_UNDEFINED,    \
+    IOTHUB_GATEWAY_VERSION_1,            \
+    IOTHUB_GATEWAY_VERSION_2
+
+MU_DEFINE_ENUM(IOTHUB_GATEWAY_VERSION, IOTHUB_GATEWAY_VERSION_VALUES);
+
 typedef struct IOTHUB_PROVISIONED_DEVICE_TAG {
     char* connectionString;
     char* primaryAuthentication;
@@ -46,6 +53,7 @@ extern const char* IoTHubAccount_GetEventHubConnectionString(IOTHUB_ACCOUNT_INFO
 extern const char* IoTHubAccount_GetIoTHostName(IOTHUB_ACCOUNT_INFO_HANDLE acctHandle);
 extern const char* IoTHubAccount_GetIoTHubName(IOTHUB_ACCOUNT_INFO_HANDLE acctHandle);
 extern const char* IoTHubAccount_GetIoTHubSuffix(IOTHUB_ACCOUNT_INFO_HANDLE acctHandle);
+extern IOTHUB_GATEWAY_VERSION IoTHubAccount_GetIoTHubVersion(IOTHUB_ACCOUNT_INFO_HANDLE acctHandle);
 extern IOTHUB_PROVISIONED_DEVICE* IoTHubAccount_GetSASDevice(IOTHUB_ACCOUNT_INFO_HANDLE acctHandle);
 extern IOTHUB_PROVISIONED_DEVICE** IoTHubAccount_GetSASDevices(IOTHUB_ACCOUNT_INFO_HANDLE acctHandle);
 extern IOTHUB_PROVISIONED_DEVICE* IoTHubAccount_GetX509Device(IOTHUB_ACCOUNT_INFO_HANDLE acctHandle);

--- a/testtools/iothub_test/src/iothub_account.c
+++ b/testtools/iothub_test/src/iothub_account.c
@@ -55,6 +55,18 @@ const int TEST_SLEEP_THROTTLE_MSEC = 5 * 1000;
 const int TEST_SLEEP_BETWEEN_CREATION_FAILURES_MSEC = 30 * 1000;
 const int TEST_SLEEP_BETWEEN_METHOD_INVOKE_FAILURES_MSEC = 30 * 1000;
 
+#define NSLOOKUP_MAX_COMMAND_SIZE 128
+
+#ifndef popen
+// If running on Microsoft Windows.
+#define popen _popen
+#endif
+
+#ifndef pclose
+// If running on Microsoft Windows.
+#define pclose _pclose
+#endif
+
 typedef struct IOTHUB_ACCOUNT_INFO_TAG
 {
     const char* connString;
@@ -1137,3 +1149,46 @@ const IOTHUB_MESSAGING_HANDLE IoTHubAccount_GetMessagingHandle(IOTHUB_ACCOUNT_IN
     return result;
 }
 
+IOTHUB_GATEWAY_VERSION IoTHubAccount_GetIoTHubVersion(IOTHUB_ACCOUNT_INFO_HANDLE acctHandle)
+{
+    IOTHUB_GATEWAY_VERSION result = IOTHUB_GATEWAY_VERSION_UNDEFINED;
+
+    const char* iotHubFqdn = IoTHubAccount_GetIoTHostName(acctHandle);
+
+    if (iotHubFqdn != NULL)
+    {
+        const char* IoTHubGwV1Suffix = "ihsu-";
+        const char* IoTHubGwV2Suffix = "gateway-prod-gw-";
+        const char* nslookup_fmt = "nslookup %s";
+        char command[NSLOOKUP_MAX_COMMAND_SIZE];
+        char stdoutLine[128];
+
+        int commandLength = snprintf(command, NSLOOKUP_MAX_COMMAND_SIZE, nslookup_fmt, iotHubFqdn);
+
+        if (commandLength > 0 && commandLength < NSLOOKUP_MAX_COMMAND_SIZE)
+        {
+            FILE* stdOut = popen(command, "r");
+
+            while (fgets(stdoutLine, sizeof(stdoutLine), stdOut) != NULL)
+            {
+                if (strstr(stdoutLine, "Name:") == stdoutLine)
+                {
+                    if (strstr(stdoutLine, IoTHubGwV1Suffix) != NULL)
+                    {
+                        result = IOTHUB_GATEWAY_VERSION_1;
+                    }
+                    else if (strstr(stdoutLine, IoTHubGwV2Suffix) != NULL)
+                    {
+                        result = IOTHUB_GATEWAY_VERSION_2;
+                    }
+
+                    break;
+                }
+            }
+
+            (void)pclose(stdOut);
+        }
+    }
+
+    return result;
+}


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
The azure-iot-sdk-c e2e tests do not cover AMQP telemetry batching.

# Description of the solution
Add e2e for AMQP telemetry batching.
The test is aimed at the IoT Hub GWv2 only, as there is a bug in GWv1 that prevents proper functionality of batching. 