### PR TITLE
sample code doesn't send required headers as needed for distributed tracing.

### DIFF
--- a/iothub_client/samples/iothub_ll_telemetry_sample/alt_sample.c
+++ b/iothub_client/samples/iothub_ll_telemetry_sample/alt_sample.c
@@ -1,0 +1,199 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// CAVEAT: This sample is to demonstrate azure IoT client concepts only and is not a guide design principles or style
+// Checking of return codes and error values shall be omitted for brevity.  Please practice sound engineering practices
+// when writing production code.
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "iothub.h"
+#include "iothub_device_client_ll.h"
+#include "iothub_client_options.h"
+#include "iothub_message.h"
+#include "azure_c_shared_utility/threadapi.h"
+#include "azure_c_shared_utility/crt_abstractions.h"
+#include "azure_c_shared_utility/shared_util_options.h"
+
+#ifdef SET_TRUSTED_CERT_IN_SAMPLES
+#include "certs.h"
+#endif // SET_TRUSTED_CERT_IN_SAMPLES
+
+/* This sample uses the _LL APIs of iothub_client for example purposes.
+Simply changing the using the convenience layer (functions not having _LL)
+and removing calls to _DoWork will yield the same results. */
+
+// The protocol you wish to use should be uncommented
+//
+#define SAMPLE_MQTT
+//#define SAMPLE_MQTT_OVER_WEBSOCKETS
+//#define SAMPLE_AMQP
+//#define SAMPLE_AMQP_OVER_WEBSOCKETS
+//#define SAMPLE_HTTP
+
+#ifdef SAMPLE_MQTT
+    #include "iothubtransportmqtt.h"
+#endif // SAMPLE_MQTT
+#ifdef SAMPLE_MQTT_OVER_WEBSOCKETS
+    #include "iothubtransportmqtt_websockets.h"
+#endif // SAMPLE_MQTT_OVER_WEBSOCKETS
+#ifdef SAMPLE_AMQP
+    #include "iothubtransportamqp.h"
+#endif // SAMPLE_AMQP
+#ifdef SAMPLE_AMQP_OVER_WEBSOCKETS
+    #include "iothubtransportamqp_websockets.h"
+#endif // SAMPLE_AMQP_OVER_WEBSOCKETS
+#ifdef SAMPLE_HTTP
+    #include "iothubtransporthttp.h"
+#endif // SAMPLE_HTTP
+
+#ifdef SET_TRUSTED_CERT_IN_SAMPLES
+#include "certs.h"
+#endif // SET_TRUSTED_CERT_IN_SAMPLES
+
+// <snippet_config>
+/* Paste in the your iothub connection string  */
+static const char* connectionString = "[device connection string]";
+#define MESSAGE_COUNT        5000
+static bool g_continueRunning = true;
+static size_t g_message_count_send_confirmations = 0;
+// </snippet_config>
+
+static void send_confirm_callback(IOTHUB_CLIENT_CONFIRMATION_RESULT result, void* userContextCallback)
+{
+    (void)userContextCallback;
+    // When a message is sent this callback will get envoked
+    g_message_count_send_confirmations++;
+    (void)printf("Confirmation callback received for message %lu with result %s\r\n", (unsigned long)g_message_count_send_confirmations, ENUM_TO_STRING(IOTHUB_CLIENT_CONFIRMATION_RESULT, result));
+}
+
+static void connection_status_callback(IOTHUB_CLIENT_CONNECTION_STATUS result, IOTHUB_CLIENT_CONNECTION_STATUS_REASON reason, void* user_context)
+{
+    (void)reason;
+    (void)user_context;
+    // This sample DOES NOT take into consideration network outages.
+    if (result == IOTHUB_CLIENT_CONNECTION_AUTHENTICATED)
+    {
+        (void)printf("The device client is connected to iothub\r\n");
+    }
+    else
+    {
+        (void)printf("The device client has been disconnected\r\n");
+    }
+}
+
+int main(void)
+{
+    IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol;
+    IOTHUB_MESSAGE_HANDLE message_handle;
+    size_t messages_sent = 0;
+    const char* telemetry_msg = "test_message";
+
+    // Select the Protocol to use with the connection
+#ifdef SAMPLE_MQTT
+    protocol = MQTT_Protocol;
+#endif // SAMPLE_MQTT
+#ifdef SAMPLE_MQTT_OVER_WEBSOCKETS
+    protocol = MQTT_WebSocket_Protocol;
+#endif // SAMPLE_MQTT_OVER_WEBSOCKETS
+#ifdef SAMPLE_AMQP
+    protocol = AMQP_Protocol;
+#endif // SAMPLE_AMQP
+#ifdef SAMPLE_AMQP_OVER_WEBSOCKETS
+    protocol = AMQP_Protocol_over_WebSocketsTls;
+#endif // SAMPLE_AMQP_OVER_WEBSOCKETS
+#ifdef SAMPLE_HTTP
+    protocol = HTTP_Protocol;
+#endif // SAMPLE_HTTP
+
+    // Used to initialize IoTHub SDK subsystem
+    (void)IoTHub_Init();
+
+    IOTHUB_DEVICE_CLIENT_LL_HANDLE device_ll_handle;
+
+    (void)printf("Creating IoTHub Device handle\r\n");
+    // Create the iothub handle here
+    device_ll_handle = IoTHubDeviceClient_LL_CreateFromConnectionString(connectionString, protocol);
+    if (device_ll_handle == NULL)
+    {
+        (void)printf("Failure createing Iothub device.  Hint: Check you connection string.\r\n");
+    }
+    else
+    {
+        // Set any option that are neccessary.
+        // For available options please see the iothub_sdk_options.md documentation
+
+        bool traceOn = true;
+        IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_LOG_TRACE, &traceOn);
+
+#ifdef SET_TRUSTED_CERT_IN_SAMPLES
+        // Setting the Trusted Certificate.  This is only necessary on system with without
+        // built in certificate stores.
+            IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_TRUSTED_CERT, certificates);
+#endif // SET_TRUSTED_CERT_IN_SAMPLES
+
+#if defined SAMPLE_MQTT || defined SAMPLE_MQTT_WS
+        //Setting the auto URL Encoder (recommended for MQTT). Please use this option unless
+        //you are URL Encoding inputs yourself.
+        //ONLY valid for use with MQTT
+        //bool urlEncodeOn = true;
+        //IoTHubDeviceClient_LL_SetOption(iothub_ll_handle, OPTION_AUTO_URL_ENCODE_DECODE, &urlEncodeOn);
+#endif
+        // <snippet_tracing>
+        // Setting connection status callback to get indication of connection to iothub
+        (void)IoTHubDeviceClient_LL_SetConnectionStatusCallback(device_ll_handle, connection_status_callback, NULL);
+
+        // Enabled the distrubted tracing policy for the device
+        (void)IoTHubDeviceClient_LL_EnablePolicyConfiguration(device_ll_handle, POLICY_CONFIGURATION_DISTRIBUTED_TRACING, true);
+
+        do
+        {
+            if (messages_sent < MESSAGE_COUNT)
+        // </snippet_tracing>
+            {
+                // Construct the iothub message from a string or a byte array
+                message_handle = IoTHubMessage_CreateFromString(telemetry_msg);
+                //message_handle = IoTHubMessage_CreateFromByteArray((const unsigned char*)msgText, strlen(msgText)));
+
+                // Set Message property
+                /*(void)IoTHubMessage_SetMessageId(message_handle, "MSG_ID");
+                (void)IoTHubMessage_SetCorrelationId(message_handle, "CORE_ID");
+                (void)IoTHubMessage_SetContentTypeSystemProperty(message_handle, "application%2fjson");
+                (void)IoTHubMessage_SetContentEncodingSystemProperty(message_handle, "utf-8");*/
+
+                // Add custom properties to message
+                (void)IoTHubMessage_SetProperty(message_handle, "property_key", "property_value");
+
+                (void)printf("Sending message %d to IoTHub\r\n", (int)(messages_sent + 1));
+                IoTHubDeviceClient_LL_SendEventAsync(device_ll_handle, message_handle, send_confirm_callback, NULL);
+
+                // The message is copied to the sdk so the we can destroy it
+                IoTHubMessage_Destroy(message_handle);
+
+                messages_sent++;
+            }
+        // <snippet_sleep>
+            else if (g_message_count_send_confirmations >= MESSAGE_COUNT)
+            {
+                // After all messages are all received stop running
+                g_continueRunning = false;
+            }
+
+            IoTHubDeviceClient_LL_DoWork(device_ll_handle);
+            ThreadAPI_Sleep(1000);
+
+        } while (g_continueRunning);
+        // </snippet_sleep>
+
+        // Clean up the iothub sdk handle
+        IoTHubDeviceClient_LL_Destroy(device_ll_handle);
+    }
+    // Free all the sdk subsystem
+    IoTHub_Deinit();
+
+    printf("Press any key to continue");
+    (void)getchar();
+
+    return 0;
+}

--- a/iothub_client/samples/iothub_ll_telemetry_sample/iothub_ll_telemetry_sample.c
+++ b/iothub_client/samples/iothub_ll_telemetry_sample/iothub_ll_telemetry_sample.c
@@ -50,8 +50,8 @@ and removing calls to _DoWork will yield the same results. */
 
 
 /* Paste in the your iothub connection string  */
-static const char* connectionString = "[device connection string]";
-#define MESSAGE_COUNT        5
+static const char* connectionString = "...";
+#define MESSAGE_COUNT        5000
 static bool g_continueRunning = true;
 static size_t g_message_count_send_confirmations = 0;
 
@@ -137,10 +137,14 @@ int main(void)
         //ONLY valid for use with MQTT
         bool urlEncodeOn = true;
         (void)IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_AUTO_URL_ENCODE_DECODE, &urlEncodeOn);
+
+        uint32_t diagPercentage = 100;
+        (void)IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_DIAGNOSTIC_SAMPLING_PERCENTAGE, &diagPercentage);
 #endif
 
         // Setting connection status callback to get indication of connection to iothub
         (void)IoTHubDeviceClient_LL_SetConnectionStatusCallback(device_ll_handle, connection_status_callback, NULL);
+        (void)IoTHubDeviceClient_LL_EnablePolicyConfiguration(device_ll_handle, POLICY_CONFIGURATION_DISTRIBUTED_TRACING, true);
 
         do
         {
@@ -178,7 +182,7 @@ int main(void)
             }
 
             IoTHubDeviceClient_LL_DoWork(device_ll_handle);
-            ThreadAPI_Sleep(1);
+            ThreadAPI_Sleep(1000);
 
         } while (g_continueRunning);
 

--- a/iothub_client/src/iothub_client_core_ll.c
+++ b/iothub_client/src/iothub_client_core_ll.c
@@ -2386,6 +2386,7 @@ IOTHUB_CLIENT_RESULT IoTHubClientCore_LL_SetOption(IOTHUB_CLIENT_CORE_LL_HANDLE 
             {
                 /*Codes_SRS_IOTHUBCLIENT_LL_10_037: [Calling IoTHubClientCore_LL_SetOption with value between [0, 100] shall return `IOTHUB_CLIENT_OK`. ]*/
                 handleData->diagnostic_setting.diagSamplingPercentage = percentage;
+                handleData->distributedTracing_setting.samplingRate = percentage;
                 handleData->diagnostic_setting.currentMessageNumber = 0;
                 result = IOTHUB_CLIENT_OK;
             }


### PR DESCRIPTION
# even after following all the instructions and fixing the code no Diagnostics are showing in Log Analytics using the required query show on the Docs link page [Trace Azure IoT device-to-cloud messages with distributed tracing (preview)](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-distributed-tracing) , nor in the table that seems related but undocumented.

## Where is there a working example and configuration, and the correct headers that enables Distributed Tracing or something akin to OpenTelemetry support?
<img width="364" alt="image" src="https://user-images.githubusercontent.com/1080406/186498820-afb165e4-d9d4-4cde-a80c-2d1087a3b9fe.png">


In the Docs article [Trace Azure IoT device-to-cloud messages with distributed tracing (preview)](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-distributed-tracing) along with the sample code result here, https://github.com/Azure-Samples/azure-iot-distributed-tracing-sample/blob/master/iothub_ll_telemetry_sample-c/iothub_ll_telemetry_sample.c

The required headers are NOT added -- as the condition within the code requires "samplingRate" to be greater than zero (0).  

So, the code here allows it to update the proper object, albeit it's first requested to be set. [line 2389](https://github.com/cicorias/azure-iot-sdk-c/commit/cd62706dc7c04d4e55099ec966bf073e0b2b6f41#diff-b4f50b8ad5bd664f55023c652d5ce59dd2b95560a7972ce815a07dfa39f7b143R2389)


```
        uint32_t diagPercentage = 100;
        (void)IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_DIAGNOSTIC_SAMPLING_PERCENTAGE, &diagPercentage);
```

It needs to be set as in this [here](https://github.com/cicorias/azure-iot-sdk-c/commit/cd62706dc7c04d4e55099ec966bf073e0b2b6f41#diff-0e44c84c34515d7d13b482704d62fc907964b03bdebcfff55dcdae32442c4907R142)

```
 handleData->distributedTracing_setting.samplingRate = percentage; 
```
