### PR TITLE
Update SDK_cross_compile_example.md

### DIFF
--- a/doc/SDK_cross_compile_example.md
+++ b/doc/SDK_cross_compile_example.md
@@ -78,7 +78,7 @@ ENV TOOLCHAIN_PREFIX=${TOOLCHAIN_SYSROOT}/usr
 ```
 Now to create the toolchain and build the SDK, run the script found at:
 ```
-/Source/azure-iot-sdk-c/blob/main/jenkins/raspberrypi_c_buster.sh
+[raspberrypi_c_buster.sh](https://github.com/Azure/azure-iot-sdk-c/blob/main/jenkins/raspberrypi_c_buster.sh)
 ```
 
 ```

--- a/doc/SDK_cross_compile_example.md
+++ b/doc/SDK_cross_compile_example.md
@@ -77,9 +77,7 @@ ENV TOOLCHAIN_NAME=arm-linux-gnueabihf
 ENV TOOLCHAIN_PREFIX=${TOOLCHAIN_SYSROOT}/usr
 ```
 Now to create the toolchain and build the SDK, run the script found at:
-```
 [raspberrypi_c_buster.sh](https://github.com/Azure/azure-iot-sdk-c/blob/main/jenkins/raspberrypi_c_buster.sh)
-```
 
 ```
 #!/bin/bash


### PR DESCRIPTION
Update doc to no longer use the build.sh script since it seems to now be used predominantly for testing, and no longer a general cmake build script for cross-compilation.

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x ] This pull-request is submitted against the `main` branch. 
  - [ ] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [ ] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem:
 The cross compilation doc uses the build.sh script which now seems to be used predominantly for testing, and no longer a general cmake build script for cross-compilation.

# Description of the solution:
Use another script we have in the repo that focuses on getting the toolchain and then builds the C SDK accordingly.