### PR TITLE
Replacing failure log with assert for failure on Map_AddOrUpdate

### DIFF
--- a/iothub_client/tests/common_e2e/iothubclient_common_e2e.c
+++ b/iothub_client/tests/common_e2e/iothubclient_common_e2e.c
@@ -837,17 +837,11 @@ void client_create_and_send_d2c_messages(TEST_MESSAGE_CREATION_MECHANISM test_me
         {
             if (g_e2e_test_options.use_special_chars)
             {
-                if (IoTHubMessage_SetProperty(msgHandle, MSG_PROP_KEYS_SPECIAL[j], MSG_PROP_VALS_SPECIAL[j]) != IOTHUB_MESSAGE_OK)
-                {
-                    LogError("ERROR: Map_AddOrUpdate failed for property %zu!", j);
-                }
+                ASSERT_ARE_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_OK, IoTHubMessage_SetProperty(msgHandle, MSG_PROP_KEYS_SPECIAL[j], MSG_PROP_VALS_SPECIAL[j]), "Map_AddOrUpdate failed for property %zu!", j);
             }
             else
             {
-                if (IoTHubMessage_SetProperty(msgHandle, MSG_PROP_KEYS[j], MSG_PROP_VALS[j]) != IOTHUB_MESSAGE_OK)
-                {
-                    LogError("ERROR: Map_AddOrUpdate failed for property %zu!", j);
-                }
+                ASSERT_ARE_EQUAL(IOTHUB_MESSAGE_RESULT, IOTHUB_MESSAGE_OK, IoTHubMessage_SetProperty(msgHandle, MSG_PROP_KEYS[j], MSG_PROP_VALS[j]), "Map_AddOrUpdate failed for property %zu!", j);
             }
         }
 


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-c/issues/2360
# Description of the problem
See github issue. Prior to change, test would not fail on failure of Map_AddOrUpdate which would indicate that something is wrong. Instead, it would log the failure and not show the problem at its root.
# Description of the solution
Replaced log and if statement with an ASSERT_ARE_EQUAL statement that checks that IotHubMessage_SetProperty results in IOTHUB_MESSAGE_OK. 