### PR TITLE
Remove python installation

### DIFF
--- a/.github/scripts/build_doxygen.sh
+++ b/.github/scripts/build_doxygen.sh
@@ -8,7 +8,7 @@ set -o nounset # Exit if variable not set.
 set -o pipefail # Exit if pipe failed.
 
 sudo apt update
-sudo apt install -y git cmake python flex bison
+sudo apt install -y git cmake flex bison
 
 pushd ~
 git clone -b Release_1_9_0 https://github.com/doxygen/doxygen.git


### PR DESCRIPTION
Installing python causes issues when this script is being run on the newest version of Ubuntu, which ships with python 3. Removing the explicit python installation in the script resolves the issue.