### PR TITLE
Fix duplicate include guard

### DIFF
--- a/provisioning_client/inc/azure_prov_client/internal/prov_transport_mqtt_common.h
+++ b/provisioning_client/inc/azure_prov_client/internal/prov_transport_mqtt_common.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#ifndef PROV_TRANSPORT_AMQP_COMMON_H
-#define PROV_TRANSPORT_AMQP_COMMON_H
+#ifndef PROV_TRANSPORT_MQTT_COMMON_H
+#define PROV_TRANSPORT_MQTT_COMMON_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,4 +39,4 @@ MOCKABLE_FUNCTION(, int, prov_transport_common_mqtt_set_option, PROV_DEVICE_TRAN
 }
 #endif /* __cplusplus */
 
-#endif // PROV_TRANSPORT_AMQP_COMMON_H
+#endif // PROV_TRANSPORT_MQTT_COMMON_H


### PR DESCRIPTION
The macro name 'PROV_TRANSPORT_AMQP_COMMON_H' is used in prov_transport_amqp_common.h

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
The macro name 'PROV_TRANSPORT_AMQP_COMMON_H' is used in two header files: prov_transport_amqp_common.h and prov_transport_mqtt_common.h.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected -->
Use a new macro for  prov_transport_mqtt_common.h.