### PR TITLE
Remove branch rename notice

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,9 +2,6 @@
 
 [![Build Status](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_apis/build/status/c/integrate-into-repo-C)](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/latest?definitionId=85)
 
-## Important branch rename information
-As of [December 1, 2021](https://github.com/Azure/azure-iot-sdk-c/commit/de09b35289313665f0d359835c661f8cb2a0fdf1), we have changed the default branch of this repo from `master` to `main`.  This may impact both your local clones of this repro made before this change as well as tools you have referencing `master`.  See [here](./doc/master_to_main_rename.md) for more information.
-
 ## Introduction
 The Azure IOT Hub Device SDK allows applications written in C99 or later or C++ to communicate easily with [Azure IoT Hub](https://azure.microsoft.com/services/iot-hub/), [Azure IoT Central][Azure-IoT-Central] and to
  [Azure IoT Device Provisioning][Azure-IoT-Device-Provisioning].  This repo includes the source code for the libraries, setup instructions, and samples demonstrating use scenarios.


### PR DESCRIPTION
At the end of 2021 we renamed our branch from `master` to `main` and put notes at the top of the primary readme.md with migration notes.

Since it's been +1 year, we can safely remove this notice.  I am leaving the [more detailed docs](https://github.com/Azure/azure-iot-sdk-c/blob/main/doc/master_to_main_rename.md) around just in case and since it's safely in a separate directory.

I'll close out #2172 once this goes in as well.