### PR TITLE
Add an option to define a custom target network interface for e2e tests

### DIFF
--- a/iothub_client/tests/common_e2e/iothubclient_common_e2e.c
+++ b/iothub_client/tests/common_e2e/iothubclient_common_e2e.c
@@ -505,6 +505,7 @@ static char* get_target_mac_address()
         {
             struct ifreq* it = ifc.ifc_req;
             const struct ifreq* const end = it + (ifc.ifc_len / sizeof(struct ifreq));
+            const char* networkInterface = IoTHubTest_GetTargetNetworkInterface(iotHubTestHandle);
 
             result = NULL;
 
@@ -527,7 +528,7 @@ static char* get_target_mac_address()
                     LogError("ioctl failed querying socket (SIOCGIFADDR)");
                     break;
                 }
-                else if (strcmp(ifr.ifr_name, "eth0") == 0)
+                else if (strcmp(ifr.ifr_name, networkInterface) == 0)
                 {
                     unsigned char* mac = (unsigned char*)ifr.ifr_hwaddr.sa_data;
 

--- a/iothub_client/tests/common_e2e/iothubclient_common_e2e.c
+++ b/iothub_client/tests/common_e2e/iothubclient_common_e2e.c
@@ -505,7 +505,7 @@ static char* get_target_mac_address()
         {
             struct ifreq* it = ifc.ifc_req;
             const struct ifreq* const end = it + (ifc.ifc_len / sizeof(struct ifreq));
-            const char* networkInterface = IoTHubTest_GetTargetNetworkInterface(iotHubTestHandle);
+            const char* networkInterface = IoTHubTest_GetTargetNetworkInterface();
 
             result = NULL;
 

--- a/testtools/iothub_test/inc/iothubtest.h
+++ b/testtools/iothub_test/inc/iothubtest.h
@@ -34,7 +34,7 @@ extern IOTHUB_TEST_CLIENT_RESULT IoTHubTest_ListenForEvent(IOTHUB_TEST_HANDLE de
 extern IOTHUB_TEST_CLIENT_RESULT IoTHubTest_ListenForRecentEvent(IOTHUB_TEST_HANDLE devhubHandle, pfIoTHubMessageCallback msgCallback, size_t partitionCount, void* context, double maxDrainTimeInSeconds);
 extern IOTHUB_TEST_CLIENT_RESULT IoTHubTest_ListenForEventForMaxDrainTime(IOTHUB_TEST_HANDLE devhubHandle, pfIoTHubMessageCallback msgCallback, size_t partitionCount, void* context);
 extern IOTHUB_TEST_CLIENT_RESULT IoTHubTest_SendMessage(IOTHUB_TEST_HANDLE devhubHandle, const unsigned char* data, size_t len);
-extern const char* IoTHubTest_GetTargetNetworkInterface(IOTHUB_TEST_HANDLE devhubHandle);
+extern const char* IoTHubTest_GetTargetNetworkInterface();
 
 #ifdef __cplusplus
 }

--- a/testtools/iothub_test/inc/iothubtest.h
+++ b/testtools/iothub_test/inc/iothubtest.h
@@ -34,6 +34,7 @@ extern IOTHUB_TEST_CLIENT_RESULT IoTHubTest_ListenForEvent(IOTHUB_TEST_HANDLE de
 extern IOTHUB_TEST_CLIENT_RESULT IoTHubTest_ListenForRecentEvent(IOTHUB_TEST_HANDLE devhubHandle, pfIoTHubMessageCallback msgCallback, size_t partitionCount, void* context, double maxDrainTimeInSeconds);
 extern IOTHUB_TEST_CLIENT_RESULT IoTHubTest_ListenForEventForMaxDrainTime(IOTHUB_TEST_HANDLE devhubHandle, pfIoTHubMessageCallback msgCallback, size_t partitionCount, void* context);
 extern IOTHUB_TEST_CLIENT_RESULT IoTHubTest_SendMessage(IOTHUB_TEST_HANDLE devhubHandle, const unsigned char* data, size_t len);
+extern const char* IoTHubTest_GetTargetNetworkInterface(IOTHUB_TEST_HANDLE devhubHandle);
 
 #ifdef __cplusplus
 }

--- a/testtools/iothub_test/src/iothubtest.c
+++ b/testtools/iothub_test/src/iothubtest.c
@@ -165,6 +165,8 @@ const char* AMQP_ADDRESS_PATH_FMT = "/devices/%s/messages/deviceBound";
 const char* AMQP_SEND_TARGET_ADDRESS_FMT = "amqps://%s/messages/deviceBound";
 const char* AMQP_SEND_AUTHCID_FMT = "iothubowner@sas.root.%s";
 
+const char* DEFAULT_TARGET_NETWORK_INTERFACE = "eth0";
+
 #define THREAD_CONTINUE             0
 #define THREAD_END                  1
 #define MAX_DRAIN_TIME              1000.0
@@ -2004,6 +2006,34 @@ IOTHUB_TEST_CLIENT_RESULT IoTHubTest_SendMessage(IOTHUB_TEST_HANDLE devhubHandle
             xio_destroy(tls_io);
             saslmechanism_destroy(sasl_mechanism_handle);
         }
+    }
+
+    return result;
+}
+
+const char* IoTHubTest_GetTargetNetworkInterface(IOTHUB_TEST_HANDLE devhubHandle)
+{
+    const char* result = NULL;
+    static char networkInterface[32];
+
+    if (devhubHandle == NULL)
+    {
+        LogError("Invalid parameter: devhubHandle is NULL", devhubHandle);
+    }
+    else
+    {
+        char* envVarValue = getenv("IOTHUB_TEST_TARGET_NETWORK_INTERFACE");
+
+        if (envVarValue != NULL)
+        {
+            (void)strcpy(networkInterface, envVarValue);
+        }
+        else
+        {
+            (void)strcpy(networkInterface, DEFAULT_TARGET_NETWORK_INTERFACE);
+        }
+
+        result = networkInterface;
     }
 
     return result;

--- a/testtools/iothub_test/src/iothubtest.c
+++ b/testtools/iothub_test/src/iothubtest.c
@@ -2018,7 +2018,7 @@ const char* IoTHubTest_GetTargetNetworkInterface(IOTHUB_TEST_HANDLE devhubHandle
 
     if (devhubHandle == NULL)
     {
-        LogError("Invalid parameter: devhubHandle is NULL", devhubHandle);
+        LogError("Invalid parameter: devhubHandle is NULL");
     }
     else
     {

--- a/testtools/iothub_test/src/iothubtest.c
+++ b/testtools/iothub_test/src/iothubtest.c
@@ -166,6 +166,8 @@ const char* AMQP_SEND_TARGET_ADDRESS_FMT = "amqps://%s/messages/deviceBound";
 const char* AMQP_SEND_AUTHCID_FMT = "iothubowner@sas.root.%s";
 
 const char* DEFAULT_TARGET_NETWORK_INTERFACE = "eth0";
+#define ENV_VAR_E2E_TARGET_NETWORK_INTERFACE               "IOTHUB_E2E_TARGET_NETWORK_INTERFACE"
+#define ENV_VAR_E2E_TARGET_NETWORK_INTERFACE_MAX_LENGTH    32
 
 #define THREAD_CONTINUE             0
 #define THREAD_END                  1
@@ -2014,12 +2016,12 @@ IOTHUB_TEST_CLIENT_RESULT IoTHubTest_SendMessage(IOTHUB_TEST_HANDLE devhubHandle
 const char* IoTHubTest_GetTargetNetworkInterface()
 {
     const char* result = NULL;
-    static char networkInterface[32];
-    char* envVarValue = getenv("IOTHUB_TEST_TARGET_NETWORK_INTERFACE");
+    static char networkInterface[ENV_VAR_E2E_TARGET_NETWORK_INTERFACE_MAX_LENGTH];
+    char* envNetworkInterfaceVal = getenv(ENV_VAR_E2E_TARGET_NETWORK_INTERFACE);
 
-    if (envVarValue != NULL)
+    if (envNetworkInterfaceVal != NULL)
     {
-        (void)strcpy(networkInterface, envVarValue);
+        (void)strcpy(networkInterface, envNetworkInterfaceVal);
     }
     else
     {

--- a/testtools/iothub_test/src/iothubtest.c
+++ b/testtools/iothub_test/src/iothubtest.c
@@ -2011,30 +2011,22 @@ IOTHUB_TEST_CLIENT_RESULT IoTHubTest_SendMessage(IOTHUB_TEST_HANDLE devhubHandle
     return result;
 }
 
-const char* IoTHubTest_GetTargetNetworkInterface(IOTHUB_TEST_HANDLE devhubHandle)
+const char* IoTHubTest_GetTargetNetworkInterface()
 {
     const char* result = NULL;
     static char networkInterface[32];
+    char* envVarValue = getenv("IOTHUB_TEST_TARGET_NETWORK_INTERFACE");
 
-    if (devhubHandle == NULL)
+    if (envVarValue != NULL)
     {
-        LogError("Invalid parameter: devhubHandle is NULL");
+        (void)strcpy(networkInterface, envVarValue);
     }
     else
     {
-        char* envVarValue = getenv("IOTHUB_TEST_TARGET_NETWORK_INTERFACE");
-
-        if (envVarValue != NULL)
-        {
-            (void)strcpy(networkInterface, envVarValue);
-        }
-        else
-        {
-            (void)strcpy(networkInterface, DEFAULT_TARGET_NETWORK_INTERFACE);
-        }
-
-        result = networkInterface;
+        (void)strcpy(networkInterface, DEFAULT_TARGET_NETWORK_INTERFACE);
     }
+
+    result = networkInterface;
 
     return result;
 }


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
Add an option to define a custom target network interface for e2e tests that explicitly choose the network interface to be used (not all e2e tests do so).
The tests are hardcoded to use the network interface "eth0", and it works ok on older distros and docker, but not on more recent linux systems.

# Description of the solution
Add an option to set the following environment variable to define which network interface the e2e tests should use:  IOTHUB_E2E_TARGET_NETWORK_INTERFACE

Example:
```
export IOTHUB_E2E_TARGET_NETWORK_INTERFACE=wlp4s0
```