### PR TITLE
Fix cross-comp CI pipeline (ARM & MIPS32) to build against target branch instead of main

### DIFF
--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -959,7 +959,7 @@ jobs:
     displayName: 'Setup'
   - script: |
       cd samples/dockerbuilds/MIPS32
-      docker build -t mipsiotbuild:latest . --network=host
+      docker build --build-arg TARGET_BRANCH=$BUILD_SOURCEBRANCH -t mipsiotbuild:latest . --network=host
       cd ..
       docker build -t mipsiotapp:latest . --network=host --file ./MIPS32/Dockerfile_adjunct
     displayName: 'Build MIPS32'
@@ -981,7 +981,7 @@ jobs:
     displayName: 'Setup'
   - script: |
       cd samples/dockerbuilds/ARM
-      docker build -t armiotbuild:latest . --network=host
+      docker build --build-arg TARGET_BRANCH=$BUILD_SOURCEBRANCH -t armiotbuild:latest . --network=host
       cd ..
       docker build -t armiotapp:latest . --network=host --file ./ARM/Dockerfile_adjunct
     displayName: 'Build ARM'

--- a/samples/dockerbuilds/ARM/Dockerfile
+++ b/samples/dockerbuilds/ARM/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:latest
 ARG DEBIAN_FRONTEND=noninteractive
+ARG TARGET_BRANCH=main
 
 #########################################
 # start from home directory
@@ -74,6 +75,8 @@ WORKDIR ..
 # Build Azure C SDK
 RUN git clone https://github.com/azure/azure-iot-sdk-c.git
 WORKDIR azure-iot-sdk-c
+RUN git fetch origin $TARGET_BRANCH
+RUN git checkout FETCH_HEAD
 RUN git submodule update --init
 RUN mkdir cmake
 WORKDIR cmake

--- a/samples/dockerbuilds/MIPS32/Dockerfile
+++ b/samples/dockerbuilds/MIPS32/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:latest
+ARG TARGET_BRANCH=main
 
 #########################################
 # start from home directory
@@ -80,6 +81,8 @@ WORKDIR ..
 
 RUN git clone https://github.com/azure/azure-iot-sdk-c.git
 WORKDIR azure-iot-sdk-c
+RUN git fetch origin $TARGET_BRANCH
+RUN git checkout FETCH_HEAD
 RUN git submodule update --init
 RUN mkdir cmake
 WORKDIR cmake


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
The ARM and the MIPS32 cross-compilation jobs in .vsts-ci.yml will always target the main branch, ignoring the branch a given PR is based on and letting potential issues sip through. 

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
This change fixes the ARM and MIPS32 jobs so they run against whatever branch the pipeline is running against.