### PR TITLE
use tick counter and not clock for connection retry

### DIFF
--- a/iothub_client/src/iothub_client_retry_control.c
+++ b/iothub_client/src/iothub_client_retry_control.c
@@ -7,6 +7,7 @@
 
 #include "azure_c_shared_utility/gballoc.h"
 #include "azure_c_shared_utility/agenttime.h"
+#include "azure_c_shared_utility/tickcounter.h"
 #include "azure_c_shared_utility/optimize_size.h"
 #include "azure_c_shared_utility/xlogging.h"
 
@@ -24,8 +25,9 @@ typedef struct RETRY_CONTROL_INSTANCE_TAG
     unsigned int max_delay_in_secs;
 
     unsigned int retry_count;
-    time_t first_retry_time;
-    time_t last_retry_time;
+    TICK_COUNTER_HANDLE tick_counter;
+    time_t first_retry_tick_seconds;
+    time_t last_retry_tick_seconds;
     unsigned int current_wait_time_in_secs;
 } RETRY_CONTROL_INSTANCE;
 
@@ -90,6 +92,25 @@ static void retry_control_destroy_option(const char* name, const void* value)
 
 // ========== _should_retry() Auxiliary Functions ========== //
 
+static time_t retry_get_tick_seconds(RETRY_CONTROL_INSTANCE* retry_control)
+{
+    time_t result = INDEFINITE_TIME;
+    int tick_result;
+    tickcounter_ms_t tick = 0;
+
+    if (NULL != retry_control && NULL != retry_control->tick_counter) 
+    {
+        tick_result = tickcounter_get_current_ms(retry_control->tick_counter, &tick);
+        if (0 == tick_result)
+        {
+            // convert tick ms into secs
+            result = (time_t)(tick / 1000); 
+        }
+    }
+
+    return result;
+}
+
 static int evaluate_retry_action(RETRY_CONTROL_INSTANCE* retry_control, RETRY_ACTION* retry_action)
 {
     int result;
@@ -99,23 +120,23 @@ static int evaluate_retry_action(RETRY_CONTROL_INSTANCE* retry_control, RETRY_AC
         *retry_action = RETRY_ACTION_RETRY_NOW;
         result = RESULT_OK;
     }
-    else if (retry_control->last_retry_time == INDEFINITE_TIME &&
+    else if (retry_control->last_retry_tick_seconds == INDEFINITE_TIME &&
              retry_control->policy != IOTHUB_CLIENT_RETRY_IMMEDIATE)
     {
-        LogError("Failed to evaluate retry action (last_retry_time is INDEFINITE_TIME)");
+        LogError("Failed to evaluate retry action (last_retry_tick_second is INDEFINITE_TIME)");
         result = MU_FAILURE;
     }
     else
     {
-        time_t current_time;
+        time_t current_tick_seconds;
 
-        if ((current_time = get_time(NULL)) == INDEFINITE_TIME)
+        if ((current_tick_seconds = retry_get_tick_seconds(retry_control)) == INDEFINITE_TIME)
         {
-            LogError("Failed to evaluate retry action (get_time() failed)");
+            LogError("Failed to evaluate retry action (retry_get_tick_seconds() failed)");
             result = MU_FAILURE;
         }
         else if (retry_control->max_retry_time_in_secs > 0 &&
-            get_difftime(current_time, retry_control->first_retry_time) >= retry_control->max_retry_time_in_secs)
+            get_difftime(current_tick_seconds, retry_control->first_retry_tick_seconds) >= retry_control->max_retry_time_in_secs)
         {
             *retry_action = RETRY_ACTION_STOP_RETRYING;
 
@@ -127,7 +148,7 @@ static int evaluate_retry_action(RETRY_CONTROL_INSTANCE* retry_control, RETRY_AC
 
             result = RESULT_OK;
         }
-        else if (get_difftime(current_time, retry_control->last_retry_time) < retry_control->current_wait_time_in_secs)
+        else if (get_difftime(current_tick_seconds, retry_control->last_retry_tick_seconds) < retry_control->current_wait_time_in_secs)
         {
             *retry_action = RETRY_ACTION_RETRY_LATER;
 
@@ -258,8 +279,8 @@ void retry_control_reset(RETRY_CONTROL_HANDLE retry_control_handle)
 
         retry_control->retry_count = 0;
         retry_control->current_wait_time_in_secs = 0;
-        retry_control->first_retry_time = INDEFINITE_TIME;
-        retry_control->last_retry_time = INDEFINITE_TIME;
+        retry_control->first_retry_tick_seconds = INDEFINITE_TIME;
+        retry_control->last_retry_tick_seconds = INDEFINITE_TIME;
     }
 }
 
@@ -267,13 +288,18 @@ RETRY_CONTROL_HANDLE retry_control_create(IOTHUB_CLIENT_RETRY_POLICY policy, uns
 {
     RETRY_CONTROL_INSTANCE* retry_control;
 
-    if ((retry_control = (RETRY_CONTROL_INSTANCE*)malloc(sizeof(RETRY_CONTROL_INSTANCE))) == NULL)
+    if ((retry_control = (RETRY_CONTROL_INSTANCE*)calloc(1, sizeof(RETRY_CONTROL_INSTANCE))) == NULL)
     {
-        LogError("Failed creating the retry control (malloc failed)");
+        LogError("Failed creating the retry control (calloc failed)");
+    }
+    else if ((retry_control->tick_counter = tickcounter_create()) == NULL)    
+    {
+        LogError("Failed creating the retry controller (tickcounter_create failed)");
+        free(retry_control);
+        retry_control = NULL;
     }
     else
     {
-        memset(retry_control, 0, sizeof(RETRY_CONTROL_INSTANCE));
         retry_control->policy = policy;
         retry_control->max_retry_time_in_secs = max_retry_time_in_secs;
 
@@ -304,6 +330,7 @@ void retry_control_destroy(RETRY_CONTROL_HANDLE retry_control_handle)
     }
     else
     {
+        tickcounter_destroy(retry_control_handle->tick_counter);
         free(retry_control_handle);
     }
 }
@@ -326,9 +353,9 @@ int retry_control_should_retry(RETRY_CONTROL_HANDLE retry_control_handle, RETRY_
             *retry_action = RETRY_ACTION_STOP_RETRYING;
             result = RESULT_OK;
         }
-        else if (retry_control->first_retry_time == INDEFINITE_TIME && (retry_control->first_retry_time = get_time(NULL)) == INDEFINITE_TIME)
+        else if (retry_control->first_retry_tick_seconds == INDEFINITE_TIME && (retry_control->first_retry_tick_seconds = retry_get_tick_seconds(retry_control_handle)) == INDEFINITE_TIME)
         {
-            LogError("Failed to evaluate if retry should be attempted (get_time() failed)");
+            LogError("Failed to evaluate if retry should be attempted (retry_get_tick_seconds() failed)");
             result = MU_FAILURE;
         }
         else if (evaluate_retry_action(retry_control, retry_action) != RESULT_OK)
@@ -344,7 +371,7 @@ int retry_control_should_retry(RETRY_CONTROL_HANDLE retry_control_handle, RETRY_
 
                 if (retry_control->policy != IOTHUB_CLIENT_RETRY_IMMEDIATE)
                 {
-                    retry_control->last_retry_time = get_time(NULL);
+                    retry_control->last_retry_tick_seconds = retry_get_tick_seconds(retry_control_handle);
 
                     retry_control->current_wait_time_in_secs = calculate_next_wait_time(retry_control);
                 }


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `main` branch. 
  - [ ] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 