### PR TITLE
Add E2E test to verify AMQP telemetry batching against IoT Hub GWv2

### DIFF
--- a/iothub_client/tests/common_e2e/iothubclient_common_e2e.c
+++ b/iothub_client/tests/common_e2e/iothubclient_common_e2e.c
@@ -445,10 +445,8 @@ static EXPECTED_SEND_DATA* EventData_Create_With_Custom_Size(size_t messageSize)
 
     ASSERT_IS_NOT_NULL(message, "Failed to allocate EventData message");
 
-    char idString[10];
-    size_t idStringLength = sprintf(idString, "%d", (int)g_iotHubTestId++);
+    size_t idStringLength = sprintf(message, "%d", (int)g_iotHubTestId++);
 
-    (void)memcpy(message, idString, idStringLength);
     (void)memset(message + idStringLength, 'a', messageSize - idStringLength - 1);
 
     result = EventData_Create_With_String(message);

--- a/iothub_client/tests/common_e2e/iothubclient_common_e2e.c
+++ b/iothub_client/tests/common_e2e/iothubclient_common_e2e.c
@@ -27,6 +27,8 @@
 #include "iothub.h"
 #include "iothub_device_client.h"
 #include "iothub_module_client.h"
+#include "iothub_device_client_ll.h"
+#include "iothub_module_client_ll.h"
 #include "iothub_client_options.h"
 #include "iothub_message.h"
 #include "iothub_messaging.h"
@@ -52,6 +54,7 @@ static TEST_PROTOCOL_TYPE test_protocol_type;
 
 const char* TEST_EVENT_DATA_FMT = "{\"data\":\"%.24s\",\"id\":\"%d\"}";
 const char* TEST_EVENT_DATA_FMT_SPECIAL_CHAR = "{\"#data\":\"$%.24s\",\";id\":\"*%d\"}";
+const char* TEST_EVENT_DATA_FMT_LONG = "{\"data\":\"*.s\",\"id\":\"%d\"}";
 
 #define MSG_UNIQUE_ID_STAMP_LEN 5
 const char MSG_ID[] = "MessageIdForE2E";
@@ -74,6 +77,8 @@ E2E_TEST_OPTIONS g_e2e_test_options;
 
 static IOTHUB_DEVICE_CLIENT_HANDLE iothub_deviceclient_handle = NULL;
 static IOTHUB_MODULE_CLIENT_HANDLE iothub_moduleclient_handle = NULL;
+static IOTHUB_DEVICE_CLIENT_LL_HANDLE iothub_deviceclient_ll_handle = NULL;
+static IOTHUB_MODULE_CLIENT_LL_HANDLE iothub_moduleclient_ll_handle = NULL;
 
 #define RETRY_COUNT                  4
 #define RETRY_DELAY_SECONDS          60
@@ -87,6 +92,11 @@ static IOTHUB_MODULE_CLIENT_HANDLE iothub_moduleclient_handle = NULL;
 #define SERVICE_EVENT_WAIT_TIME_DELTA_SECONDS 60
 
 #define MAX_SECURITY_DEVICE_WAIT_TIME   30
+
+// A default message size of 0 causes client_create_and_send_d2c_messages to use 
+// `test_message_creation` for creating the telemetry message.
+#define DEFAULT_MESSAGE_SIZE    0
+#define LARGE_MESSAGE_SIZE      64536
 
 TEST_DEFINE_ENUM_TYPE(IOTHUB_TEST_CLIENT_RESULT, IOTHUB_TEST_CLIENT_RESULT_VALUES);
 TEST_DEFINE_ENUM_TYPE(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_RESULT_VALUES);
@@ -103,6 +113,14 @@ typedef struct EXPECTED_SEND_DATA_TAG
     LOCK_HANDLE lock;
     IOTHUB_MESSAGE_HANDLE msgHandle;
 } EXPECTED_SEND_DATA;
+
+#define MAX_SEND_DATA_BUNDLE_ITEM_COUNT 10
+
+typedef struct SEND_DATA_BUNDLE_TAG
+{
+    int count;
+    EXPECTED_SEND_DATA* items[MAX_SEND_DATA_BUNDLE_ITEM_COUNT];
+} SEND_DATA_BUNDLE;
 
 typedef struct EXPECTED_RECEIVE_DATA_TAG
 {
@@ -144,29 +162,37 @@ static void sendCompleteCallback(void* context, IOTHUB_MESSAGING_RESULT messagin
 
 static int IoTHubCallback(void* context, const char* data, size_t size)
 {
-    (void)size;
-    int result = 0; // 0 means "keep processing"
-    EXPECTED_SEND_DATA* expectedData = (EXPECTED_SEND_DATA*)context;
-    if (expectedData != NULL)
+    int messagesReceived = 0;
+    SEND_DATA_BUNDLE* d2cMessages = (SEND_DATA_BUNDLE*)context;
+
+    for (int i = 0; i < d2cMessages->count; i++)
     {
-        if (Lock(expectedData->lock) != LOCK_OK)
+        EXPECTED_SEND_DATA* expectedData = d2cMessages->items[i];
+        if (expectedData != NULL)
         {
-            ASSERT_FAIL("unable to lock");
-        }
-        else
-        {
-            if (
-                (strlen(expectedData->expectedString) == size) &&
-                (memcmp(expectedData->expectedString, data, size) == 0)
-                )
+            if (Lock(expectedData->lock) != LOCK_OK)
             {
-                expectedData->wasFound = true;
-                result = 1;
+                ASSERT_FAIL("unable to lock");
             }
-            (void)Unlock(expectedData->lock);
+            else
+            {
+                if (
+                    (strlen(expectedData->expectedString) == size) &&
+                    (memcmp(expectedData->expectedString, data, size) == 0)
+                    )
+                {
+                    expectedData->wasFound = true;
+                }
+
+                messagesReceived += (expectedData->wasFound ? 1 : 0);
+
+                (void)Unlock(expectedData->lock);
+            }
         }
     }
-    return result;
+
+    // Returning 0 means "keep processing"
+    return (messagesReceived == d2cMessages->count ? 1 : 0);
 }
 
 // Invoked when a connection status changes.  Tests poll the status in the connection_status_info to make sure expected transitions occur.
@@ -342,50 +368,101 @@ static void ReceiveUserContext_Destroy(EXPECTED_RECEIVE_DATA* data)
     }
 }
 
-static EXPECTED_SEND_DATA* EventData_Create(void)
+static EXPECTED_SEND_DATA* EventData_Create_With_String(char* string)
 {
     EXPECTED_SEND_DATA* result = (EXPECTED_SEND_DATA*)malloc(sizeof(EXPECTED_SEND_DATA));
-    if (result != NULL)
+
+    if (result == NULL)
+    {
+        LogError("Failed allocating EXPECTED_SEND_DATA");
+    }
+    else
     {
         memset(result, 0, sizeof(*result));
+
         if ((result->lock = Lock_Init()) == NULL)
         {
             ASSERT_FAIL("unable to Lock_Init");
+            free(result);
+            result = NULL;
         }
         else
         {
-            char temp[1000];
-            char* tempString;
-            time_t t = time(NULL);
-            size_t string_length;
-            const char* data_fmt;
-
-            if (g_e2e_test_options.use_special_chars)
-            {
-                data_fmt = TEST_EVENT_DATA_FMT_SPECIAL_CHAR;
-            }
-            else
-            {
-                data_fmt = TEST_EVENT_DATA_FMT;
-            }
-
-            string_length = sprintf(temp, data_fmt, ctime(&t), g_iotHubTestId);
-            if ((tempString = (char*)malloc(string_length + 1)) == NULL)
-            {
-                Lock_Deinit(result->lock);
-                free(result);
-                result = NULL;
-            }
-            else
-            {
-                strcpy(tempString, temp);
-                result->expectedString = tempString;
-                result->wasFound = false;
-                result->dataWasRecv = false;
-                result->result = IOTHUB_CLIENT_CONFIRMATION_ERROR;
-            }
+            result->expectedString = string;
+            result->wasFound = false;
+            result->dataWasRecv = false;
+            result->result = IOTHUB_CLIENT_CONFIRMATION_ERROR;
         }
     }
+
+    return result;
+}
+
+static EXPECTED_SEND_DATA* EventData_Create(void)
+{
+    EXPECTED_SEND_DATA* result;
+    char temp[1000];
+    char* tempString;
+    time_t t = time(NULL);
+    size_t string_length;
+    const char* data_fmt;
+
+    if (g_e2e_test_options.use_special_chars)
+    {
+        data_fmt = TEST_EVENT_DATA_FMT_SPECIAL_CHAR;
+    }
+    else
+    {
+        data_fmt = TEST_EVENT_DATA_FMT;
+    }
+
+    string_length = sprintf(temp, data_fmt, ctime(&t), g_iotHubTestId++);
+    if ((tempString = (char*)malloc(string_length + 1)) == NULL)
+    {
+        result = NULL;
+    }
+    else
+    {
+        (void)strcpy(tempString, temp);
+        result = EventData_Create_With_String(tempString);
+
+        if (result == NULL)
+        {
+            free(tempString);
+        }
+    }
+
+    return result;
+}
+
+static EXPECTED_SEND_DATA* EventData_Create_With_Custom_Size(size_t messageSize)
+{
+    EXPECTED_SEND_DATA* result;
+    char* message = malloc(sizeof(char) * messageSize);
+
+    if (message == NULL)
+    {
+        LogError("Failed to allocate EventData message");
+        result = NULL;
+    }
+    else
+    {
+        char idString[10];
+        size_t idStringLength = sprintf(idString, "%d", (int)g_iotHubTestId++);
+
+        (void)memset(message, (int)'a', messageSize - 1);
+        (void)memcpy(message + 1, idString, idStringLength);
+        message[messageSize - 1] = '\0';
+
+        result = EventData_Create_With_String(message);
+
+        if (result == NULL)
+        {
+            LogError("Failed allocating EventData");
+            free(message);
+        }
+    }
+
     return result;
 }
 
@@ -519,9 +596,17 @@ static void setoption_on_device_or_module(const char * optionName, const void * 
     {
         result = IoTHubModuleClient_SetOption(iothub_moduleclient_handle, optionName, optionData);
     }
-    else
+    else if (iothub_deviceclient_handle != NULL)
     {
         result = IoTHubDeviceClient_SetOption(iothub_deviceclient_handle, optionName, optionData);
+    }
+    else if (iothub_moduleclient_ll_handle != NULL)
+    {
+        result = IoTHubModuleClient_LL_SetOption(iothub_moduleclient_ll_handle, optionName, optionData);
+    }
+    else
+    {
+        result = IoTHubDeviceClient_LL_SetOption(iothub_deviceclient_ll_handle, optionName, optionData);
     }
 
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result, errorMessage);
@@ -535,9 +620,17 @@ static void setconnectionstatuscallback_on_device_or_module()
     {
         result = IoTHubModuleClient_SetConnectionStatusCallback(iothub_moduleclient_handle, connection_status_callback, &g_connection_status_info);
     }
-    else
+    else if (iothub_deviceclient_handle != NULL)
     {
         result = IoTHubDeviceClient_SetConnectionStatusCallback(iothub_deviceclient_handle, connection_status_callback, &g_connection_status_info);
+    }
+    else if(iothub_moduleclient_ll_handle != NULL)
+    {
+        result = IoTHubModuleClient_LL_SetConnectionStatusCallback(iothub_moduleclient_ll_handle, connection_status_callback, &g_connection_status_info);
+    }
+    else
+    {
+        result = IoTHubDeviceClient_LL_SetConnectionStatusCallback(iothub_deviceclient_ll_handle, connection_status_callback, &g_connection_status_info);
     }
 
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result, "Could not set connection Status Callback");
@@ -551,9 +644,17 @@ static void sendeventasync_on_device_or_module(IOTHUB_MESSAGE_HANDLE msgHandle, 
     {
         result = IoTHubModuleClient_SendEventAsync(iothub_moduleclient_handle, msgHandle, ReceiveConfirmationCallback, sendData);
     }
-    else
+    else if (iothub_deviceclient_handle != NULL)
     {
         result = IoTHubDeviceClient_SendEventAsync(iothub_deviceclient_handle, msgHandle, ReceiveConfirmationCallback, sendData);
+    }
+    else if (iothub_moduleclient_ll_handle != NULL)
+    {
+        result = IoTHubModuleClient_LL_SendEventAsync(iothub_moduleclient_ll_handle, msgHandle, ReceiveConfirmationCallback, sendData);
+    }
+    else
+    {
+        result = IoTHubDeviceClient_LL_SendEventAsync(iothub_deviceclient_ll_handle, msgHandle, ReceiveConfirmationCallback, sendData);
     }
 
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result, "SendEventAsync failed");
@@ -567,9 +668,17 @@ static void setmessagecallback_on_device_or_module(EXPECTED_RECEIVE_DATA* receiv
     {
         result = IoTHubModuleClient_SetMessageCallback(iothub_moduleclient_handle, ReceiveMessageCallback, receiveUserContext);
     }
-    else
+    else if (iothub_deviceclient_handle != NULL)
     {
         result = IoTHubDeviceClient_SetMessageCallback(iothub_deviceclient_handle, ReceiveMessageCallback, receiveUserContext);
+    }
+    else if (iothub_moduleclient_ll_handle != NULL)
+    {
+        result = IoTHubModuleClient_LL_SetMessageCallback(iothub_moduleclient_ll_handle, ReceiveMessageCallback, receiveUserContext);
+    }
+    else
+    {
+        result = IoTHubDeviceClient_LL_SetMessageCallback(iothub_deviceclient_ll_handle, ReceiveMessageCallback, receiveUserContext);
     }
 
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result, "IoTHubDeviceClient_SetMessageCallback failed");
@@ -588,6 +697,35 @@ static void destroy_on_device_or_module()
     {
         IoTHubModuleClient_Destroy(iothub_moduleclient_handle);
         iothub_moduleclient_handle = NULL;
+    }
+
+    if (iothub_deviceclient_ll_handle != NULL)
+    {
+        IoTHubDeviceClient_LL_Destroy(iothub_deviceclient_ll_handle);
+        iothub_deviceclient_ll_handle = NULL;
+    }
+
+    if (iothub_moduleclient_ll_handle != NULL)
+    {
+        IoTHubModuleClient_LL_Destroy(iothub_moduleclient_ll_handle);
+        iothub_moduleclient_ll_handle = NULL;
+    }
+}
+
+static void setup_iothub_client()
+{
+    // TODO: implement to simplify the functions below.
+}
+
+static void run_client_do_work()
+{
+    if (iothub_deviceclient_ll_handle != NULL)
+    {
+        IoTHubDeviceClient_LL_DoWork(iothub_deviceclient_ll_handle);
+    }
+    else if (iothub_moduleclient_ll_handle != NULL)
+    {
+        IoTHubModuleClient_LL_DoWork(iothub_moduleclient_ll_handle);
     }
 }
 
@@ -657,15 +795,85 @@ static void client_connect_to_hub(IOTHUB_PROVISIONED_DEVICE* deviceToUse, IOTHUB
 #endif //AZIOT_LINUX
 }
 
-D2C_MESSAGE_HANDLE client_create_and_send_d2c(TEST_MESSAGE_CREATION_MECHANISM test_message_creation)
+static void client_ll_connect_to_hub(IOTHUB_PROVISIONED_DEVICE* deviceToUse, IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol)
 {
-    IOTHUB_MESSAGE_HANDLE msgHandle;
+    size_t client_conn_wait_time = 4000;
 
-    EXPECTED_SEND_DATA* sendData = EventData_Create();
-    ASSERT_IS_NOT_NULL(sendData, "Could not create the EventData associated with the event to be sent");
+    ASSERT_IS_NULL(iothub_deviceclient_ll_handle, "iothub_deviceclient_ll_handle is non-NULL on test initialization");
+    ASSERT_IS_NULL(iothub_moduleclient_ll_handle, "iothub_moduleclient_ll_handle is non-NULL on test initialization");
 
-    if (sendData != NULL)
+    if (deviceToUse->moduleConnectionString != NULL)
     {
+        iothub_moduleclient_ll_handle = IoTHubModuleClient_LL_CreateFromConnectionString(deviceToUse->moduleConnectionString, protocol);
+        ASSERT_IS_NOT_NULL(iothub_moduleclient_ll_handle, "Could not invoke IoTHubModuleClient_LL_CreateFromConnectionString");
+    }
+    else
+    {
+        iothub_deviceclient_ll_handle = IoTHubDeviceClient_LL_CreateFromConnectionString(deviceToUse->connectionString, protocol);
+        ASSERT_IS_NOT_NULL(iothub_deviceclient_ll_handle, "Could not invoke IoTHubDeviceClient_LL_CreateFromConnectionString");
+    }
+
+#ifdef SET_TRUSTED_CERT_IN_SAMPLES
+    setoption_on_device_or_module(OPTION_TRUSTED_CERT, certificates, "Cannot enable trusted cert");
+#endif // SET_TRUSTED_CERT_IN_SAMPLES
+
+    // Set connection status change callback
+    setconnectionstatuscallback_on_device_or_module();
+
+    if (deviceToUse->howToCreate == IOTHUB_ACCOUNT_AUTH_X509)
+    {
+        setoption_on_device_or_module(OPTION_X509_CERT, deviceToUse->certificate, "Could not set the device x509 certificate");
+        setoption_on_device_or_module(OPTION_X509_PRIVATE_KEY, deviceToUse->primaryAuthentication, "Could not set the device x509 privateKey");
+    }
+
+    bool trace = true;
+    setoption_on_device_or_module(OPTION_LOG_TRACE, &trace, "Cannot enable tracing");
+
+    setoption_on_device_or_module(OPTION_PRODUCT_INFO, "MQTT_E2E/1.1.12", "Cannot set product info");
+
+    //Turn on URL encoding/decoding (MQTT)
+    if (g_e2e_test_options.use_special_chars)
+    {
+        bool encodeDecode = true;
+        setoption_on_device_or_module(OPTION_AUTO_URL_ENCODE_DECODE, &encodeDecode, "Cannot set auto_url_encode/decode");
+    }
+
+    if (test_protocol_type == TEST_AMQP || test_protocol_type == TEST_AMQP_WEBSOCKETS)
+    {
+        size_t svc2cl_keep_alive_timeout_secs = 120; // service will send pings at 120 x 7/8 = 105 seconds. Higher the value, lesser the frequency of service side pings.
+        setoption_on_device_or_module(OPTION_SERVICE_SIDE_KEEP_ALIVE_FREQ_SECS, &svc2cl_keep_alive_timeout_secs, "Cannot set OPTION_SERVICE_SIDE_KEEP_ALIVE_FREQ_SECS");
+
+        // Set keep alive for remote idle is optional. If it is not set the default ratio of 1/2 will be used. For default value of 4 minutes, it will be 2 minutes (120 seconds)
+        double cl2svc_keep_alive_send_ratio = 1.0 / 2.0; // Set it to 120 seconds (240 x 1/2 = 120 seconds) for 4 minutes remote idle.
+
+        // client will send pings to service at 210 second interval for 4 minutes remote idle. For 25 minutes remote idle, it will be set to 21 minutes.
+        setoption_on_device_or_module(OPTION_REMOTE_IDLE_TIMEOUT_RATIO, &cl2svc_keep_alive_send_ratio, "Cannot set OPTION_REMOTE_IDLE_TIMEOUT_RATIO");
+    }
+#ifdef AZIOT_LINUX
+    if (g_e2e_test_options.set_mac_address)
+    {
+        char* mac_address = get_target_mac_address();
+        ASSERT_IS_NOT_NULL(mac_address, "failed getting the target MAC ADDRESS");
+
+        setoption_on_device_or_module(OPTION_NET_INT_MAC_ADDRESS, mac_address, "Cannot setoption MAC ADDRESS");
+
+        LogInfo("Target MAC ADDRESS: %s", mac_address);
+        free(mac_address);
+    }
+#endif //AZIOT_LINUX
+
+    // TODO: maintain just this end
+    ASSERT_IS_TRUE(wait_for_client_authenticated(client_conn_wait_time));
+}
+
+void client_create_and_send_d2c_messages(TEST_MESSAGE_CREATION_MECHANISM test_message_creation, int count, size_t messageSize, SEND_DATA_BUNDLE* d2cMessages)
+{
+    for (int i = 0; i < count; i++)
+    {
+        IOTHUB_MESSAGE_HANDLE msgHandle;
+        EXPECTED_SEND_DATA* sendData = (messageSize == 0 ? EventData_Create() : EventData_Create_With_Custom_Size(messageSize));
+        ASSERT_IS_NOT_NULL(sendData, "Could not create the EventData associated with the event to be sent");
+
         if (test_message_creation == TEST_MESSAGE_CREATE_BYTE_ARRAY)
         {
             msgHandle = IoTHubMessage_CreateFromByteArray((const unsigned char*)sendData->expectedString, strlen(sendData->expectedString));
@@ -681,56 +889,86 @@ D2C_MESSAGE_HANDLE client_create_and_send_d2c(TEST_MESSAGE_CREATION_MECHANISM te
         }
         ASSERT_IS_NOT_NULL(msgHandle, "Could not create the D2C message to be sent");
 
-        for (size_t i = 0; i < MSG_PROP_COUNT; i++)
+        for (size_t j = 0; j < MSG_PROP_COUNT; j++)
         {
             if (g_e2e_test_options.use_special_chars)
             {
-                if (IoTHubMessage_SetProperty(msgHandle, MSG_PROP_KEYS_SPECIAL[i], MSG_PROP_VALS_SPECIAL[i]) != IOTHUB_MESSAGE_OK)
+                if (IoTHubMessage_SetProperty(msgHandle, MSG_PROP_KEYS_SPECIAL[j], MSG_PROP_VALS_SPECIAL[j]) != IOTHUB_MESSAGE_OK)
                 {
-                    LogError("ERROR: Map_AddOrUpdate failed for property %zu!", i);
+                    LogError("ERROR: Map_AddOrUpdate failed for property %zu!", j);
                 }
             }
             else
             {
-                if (IoTHubMessage_SetProperty(msgHandle, MSG_PROP_KEYS[i], MSG_PROP_VALS[i]) != IOTHUB_MESSAGE_OK)
+                if (IoTHubMessage_SetProperty(msgHandle, MSG_PROP_KEYS[j], MSG_PROP_VALS[j]) != IOTHUB_MESSAGE_OK)
                 {
-                    LogError("ERROR: Map_AddOrUpdate failed for property %zu!", i);
+                    LogError("ERROR: Map_AddOrUpdate failed for property %zu!", j);
                 }
             }
         }
 
         sendData->msgHandle = msgHandle;
+        d2cMessages->items[i] = sendData;
+        d2cMessages->count++;
 
         // act
         sendeventasync_on_device_or_module(msgHandle, sendData);
     }
-
-    return (D2C_MESSAGE_HANDLE)sendData;
 }
 
-bool client_wait_for_d2c_confirmation(D2C_MESSAGE_HANDLE d2cMessage, IOTHUB_CLIENT_CONFIRMATION_RESULT expectedClientResult)
+D2C_MESSAGE_HANDLE client_create_and_send_d2c(TEST_MESSAGE_CREATION_MECHANISM test_message_creation)
+{
+    SEND_DATA_BUNDLE d2cMessages;
+    client_create_and_send_d2c_messages(test_message_creation, 1, DEFAULT_MESSAGE_SIZE, &d2cMessages);
+    return d2cMessages.items[0];
+}
+
+bool client_wait_for_d2c_confirmations(SEND_DATA_BUNDLE* d2cMessages, IOTHUB_CLIENT_CONFIRMATION_RESULT expectedClientResult)
 {
     time_t beginOperation, nowTime;
-    bool ret;
+    bool allMessagesSent = false;
 
-    LogInfo("Begin wait for d2c confirmation.  d2cMessage=<%p>", d2cMessage);
+    for (int i = 0; i < d2cMessages->count; i++)
+    {
+        LogInfo("Begin wait for d2c confirmation.  d2cMessage=<%p>", d2cMessages->items[i]);
+    }
 
     beginOperation = time(NULL);
     while (
         (nowTime = time(NULL)),
-        (difftime(nowTime, beginOperation) < MAX_CLOUD_TRAVEL_TIME) // time box
+        !allMessagesSent && (difftime(nowTime, beginOperation) < MAX_CLOUD_TRAVEL_TIME) // time box
         )
     {
-        if (client_received_confirmation(d2cMessage, expectedClientResult))
+        allMessagesSent = true;
+
+        for (int i = 0; i < d2cMessages->count; i++)
         {
-            break;
+            if (!client_received_confirmation(d2cMessages->items[i], expectedClientResult))
+            {
+                allMessagesSent = false;
+                break;
+            }
         }
+
+        run_client_do_work();
         ThreadAPI_Sleep(100);
     }
-    ret = client_received_confirmation(d2cMessage, expectedClientResult);
 
-    LogInfo("Completed wait for d2c confirmation.  d2cMessage=<%p>, ret=<%d>", d2cMessage, ret);
-    return ret;
+    for (int i = 0; i < d2cMessages->count; i++)
+    {
+        bool messageSent = client_received_confirmation(d2cMessages->items[i], expectedClientResult);
+        LogInfo("Completed wait for d2c confirmation.  d2cMessage=<%p>, ret=<%d>", d2cMessages->items[i], messageSent);
+    }
+
+    return allMessagesSent;
+}
+
+bool client_wait_for_d2c_confirmation(D2C_MESSAGE_HANDLE d2cMessage, IOTHUB_CLIENT_CONFIRMATION_RESULT expectedClientResult)
+{
+    SEND_DATA_BUNDLE d2cMessages;
+    d2cMessages.count = 1;
+    d2cMessages.items[0] = (EXPECTED_SEND_DATA*)d2cMessage;
+    return client_wait_for_d2c_confirmations(&d2cMessages, expectedClientResult);
 }
 
 bool client_received_confirmation(D2C_MESSAGE_HANDLE d2cMessage, IOTHUB_CLIENT_CONFIRMATION_RESULT expectedClientResult)
@@ -827,7 +1065,9 @@ bool wait_for_client_authenticated(size_t wait_time)
         {
             break;
         }
-        ThreadAPI_Sleep(500);
+
+        run_client_do_work();
+        ThreadAPI_Sleep(100);
     }
     return result;
 }
@@ -877,11 +1117,15 @@ static void service_wait_for_security_d2c_event_arrival(IOTHUB_PROVISIONED_DEVIC
 {
     EXPECTED_SEND_DATA* sendData = (EXPECTED_SEND_DATA*)d2cMessage;
 
+    SEND_DATA_BUNDLE d2cMessages;
+    d2cMessages.count = 1;
+    d2cMessages.items[0] = sendData;
+
     IOTHUB_TEST_HANDLE iotHubTestHandle = IoTHubTest_Initialize(IoTHubAccount_GetEventHubConnectionString(g_iothubAcctInfo), IoTHubAccount_GetIoTHubConnString(g_iothubAcctInfo), deviceToUse->deviceId, IoTHubAccount_GetEventhubListenName(g_iothubAcctInfo), IoTHubAccount_GetEventhubAccessKey(g_iothubAcctInfo), IoTHubAccount_GetSharedAccessSignature(g_iothubAcctInfo), IoTHubAccount_GetEventhubConsumerGroup(g_iothubAcctInfo));
     ASSERT_IS_NOT_NULL(iotHubTestHandle, "Could not initialize IoTHubTest in order to listen for events");
 
     LogInfo("Beginning to listen for d2c event arrival.  Waiting up to %f seconds...", max_wait_time);
-    IOTHUB_TEST_CLIENT_RESULT result = IoTHubTest_ListenForEvent(iotHubTestHandle, IoTHubCallback, IoTHubAccount_GetIoTHubPartitionCount(g_iothubAcctInfo), sendData, time(NULL)-SERVICE_EVENT_WAIT_TIME_DELTA_SECONDS, max_wait_time);
+    IOTHUB_TEST_CLIENT_RESULT result = IoTHubTest_ListenForEvent(iotHubTestHandle, IoTHubCallback, IoTHubAccount_GetIoTHubPartitionCount(g_iothubAcctInfo), &d2cMessages, time(NULL)-SERVICE_EVENT_WAIT_TIME_DELTA_SECONDS, max_wait_time);
     ASSERT_ARE_EQUAL(IOTHUB_TEST_CLIENT_RESULT, IOTHUB_TEST_CLIENT_ERROR, result, "Listening for the event failed");
 
     ASSERT_IS_FALSE(sendData->wasFound, "Failure event was not routed correctly when sending security event"); // was found is written by the callback...
@@ -891,22 +1135,35 @@ static void service_wait_for_security_d2c_event_arrival(IOTHUB_PROVISIONED_DEVIC
     LogInfo("Completed listening for security event arrival.");
 }
 
-void service_wait_for_d2c_event_arrival(IOTHUB_PROVISIONED_DEVICE* deviceToUse, D2C_MESSAGE_HANDLE d2cMessage, double max_wait_time)
+void service_wait_for_d2c_events_arrival(IOTHUB_PROVISIONED_DEVICE* deviceToUse, SEND_DATA_BUNDLE* d2cMessages, double max_wait_time)
 {
-    EXPECTED_SEND_DATA* sendData = (EXPECTED_SEND_DATA*)d2cMessage;
+    bool allMessagesArrived = true;
 
     IOTHUB_TEST_HANDLE iotHubTestHandle = IoTHubTest_Initialize(IoTHubAccount_GetEventHubConnectionString(g_iothubAcctInfo), IoTHubAccount_GetIoTHubConnString(g_iothubAcctInfo), deviceToUse->deviceId, IoTHubAccount_GetEventhubListenName(g_iothubAcctInfo), IoTHubAccount_GetEventhubAccessKey(g_iothubAcctInfo), IoTHubAccount_GetSharedAccessSignature(g_iothubAcctInfo), IoTHubAccount_GetEventhubConsumerGroup(g_iothubAcctInfo));
     ASSERT_IS_NOT_NULL(iotHubTestHandle, "Could not initialize IoTHubTest in order to listen for events");
 
     LogInfo("Beginning to listen for d2c event arrival.  Waiting up to %f seconds...", max_wait_time);
-    IOTHUB_TEST_CLIENT_RESULT result = IoTHubTest_ListenForEvent(iotHubTestHandle, IoTHubCallback, IoTHubAccount_GetIoTHubPartitionCount(g_iothubAcctInfo), sendData, time(NULL)-SERVICE_EVENT_WAIT_TIME_DELTA_SECONDS, max_wait_time);
+    IOTHUB_TEST_CLIENT_RESULT result = IoTHubTest_ListenForEvent(iotHubTestHandle, IoTHubCallback, IoTHubAccount_GetIoTHubPartitionCount(g_iothubAcctInfo), d2cMessages, time(NULL) - SERVICE_EVENT_WAIT_TIME_DELTA_SECONDS, max_wait_time);
     ASSERT_ARE_EQUAL(IOTHUB_TEST_CLIENT_RESULT, IOTHUB_TEST_CLIENT_OK, result, "Listening for the event failed");
 
-    ASSERT_IS_TRUE(sendData->wasFound, "Failure retrieving data that was sent to eventhub"); // was found is written by the callback...
+    for (int i = 0; i < d2cMessages->count; i++)
+    {
+        allMessagesArrived &= d2cMessages->items[i]->wasFound;
+        LogInfo("d2c message %p received by eventhub: %d", d2cMessages->items[i], d2cMessages->items[i]->wasFound);
+    }
+    ASSERT_IS_TRUE(allMessagesArrived, "Failure retrieving all data that was sent to eventhub"); // was found is written by the callback...
 
     IoTHubTest_Deinit(iotHubTestHandle);
 
     LogInfo("Completed listening for d2c event arrival.");
+}
+
+void service_wait_for_d2c_event_arrival(IOTHUB_PROVISIONED_DEVICE* deviceToUse, D2C_MESSAGE_HANDLE d2cMessage, double max_wait_time)
+{
+    SEND_DATA_BUNDLE d2cMessages;
+    d2cMessages.count = 1;
+    d2cMessages.items[0] = (EXPECTED_SEND_DATA*)d2cMessage;
+    service_wait_for_d2c_events_arrival(deviceToUse, &d2cMessages, max_wait_time);
 }
 
 bool service_received_the_message(D2C_MESSAGE_HANDLE d2cMessage)
@@ -918,6 +1175,14 @@ void destroy_d2c_message_handle(D2C_MESSAGE_HANDLE d2cMessage)
 {
     LogInfo("Destroying message %p", d2cMessage);
     EventData_Destroy((EXPECTED_SEND_DATA*)d2cMessage);
+}
+
+void destroy_d2c_messages(SEND_DATA_BUNDLE* d2cMessages)
+{
+    for (int i = 0; i < d2cMessages->count; i++)
+    {
+        destroy_d2c_message_handle(d2cMessages->items[i]);
+    }
 }
 
 static void send_event_test(IOTHUB_PROVISIONED_DEVICE* deviceToUse, IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol)
@@ -949,12 +1214,49 @@ static void send_event_test(IOTHUB_PROVISIONED_DEVICE* deviceToUse, IOTHUB_CLIEN
         // cleanup
         destroy_d2c_message_handle(d2cMessage);
     }
+}
 
+static void send_batch_event_test(IOTHUB_PROVISIONED_DEVICE* deviceToUse, IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol)
+{
+    TEST_MESSAGE_CREATION_MECHANISM test_message_creation[] = { TEST_MESSAGE_CREATE_BYTE_ARRAY, TEST_MESSAGE_CREATE_STRING };
+
+    int i;
+    for (i = 0; i < sizeof(test_message_creation) / sizeof(test_message_creation[0]); i++)
+    {
+        // arrange
+        SEND_DATA_BUNDLE d2cMessages = { 0 };
+
+        clear_connection_status_info_flags();
+
+        // Create the IoT Hub Data
+        client_ll_connect_to_hub(deviceToUse, protocol);
+
+        // Send the Events from the client
+        client_create_and_send_d2c_messages(test_message_creation[i], 5, LARGE_MESSAGE_SIZE, &d2cMessages);
+
+        // Wait for confirmation that the event was recevied
+        bool dataWasRecv = client_wait_for_d2c_confirmations(&d2cMessages, IOTHUB_CLIENT_CONFIRMATION_OK);
+        ASSERT_IS_TRUE(dataWasRecv, "Failure sending data to IotHub"); // was received by the callback...
+
+        // close the client connection
+        destroy_on_device_or_module();
+
+        // Wait for the message to arrive
+        service_wait_for_d2c_events_arrival(deviceToUse, &d2cMessages, MAX_SERVICE_EVENT_WAIT_TIME_SECONDS);
+
+        // cleanup
+        destroy_d2c_messages(&d2cMessages);
+    }
 }
 
 void e2e_send_event_test_sas(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol)
 {
     send_event_test(IoTHubAccount_GetSASDevice(g_iothubAcctInfo), protocol);
+}
+
+void e2e_send_batch_event_test_sas(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol)
+{
+    send_batch_event_test(IoTHubAccount_GetSASDevice(g_iothubAcctInfo), protocol);
 }
 
 void e2e_send_event_test_x509(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol)

--- a/iothub_client/tests/common_e2e/iothubclient_common_e2e.h
+++ b/iothub_client/tests/common_e2e/iothubclient_common_e2e.h
@@ -39,6 +39,7 @@ extern void e2e_init(TEST_PROTOCOL_TYPE protocol_type, bool testing_modules);
 extern void e2e_deinit(void);
 
 extern void e2e_send_event_test_sas(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol);
+extern void e2e_send_batch_event_test_sas(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol);
 extern void e2e_send_event_test_x509(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol);
 extern void e2e_recv_message_test_sas(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol);
 extern void e2e_recv_message_test_x509(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol);

--- a/iothub_client/tests/iothubclient_amqp_e2e/iothubclient_amqp_e2e.c
+++ b/iothub_client/tests/iothubclient_amqp_e2e/iothubclient_amqp_e2e.c
@@ -25,6 +25,25 @@ BEGIN_TEST_SUITE(iothubclient_amqp_e2e)
         e2e_send_event_test_sas(AMQP_Protocol);
     }
 
+    TEST_FUNCTION(IoTHub_AMQP_SendBatchEvent_e2e_sas)
+    {
+#ifdef AZIOT_LINUX
+        g_e2e_test_options.set_mac_address = true;
+#endif
+        IOTHUB_GATEWAY_VERSION iotHubVersion = IoTHubAccount_GetIoTHubVersion(g_iothubAcctInfo);
+
+        ASSERT_ARE_NOT_EQUAL(int, IOTHUB_GATEWAY_VERSION_UNDEFINED, iotHubVersion);
+
+        if (iotHubVersion == IOTHUB_GATEWAY_VERSION_2)
+        {
+            e2e_send_batch_event_test_sas(AMQP_Protocol);
+        }
+        else
+        {
+            // Skipping the test if not running against IoT Hub Gateway V2.
+        }
+    }
+
     TEST_FUNCTION(IoTHub_AMQP_RecvMessage_E2ETest_sas)
     {
 #ifdef AZIOT_LINUX

--- a/testtools/iothub_test/CMakeLists.txt
+++ b/testtools/iothub_test/CMakeLists.txt
@@ -7,6 +7,10 @@ compileAsC99()
 
 usePermissiveRulesForSamplesAndTests()
 
+if(${LINUX})
+    add_definitions(-DAZIOT_LINUX)
+endif()
+
 set(iothub_test_c_files
     ./src/iothubtest.c
     ./src/iothub_account.c

--- a/testtools/iothub_test/inc/iothub_account.h
+++ b/testtools/iothub_test/inc/iothub_account.h
@@ -21,6 +21,13 @@ extern "C"
 
 MU_DEFINE_ENUM(IOTHUB_ACCOUNT_AUTH_METHOD, IOTHUB_ACCOUNT_AUTH_METHOD_VALUES);
 
+#define IOTHUB_GATEWAY_VERSION_VALUES    \
+    IOTHUB_GATEWAY_VERSION_UNDEFINED,    \
+    IOTHUB_GATEWAY_VERSION_1,            \
+    IOTHUB_GATEWAY_VERSION_2
+
+MU_DEFINE_ENUM(IOTHUB_GATEWAY_VERSION, IOTHUB_GATEWAY_VERSION_VALUES);
+
 typedef struct IOTHUB_PROVISIONED_DEVICE_TAG {
     char* connectionString;
     char* primaryAuthentication;
@@ -46,6 +53,7 @@ extern const char* IoTHubAccount_GetEventHubConnectionString(IOTHUB_ACCOUNT_INFO
 extern const char* IoTHubAccount_GetIoTHostName(IOTHUB_ACCOUNT_INFO_HANDLE acctHandle);
 extern const char* IoTHubAccount_GetIoTHubName(IOTHUB_ACCOUNT_INFO_HANDLE acctHandle);
 extern const char* IoTHubAccount_GetIoTHubSuffix(IOTHUB_ACCOUNT_INFO_HANDLE acctHandle);
+extern IOTHUB_GATEWAY_VERSION IoTHubAccount_GetIoTHubVersion(IOTHUB_ACCOUNT_INFO_HANDLE acctHandle);
 extern IOTHUB_PROVISIONED_DEVICE* IoTHubAccount_GetSASDevice(IOTHUB_ACCOUNT_INFO_HANDLE acctHandle);
 extern IOTHUB_PROVISIONED_DEVICE** IoTHubAccount_GetSASDevices(IOTHUB_ACCOUNT_INFO_HANDLE acctHandle);
 extern IOTHUB_PROVISIONED_DEVICE* IoTHubAccount_GetX509Device(IOTHUB_ACCOUNT_INFO_HANDLE acctHandle);

--- a/testtools/iothub_test/src/iothub_account.c
+++ b/testtools/iothub_test/src/iothub_account.c
@@ -57,16 +57,6 @@ const int TEST_SLEEP_BETWEEN_METHOD_INVOKE_FAILURES_MSEC = 30 * 1000;
 
 #define NSLOOKUP_MAX_COMMAND_SIZE 128
 
-#ifndef popen
-// If running on Microsoft Windows.
-#define popen _popen
-#endif
-
-#ifndef pclose
-// If running on Microsoft Windows.
-#define pclose _pclose
-#endif
-
 typedef struct IOTHUB_ACCOUNT_INFO_TAG
 {
     const char* connString;
@@ -1167,7 +1157,11 @@ IOTHUB_GATEWAY_VERSION IoTHubAccount_GetIoTHubVersion(IOTHUB_ACCOUNT_INFO_HANDLE
 
         if (commandLength > 0 && commandLength < NSLOOKUP_MAX_COMMAND_SIZE)
         {
+#if defined(__APPLE__) || defined(AZIOT_LINUX)
             FILE* stdOut = popen(command, "r");
+#else
+            FILE* stdOut = _popen(command, "r");
+#endif
 
             while (fgets(stdoutLine, sizeof(stdoutLine), stdOut) != NULL)
             {
@@ -1186,7 +1180,11 @@ IOTHUB_GATEWAY_VERSION IoTHubAccount_GetIoTHubVersion(IOTHUB_ACCOUNT_INFO_HANDLE
                 }
             }
 
+#if defined(__APPLE__) || defined(AZIOT_LINUX)
             (void)pclose(stdOut);
+#else
+            (void)_pclose(stdOut);
+#endif
         }
     }
 

--- a/testtools/iothub_test/src/iothub_account.c
+++ b/testtools/iothub_test/src/iothub_account.c
@@ -1167,10 +1167,10 @@ IOTHUB_GATEWAY_VERSION IoTHubAccount_GetIoTHubVersion(IOTHUB_ACCOUNT_INFO_HANDLE
 
             while (fgets(stdoutLine, sizeof(stdoutLine), stdOut) != NULL)
             {
+                LogInfo("nslookup: %s", stdoutLine);
+
                 if (strstr(stdoutLine, "Name:") == stdoutLine)
                 {
-                    LogInfo("nslookup: result=%s", stdoutLine);
-
                     if (strstr(stdoutLine, IoTHubGwV1Suffix) != NULL)
                     {
                         result = IOTHUB_GATEWAY_VERSION_1;

--- a/testtools/iothub_test/src/iothub_account.c
+++ b/testtools/iothub_test/src/iothub_account.c
@@ -1145,6 +1145,8 @@ IOTHUB_GATEWAY_VERSION IoTHubAccount_GetIoTHubVersion(IOTHUB_ACCOUNT_INFO_HANDLE
 
     const char* iotHubFqdn = IoTHubAccount_GetIoTHostName(acctHandle);
 
+    LogInfo("nslookup: check %s", iotHubFqdn);
+
     if (iotHubFqdn != NULL)
     {
         const char* IoTHubGwV1Suffix = "ihsu-";
@@ -1167,6 +1169,8 @@ IOTHUB_GATEWAY_VERSION IoTHubAccount_GetIoTHubVersion(IOTHUB_ACCOUNT_INFO_HANDLE
             {
                 if (strstr(stdoutLine, "Name:") == stdoutLine)
                 {
+                    LogInfo("nslookup: result=%s", stdoutLine);
+
                     if (strstr(stdoutLine, IoTHubGwV1Suffix) != NULL)
                     {
                         result = IOTHUB_GATEWAY_VERSION_1;

--- a/testtools/iothub_test/src/iothub_account.c
+++ b/testtools/iothub_test/src/iothub_account.c
@@ -55,6 +55,18 @@ const int TEST_SLEEP_THROTTLE_MSEC = 5 * 1000;
 const int TEST_SLEEP_BETWEEN_CREATION_FAILURES_MSEC = 30 * 1000;
 const int TEST_SLEEP_BETWEEN_METHOD_INVOKE_FAILURES_MSEC = 30 * 1000;
 
+#define NSLOOKUP_MAX_COMMAND_SIZE 128
+
+#ifndef popen
+// If running on Microsoft Windows.
+#define popen _popen
+#endif
+
+#ifndef pclose
+// If running on Microsoft Windows.
+#define pclose _pclose
+#endif
+
 typedef struct IOTHUB_ACCOUNT_INFO_TAG
 {
     const char* connString;
@@ -1137,3 +1149,46 @@ const IOTHUB_MESSAGING_HANDLE IoTHubAccount_GetMessagingHandle(IOTHUB_ACCOUNT_IN
     return result;
 }
 
+IOTHUB_GATEWAY_VERSION IoTHubAccount_GetIoTHubVersion(IOTHUB_ACCOUNT_INFO_HANDLE acctHandle)
+{
+    IOTHUB_GATEWAY_VERSION result = IOTHUB_GATEWAY_VERSION_UNDEFINED;
+
+    const char* iotHubFqdn = IoTHubAccount_GetIoTHostName(acctHandle);
+
+    if (iotHubFqdn != NULL)
+    {
+        const char* IoTHubGwV1Suffix = "ihsu-";
+        const char* IoTHubGwV2Suffix = "gateway-prod-gw-";
+        const char* nslookup_fmt = "nslookup %s";
+        char command[NSLOOKUP_MAX_COMMAND_SIZE];
+        char stdoutLine[128];
+
+        int commandLength = snprintf(command, NSLOOKUP_MAX_COMMAND_SIZE, nslookup_fmt, iotHubFqdn);
+
+        if (commandLength > 0 && commandLength < NSLOOKUP_MAX_COMMAND_SIZE)
+        {
+            FILE* stdOut = popen(command, "r");
+
+            while (fgets(stdoutLine, sizeof(stdoutLine), stdOut) != NULL)
+            {
+                if (strstr(stdoutLine, "Name:") == stdoutLine)
+                {
+                    if (strstr(stdoutLine, IoTHubGwV1Suffix) != NULL)
+                    {
+                        result = IOTHUB_GATEWAY_VERSION_1;
+                    }
+                    else if (strstr(stdoutLine, IoTHubGwV2Suffix) != NULL)
+                    {
+                        result = IOTHUB_GATEWAY_VERSION_2;
+                    }
+
+                    break;
+                }
+            }
+
+            (void)pclose(stdOut);
+        }
+    }
+
+    return result;
+}


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
The azure-iot-sdk-c e2e tests do not cover AMQP telemetry batching.

# Description of the solution
Add e2e for AMQP telemetry batching.
The test is aimed at the IoT Hub GWv2 only, as there is a bug in GWv1 that prevents proper functionality of batching. 
Note: this PR builds the E2E tests using iothub client LL (as suggested by John).