### PR TITLE
Curl is not needed in the iothub_client_sample_mqtt_dm sample

### DIFF
--- a/iothub_client/samples/iothub_client_sample_mqtt_dm/CMakeLists.txt
+++ b/iothub_client/samples/iothub_client_sample_mqtt_dm/CMakeLists.txt
@@ -44,7 +44,6 @@ if(LINUX)
         aziotsharedutil
         umqtt
         pthread
-        curl
         m
     )
 


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
In Linux, if curl is not installed, the iothub_client_sample_mqtt_dm sample fails to compile, but curl is not needed at all by sample. So we should not be linking iothub_client_sample_mqtt_dm against curl.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Remove curl from the list of target_link_libraries of iothub_client_sample_mqtt_dm.