### PR TITLE
Remove public-preview.

### DIFF
--- a/doc/setting_up_vcpkg.md
+++ b/doc/setting_up_vcpkg.md
@@ -21,17 +21,6 @@ The `use-prov-client` feature uses the syntax: `vcpkg install azure-iot-sdk-c[us
     -Duse_prov_client=ON
 ```
 
-The `public-preview` feature allows you to build and install the azure-iot-sdk-c from a provided public-preview hash. The `REF` hash used can be found in the [portfile.cmake](https://github.com/microsoft/vcpkg/blob/master/ports/azure-iot-sdk-c/portfile.cmake) file. To access this feature, use the syntax: `vcpkg install azure-iot-sdk-c[public-preview]`. The following CMake flags will be set:
-
-```
-    -Dskip_samples=ON
-    -Duse_installed_dependencies=ON
-    -Duse_default_uuid=ON
-    -Dbuild_as_dynamic=OFF
-    -Duse_edge_modules=ON
-    -Dwarnings_as_errors=OFF
-```
-
 There are no other configuration options via vcpkg available.
 
 > NOTE: If your application requires specific CMake flags not shown above, please build and install directly from the source code.  See [devbox_setup.md](https://github.com/Azure/azure-iot-sdk-c/blob/main/doc/devbox_setup.md) for further information.

--- a/doc/setting_up_vcpkg.md
+++ b/doc/setting_up_vcpkg.md
@@ -15,12 +15,6 @@ The Azure IoT C SDK uses [vcpkg](https://github.com/microsoft/vcpkg) primarily f
     -Dwarnings_as_errors=OFF
 ```
 
-The `use-prov-client` feature uses the syntax: `vcpkg install azure-iot-sdk-c[use-prov-client]` and builds using additional CMake flags:
-```
-    -Dhsm_type_symm_key=ON
-    -Duse_prov_client=ON
-```
-
 There are no other configuration options via vcpkg available.
 
 > NOTE: If your application requires specific CMake flags not shown above, please build and install directly from the source code.  See [devbox_setup.md](https://github.com/Azure/azure-iot-sdk-c/blob/main/doc/devbox_setup.md) for further information.


### PR DESCRIPTION
# Description of the problem
Public-preview was removed from vcpkg and the documentation did not reflect the changes.

# Description of the solution
Updated the documentation to reflect the changes that were made.