### PR TITLE
Fix incorrect internal header include introduced by upload-to-blob refactoring

### DIFF
--- a/iothub_client/inc/internal/iothub_client_ll_uploadtoblob.h
+++ b/iothub_client/inc/internal/iothub_client_ll_uploadtoblob.h
@@ -41,16 +41,6 @@ extern "C"
 
     typedef struct IOTHUB_CLIENT_LL_UPLOADTOBLOB_HANDLE_DATA* IOTHUB_CLIENT_LL_UPLOADTOBLOB_HANDLE;
 
-    /*
-     * @remark `struct IOTHUB_CLIENT_LL_UPLOADTOBLOB_CONTEXT_STRUCT` contains information specifically
-     *         related to an individual upload request currently active in Azure IoT Hub, mainly
-     *         the correlation-id and Azure Blob SAS URI provided by the Azure IoT Hub when a new
-     *         upload is started. The `struct IOTHUB_CLIENT_LL_UPLOADTOBLOB_HANDLE_DATA` on the other hand 
-     *         holds common information (independent from individual upload requests) that is used for
-     *         upload-to-blob Rest API calls to Azure IoT Hub.
-     */    
-    typedef struct IOTHUB_CLIENT_LL_UPLOADTOBLOB_CONTEXT_STRUCT* IOTHUB_CLIENT_LL_UPLOADTOBLOB_CONTEXT_HANDLE;
-
     MOCKABLE_FUNCTION(, IOTHUB_CLIENT_LL_UPLOADTOBLOB_HANDLE, IoTHubClient_LL_UploadToBlob_Create, const IOTHUB_CLIENT_CONFIG*, config, IOTHUB_AUTHORIZATION_HANDLE, auth_handle);
 
     /*

--- a/iothub_client/inc/iothub_client_core_common.h
+++ b/iothub_client/inc/iothub_client_core_common.h
@@ -33,6 +33,15 @@ extern "C"
     */
     typedef void(*IOTHUB_CLIENT_FILE_UPLOAD_CALLBACK)(IOTHUB_CLIENT_FILE_UPLOAD_RESULT result, void* userContextCallback);
 
+/** @remark `struct IOTHUB_CLIENT_LL_UPLOADTOBLOB_CONTEXT_STRUCT` contains information specifically
+ *          related to an individual upload request currently active in Azure IoT Hub, mainly
+ *          the correlation-id and Azure Blob SAS URI provided by the Azure IoT Hub when a new
+ *          upload is started. The `struct IOTHUB_CLIENT_LL_UPLOADTOBLOB_HANDLE_DATA` on the other hand 
+ *          holds common information (independent from individual upload requests) that is used for
+ *          upload-to-blob Rest API calls to Azure IoT Hub.
+ */
+typedef struct IOTHUB_CLIENT_LL_UPLOADTOBLOB_CONTEXT_STRUCT* IOTHUB_CLIENT_LL_UPLOADTOBLOB_CONTEXT_HANDLE;
+
 #define IOTHUB_CLIENT_RESULT_VALUES       \
     IOTHUB_CLIENT_OK,                     \
     IOTHUB_CLIENT_INVALID_ARG,            \

--- a/iothub_client/inc/iothub_client_core_ll.h
+++ b/iothub_client/inc/iothub_client_core_ll.h
@@ -18,9 +18,6 @@ typedef struct IOTHUB_CLIENT_CORE_LL_HANDLE_DATA_TAG* IOTHUB_CLIENT_CORE_LL_HAND
 #include "umock_c/umock_c_prod.h"
 #include "iothub_transport_ll.h"
 #include "iothub_client_core_common.h"
-#ifndef DONT_USE_UPLOADTOBLOB
-#include "internal/iothub_client_ll_uploadtoblob.h"
-#endif
 
 #ifdef __cplusplus
 extern "C"


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
Internal headers must not be referenced by any public header. The recent u2b changes caused iothub_client_core_ll.h to include internal/iothub_client_ll_uploadtoblob.h, which is incorrect.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
This fix removes this include directive from iothub_client_core_ll.h and moves the type IOTHUB_CLIENT_LL_UPLOADTOBLOB_HANDLE into iothub_client_core_common.h, solving the need for both client layer and upload-to-blob modules to reference this type.