### PR TITLE
provisioning_client: build libprov_mqtt_transport.so

### DIFF
--- a/provisioning_client/CMakeLists.txt
+++ b/provisioning_client/CMakeLists.txt
@@ -360,6 +360,20 @@ if(${use_prov_client} OR (${use_prov_client_core} AND ${run_e2e_tests}))
         target_link_libraries(prov_mqtt_transport umqtt)
         set(provisioning_libs ${provisioning_libs} prov_mqtt_transport)
         set(provisioning_headers ${provisioning_headers} ${PROV_MQTT_CLIENT_H_FILES})
+        if(${build_as_dynamic})
+            add_library(prov_mqtt_transport_dll SHARED
+                ${PROV_MQTT_CLIENT_C_FILES}
+                ${PROV_MQTT_CLIENT_H_FILES}
+            )
+            linkSharedUtil(prov_mqtt_transport_dll)
+            target_link_libraries(prov_mqtt_transport_dll umqtt)
+            set_target_properties(prov_mqtt_transport_dll PROPERTIES
+                OUTPUT_NAME "prov_mqtt_transport"
+                VERSION ${PROV_SDK_VERSION}
+                SOVERSION ${PROV_SDK_VERSION_MAJOR}
+            )
+            set(provisioning_libs ${provisioning_libs} prov_mqtt_transport_dll)
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
Adding support in provisioning_client/CMakeLists.txt to build an so library for libprov_mqtt_transport.

<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [Yes] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [No] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [No] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [Yes] This pull-request is submitted against the `main` branch. 
  - [Yes] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [Yes] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

This addresses #2435.
  In addition to adding build support for libprov_mqtt_transport.so, this will allow easier updates in Intel's[ meta-iot-cloud yocto layer](https://github.com/intel-iot-devkit/meta-iot-cloud/tree/master/recipes-azure/azure-iot-sdk-c).

# Description of the problem
The build as dynamic config switch has no effect on the mqtt_transport library. While the build outputs a static library, there is no dynamic library being built, even if the -Dbuild_as_dynamic:BOOL=ON switch is specified.
# Description of the solution
To solve this issue, I just looked at how the other so libraries are built in this SDK and added the build support for that.

# Testing
1. built the sdk using the build_as_dynamic switch and verified that both (.a and .so) libraries were produced.
        /usr/lib/libprov_mqtt_transport.so
        /usr/lib/libprov_mqtt_transport.so.1
        /usr/lib/libprov_mqtt_transport.so.1.11.0
        /usr/lib/libprov_mqtt_transport.a
2. Verified that the so versioning was present (see build artifact output above)
3. Linked and used the libprov_mqtt_transport.so with my application.
4. Verified that my application can connect with the IoT Hub using this .so.

