### PR TITLE
Fix data type of error code for Upload to Blob error responses

### DIFF
--- a/iothub_client/samples/iothub_client_sample_mqtt_dm/CMakeLists.txt
+++ b/iothub_client/samples/iothub_client_sample_mqtt_dm/CMakeLists.txt
@@ -44,7 +44,6 @@ if(LINUX)
         aziotsharedutil
         umqtt
         pthread
-        curl
         m
     )
 

--- a/iothub_client/src/iothub_client_ll_uploadtoblob.c
+++ b/iothub_client/src/iothub_client_ll_uploadtoblob.c
@@ -30,7 +30,7 @@
 static const char* const RESPONSE_BODY_FORMAT = "{\"correlationId\":\"%s\", \"isSuccess\":%s, \"statusCode\":%d, \"statusDescription\":\"%s\"}";
 static const char* const RESPONSE_BODY_ABORTED_MESSAGE = "file upload aborted";
 static const char* const RESPONSE_BODY_FAILED_MESSAGE = "client not able to connect with the server";
-static const char* const RESPONSE_BODY_ERROR_RETURN_CODE = "-1";
+static const int RESPONSE_BODY_ERROR_RETURN_CODE = -1;
 static const char* const RESPONSE_BODY_ERROR_BOOLEAN_STRING = "false";
 
 #define INDEFINITE_TIME                            ((time_t)-1)

--- a/iothub_client/tests/iothubclient_uploadtoblob_e2e/iothubclient_uploadtoblob_e2e.c
+++ b/iothub_client/tests/iothubclient_uploadtoblob_e2e/iothubclient_uploadtoblob_e2e.c
@@ -365,6 +365,10 @@ static void e2e_uploadtoblob_multiblock_test(IOTHUB_CLIENT_TRANSPORT_PROVIDER pr
         IOTHUB_CLIENT_HANDLE iotHubClientHandle = IoTHubClient_CreateFromConnectionString(deviceToUse->connectionString, protocol);
         ASSERT_IS_NOT_NULL(iotHubClientHandle, "Could not invoke IoTHubClient_CreateFromConnectionString");
 
+        // We ignore the error if it occurs, in case this CURL is not installed nor used. 
+        size_t enableCurlVerboseLogging = 1;
+        (void)IoTHubClient_SetOption(iotHubClientHandle, OPTION_CURL_VERBOSE, &enableCurlVerboseLogging);
+
         uploadToBlobCauseAbort = causeAbort;
         g_uploadToBlobStatus = UPLOADTOBLOB_CALLBACK_PENDING;
         uploadBlobNumber = noData ? 1 : 0;
@@ -505,6 +509,11 @@ TEST_FUNCTION(IoTHub_MQTT_UploadMultipleBlocksToBlobEx)
 TEST_FUNCTION(IoTHub_MQTT_UploadMultipleBlocksNoData)
 {
     e2e_uploadtoblob_multiblock_test(MQTT_Protocol, true, false, true);
+}
+
+TEST_FUNCTION(IoTHub_MQTT_UploadMultipleBlocksAbort)
+{
+    e2e_uploadtoblob_multiblock_test(MQTT_Protocol, true, false, false);
 }
 
 #ifndef __APPLE__


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
When simulating errors during upload to blob, the response message back to IoT Hub was generated with incorrect response code. That's because the sprintf-like function expected the code as integer, but the code was passing a const char*.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Change the default error code for u2b to integer. 

**Note: unit tests were not modified because the STRING_construct_sprintf is mocked (abstracted) in iothub_client_ll_u2b_ut**