### PR TITLE
Add a Deprecation Notes section to readme.md, add MBED OS deprecation note

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,14 @@ In the repository you will find instructions and build tools to compile and run 
 
 If you are considering porting the device client SDK for C to a new platform, check out the [porting guide](https://github.com/Azure/azure-c-shared-utility/blob/master/devdoc/porting_guide.md) document.
 
+## Deprecation Notes
+
+  `MBED OS`
+
+  - Packages of azure-iot-sdk-c for MBED OS have been deprecated in January, 2023.
+
+  See also [Deprecated Folders](#deprecated-folders) below for other relevant notes.
+
 ## Contribution, Feedback and Issues
 
 If you encounter any bugs, have suggestions for new features or if you would like to become an active contributor to this project please follow the instructions provided in the [contribution guidelines](.github/CONTRIBUTING.md).
@@ -245,6 +253,7 @@ Contains libraries that enable interactions with the Device Proviosining service
 `/serializer`
 
 Contains libraries that provide modeling and JSON serialization capabilities on top of the raw messaging library.
+
 
 # Releases
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 # Azure IoT C SDKs and Libraries
 
 [![Build Status](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_apis/build/status/c/integrate-into-repo-C)](https://azure-iot-sdks.visualstudio.com/azure-iot-sdks/_build/latest?definitionId=85)
+  
 
 ## Introduction
 The Azure IOT Hub Device SDK allows applications written in C99 or later or C++ to communicate easily with [Azure IoT Hub](https://azure.microsoft.com/services/iot-hub/), [Azure IoT Central][Azure-IoT-Central] and to
@@ -26,6 +27,7 @@ For **constrained devices**, where memory is measured in kilobytes and not megab
     - [Provisioning Client SDK](#provisioning-client-sdk)
   - [OS Platforms and Hardware Compatibility](#os-platforms-and-hardware-compatibility)
   - [Porting the Azure IoT Device Client SDK for C to New Devices](#porting-the-azure-iot-device-client-sdk-for-c-to-new-devices)
+  - [Deprecation Notes](#deprecation-notes)
   - [Contribution, Feedback and Issues](#contribution-feedback-and-issues)
   - [Support](#support)
   - [Read More](#read-more)
@@ -253,7 +255,6 @@ Contains libraries that enable interactions with the Device Proviosining service
 `/serializer`
 
 Contains libraries that provide modeling and JSON serialization capabilities on top of the raw messaging library.
-
 
 # Releases
 


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
MBED OS packages for azure-iot-sdk-c have been deprecated, and no note has been posted on this repo.

# Description of the solution
Add a note of deprecation of azure-iot-sdk-c MBED OS packages in the local readme.md