### PR TITLE
Remove unused structure IOTHUB_REQ_INFO

### DIFF
--- a/provisioning_client/src/prov_device_ll_client.c
+++ b/provisioning_client/src/prov_device_ll_client.c
@@ -78,13 +78,6 @@ typedef enum CLIENT_STATE_TAG
     CLIENT_STATE_ERROR
 } CLIENT_STATE;
 
-typedef struct IOTHUB_REQ_INFO_TAG
-{
-    char* iothub_url;
-    char* iothub_key;
-    char* device_id;
-} IOTHUB_REQ_INFO;
-
 typedef struct PROV_INSTANCE_INFO_TAG
 {
     PROV_DEVICE_CLIENT_REGISTER_DEVICE_CALLBACK register_callback;
@@ -113,8 +106,6 @@ typedef struct PROV_INSTANCE_INFO_TAG
     bool is_connected;
 
     PROV_AUTH_TYPE hsm_type;
-
-    IOTHUB_REQ_INFO iothub_info;
 
     CLIENT_STATE prov_state;
 
@@ -709,12 +700,6 @@ static void cleanup_prov_info(PROV_INSTANCE_INFO* prov_info)
     }
     free(prov_info->registration_id);
     prov_info->registration_id = NULL;
-    free(prov_info->iothub_info.device_id);
-    prov_info->iothub_info.device_id = NULL;
-    free(prov_info->iothub_info.iothub_key);
-    prov_info->iothub_info.iothub_key = NULL;
-    free(prov_info->iothub_info.iothub_url);
-    prov_info->iothub_info.iothub_url = NULL;
     prov_info->auth_attempts_made = 0;
 }
 

--- a/provisioning_client/tests/prov_device_client_ll_ut/prov_device_client_ll_ut.c
+++ b/provisioning_client/tests/prov_device_client_ll_ut/prov_device_client_ll_ut.c
@@ -619,9 +619,6 @@ BEGIN_TEST_SUITE(prov_device_client_ll_ut)
     static void setup_cleanup_prov_info_mocks(void)
     {
         STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
     }
 
     static void setup_destroy_prov_info_mocks(void)


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
https://github.com/Azure/azure-iot-sdk-c/issues/2529

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Remove unused structure and references to it in PROV_INSTANCE_INFO.