### PR TITLE
Fix AMQP transport to break infinite loop of link re-ATTACH-ments

### DIFF
--- a/iothub_client/src/iothubtransport_amqp_device.c
+++ b/iothub_client/src/iothubtransport_amqp_device.c
@@ -804,7 +804,7 @@ int amqp_device_start_async(AMQP_DEVICE_HANDLE handle, SESSION_HANDLE session_ha
         {
             instance->session_handle = session_handle;
             instance->cbs_handle = cbs_handle;
-	    instance->stop_delay_ms = 0;
+	        instance->stop_delay_ms = 0;
 
             update_state(instance, DEVICE_STATE_STARTING);
 

--- a/iothub_client/tests/iothubtransport_amqp_common_ut/iothubtransport_amqp_common_ut.c
+++ b/iothub_client/tests/iothubtransport_amqp_common_ut/iothubtransport_amqp_common_ut.c
@@ -488,6 +488,25 @@ static DLIST_ENTRY TEST_waitingToSend;
 static unsigned long TEST_MESSAGE_ID;
 
 
+// ---------- Time-related Test Helpers ---------- //
+static time_t add_seconds(time_t base_time, unsigned int seconds)
+{
+    time_t new_time;
+    struct tm* bd_new_time;
+
+    if ((bd_new_time = localtime(&base_time)) == NULL)
+    {
+        new_time = INDEFINITE_TIME;
+    }
+    else
+    {
+        bd_new_time->tm_sec += seconds;
+        new_time = mktime(bd_new_time);
+    }
+
+    return new_time;
+}
+
 // ---------- Helpers for Expected Calls ---------- //
 
 // @remarks
@@ -4321,6 +4340,137 @@ TEST_FUNCTION(ConnectionStatusCallBack_UNAUTH_msg_communication_error)
     // act
     TEST_device_create_saved_on_state_changed_callback(TEST_device_create_saved_on_state_changed_context,
         DEVICE_STATE_STARTED, DEVICE_STATE_ERROR_MSG);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    destroy_transport(handle, device_handle, NULL);
+}
+
+TEST_FUNCTION(Transport_Fully_Reconnects_After_5_AMQP_device_errors)
+{
+    // arrange
+    initialize_test_variables();
+    time_t current_time = TEST_current_time;
+    bool is_state_change_timedout = false;
+    TRANSPORT_LL_HANDLE handle = create_transport();
+    IOTHUB_DEVICE_CONFIG* device_config = create_device_config(TEST_DEVICE_ID_CHAR_PTR, true);
+
+    IOTHUB_DEVICE_HANDLE device_handle;
+    device_handle = register_device(handle, device_config, &TEST_waitingToSend, true);
+
+    crank_transport_ready_after_create(handle, &TEST_waitingToSend, 0, false, true, 1, TEST_current_time, false);
+
+    // act
+    // Fail AMQP device enough times to trigger reconnection:
+    umock_c_reset_all_calls();
+
+    for (int i = 0; i < 4; i++)
+    {
+        // Raise error from amqp_device level.
+        STRICT_EXPECTED_CALL(get_time(NULL)).SetReturn(current_time);
+        STRICT_EXPECTED_CALL(Transport_ConnectionStatusCallBack(IOTHUB_CLIENT_CONNECTION_UNAUTHENTICATED, IOTHUB_CLIENT_CONNECTION_COMMUNICATION_ERROR, IGNORED_PTR_ARG));
+        TEST_device_create_saved_on_state_changed_callback(TEST_device_create_saved_on_state_changed_context,
+            DEVICE_STATE_STARTED, DEVICE_STATE_ERROR_MSG);
+
+        // On first error, restablish the links (amqp_device_delayed_stop)
+        STRICT_EXPECTED_CALL(singlylinkedlist_get_head_item(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(amqp_device_delayed_stop(IGNORED_PTR_ARG, IGNORED_NUM_ARG));
+        STRICT_EXPECTED_CALL(amqp_device_do_work(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(singlylinkedlist_get_next_item(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(amqp_connection_do_work(IGNORED_PTR_ARG));
+        (void)IoTHubTransport_AMQP_Common_DoWork(handle);
+
+        STRICT_EXPECTED_CALL(get_time(NULL)).SetReturn(current_time);
+        TEST_device_create_saved_on_state_changed_callback(TEST_device_create_saved_on_state_changed_context,
+            DEVICE_STATE_ERROR_MSG, DEVICE_STATE_STOPPING);
+
+        // amqp_device_delayed_stop takes 10 seconds to fully stop.
+        current_time = add_seconds(current_time, 10);
+
+        STRICT_EXPECTED_CALL(singlylinkedlist_get_head_item(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(is_timeout_reached(IGNORED_NUM_ARG, IGNORED_NUM_ARG, IGNORED_PTR_ARG))
+            .CopyOutArgumentBuffer_is_timed_out(&is_state_change_timedout, sizeof(is_state_change_timedout))
+            .SetReturn(0);
+        STRICT_EXPECTED_CALL(amqp_device_do_work(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(singlylinkedlist_get_next_item(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(amqp_connection_do_work(IGNORED_PTR_ARG));
+        (void)IoTHubTransport_AMQP_Common_DoWork(handle);
+
+        // Complete stopping amqp_device.
+        STRICT_EXPECTED_CALL(get_time(NULL)).SetReturn(current_time);
+        STRICT_EXPECTED_CALL(Transport_ConnectionStatusCallBack(
+            IOTHUB_CLIENT_CONNECTION_UNAUTHENTICATED, IOTHUB_CLIENT_CONNECTION_OK, IGNORED_PTR_ARG));
+        TEST_device_create_saved_on_state_changed_callback(TEST_device_create_saved_on_state_changed_context,
+            DEVICE_STATE_STOPPING, DEVICE_STATE_STOPPED);
+
+        current_time = add_seconds(current_time, 1);
+
+        // AMQP transport starts the amqp_device again.
+        STRICT_EXPECTED_CALL(singlylinkedlist_get_head_item(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(amqp_connection_get_session_handle(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(amqp_connection_get_cbs_handle(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(amqp_device_start_async(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(amqp_device_do_work(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(singlylinkedlist_get_next_item(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(amqp_connection_do_work(IGNORED_PTR_ARG));
+        (void)IoTHubTransport_AMQP_Common_DoWork(handle);
+
+        STRICT_EXPECTED_CALL(get_time(NULL)).SetReturn(current_time);
+        TEST_device_create_saved_on_state_changed_callback(TEST_device_create_saved_on_state_changed_context,
+            DEVICE_STATE_STOPPED, DEVICE_STATE_STARTING);
+
+        // amqp_device now goes fully started.
+        current_time = add_seconds(current_time, 1);
+
+        STRICT_EXPECTED_CALL(singlylinkedlist_get_head_item(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(is_timeout_reached(IGNORED_NUM_ARG, IGNORED_NUM_ARG, IGNORED_PTR_ARG))
+            .CopyOutArgumentBuffer_is_timed_out(&is_state_change_timedout, sizeof(is_state_change_timedout))
+            .SetReturn(0);
+        STRICT_EXPECTED_CALL(amqp_device_do_work(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(singlylinkedlist_get_next_item(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(amqp_connection_do_work(IGNORED_PTR_ARG));
+        (void)IoTHubTransport_AMQP_Common_DoWork(handle);
+
+        STRICT_EXPECTED_CALL(get_time(NULL)).SetReturn(current_time);
+        STRICT_EXPECTED_CALL(retry_control_reset(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(Transport_ConnectionStatusCallBack(
+            IOTHUB_CLIENT_CONNECTION_AUTHENTICATED, IOTHUB_CLIENT_CONNECTION_OK, IGNORED_PTR_ARG));
+        TEST_device_create_saved_on_state_changed_callback(TEST_device_create_saved_on_state_changed_context,
+            DEVICE_STATE_STARTING, DEVICE_STATE_STARTED);
+
+        // Regular DoWork call with no issues.
+        STRICT_EXPECTED_CALL(singlylinkedlist_get_head_item(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(DList_IsListEmpty(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(amqp_device_do_work(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(singlylinkedlist_get_next_item(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(amqp_connection_do_work(IGNORED_PTR_ARG));
+        (void)IoTHubTransport_AMQP_Common_DoWork(handle);
+    }
+
+    // Raise 5th error from amqp_device, triggering AMQP transport to do a full reconnection.
+    STRICT_EXPECTED_CALL(get_time(NULL)).SetReturn(current_time);
+    STRICT_EXPECTED_CALL(Transport_ConnectionStatusCallBack(IOTHUB_CLIENT_CONNECTION_UNAUTHENTICATED, IOTHUB_CLIENT_CONNECTION_COMMUNICATION_ERROR, IGNORED_PTR_ARG));
+    TEST_device_create_saved_on_state_changed_callback(TEST_device_create_saved_on_state_changed_context,
+        DEVICE_STATE_STARTED, DEVICE_STATE_ERROR_MSG);
+
+    STRICT_EXPECTED_CALL(singlylinkedlist_get_head_item(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(STRING_c_str(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(amqp_device_do_work(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(singlylinkedlist_get_next_item(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(amqp_connection_do_work(IGNORED_PTR_ARG));
+    (void)IoTHubTransport_AMQP_Common_DoWork(handle);
+
+    // Observe the AMQP transport do a full re-connection.
+    set_expected_calls_for_prepare_for_connection_retry(1, DEVICE_STATE_ERROR_MSG);
+    (void)IoTHubTransport_AMQP_Common_DoWork(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
    In iothubtransport_amqp_common.c `number_of_previous_failures` is used to track issues with the AMQP device and either restart or re-connect it as appropriately.
    Note: AMQP device (iothubtransport_amqp_device.c) is a subcomponent of the AMQP transport, representing each registered device.
    The AMQP transport can either just restart a registered AMQP device (causing just re-ATTACH-ment of AMQP links) or completely reconnect it (with END, CLOSE, OPEN, BEGIN, ...).
    When a failure occurs (e.g., the Twin messenger reports an error), the AMQP device goes into an error state itself and `number_of_previous_failures` (on AMQP transport layer) is incremented.
    If `number_of_previous_failures` is less than `MAX_NUMBER_OF_DEVICE_FAILURES`, the AMQP device is just restarted.
    If `number_of_previous_failures` reaches `MAX_NUMBER_OF_DEVICE_FAILURES`, the AMQP device is completely reconnected.
    If `number_of_previous_failures` never reaches `MAX_NUMBER_OF_DEVICE_FAILURES` (iothubtransport_amqp_common.c:1058) then the transport will never force a full reconnection, always trying to stop the registered AMQP device.
    When IoTHubTransport_AMQP_Common_Device_DoWork is called (for each registered device), if `send_pending_events` succeeds, `number_of_previous_failures` is set to 0.
    But all `send_pending_events` does is to add a message on the outgoing queue of the AMQP messenger, so it is always expected to succeed, always resetting `number_of_previous_failures`.
    That prevents in such case the AMQP transport from fully reconnecting with the IoT Hub in specific error scenarios - like when the Twin throttling occurs, causing outgoing Twin messages (e.g, PATCH, i.e., reported properties update) to fail.
    The AMQP transport keeps trapped in a loop of just trying to restablish the AMQP links in in this case.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Move the code that resets the number of failures to the correct places, when messages get effectively and successfully sent or received.