### PR TITLE
Fix IoTHubClient_LL_UploadToBlob_NotifyCompletion to use empty string when responseMessage is NULL (gh2554)

### DIFF
--- a/iothub_client/src/iothub_client_ll_uploadtoblob.c
+++ b/iothub_client/src/iothub_client_ll_uploadtoblob.c
@@ -1061,7 +1061,7 @@ IOTHUB_CLIENT_RESULT IoTHubClient_LL_UploadToBlob_NotifyCompletion(IOTHUB_CLIENT
                                                     uploadCorrelationId,
                                                     isSuccess ? RESPONSE_BODY_SUCCESS_BOOLEAN_STRING : RESPONSE_BODY_ERROR_BOOLEAN_STRING,
                                                     responseCode,
-                                                    responseMessage);
+                                                    responseMessage != NULL ? responseMessage : EMPTY_STRING);
 
         if(response == NULL)
         {


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-c/issues/2554

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
https://github.com/Azure/azure-iot-sdk-c/issues/2554

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 

Use empty string as format argument in STRING_construct_sprintf instead of NULL.

Note: Test not added because STRING_construct_sprintf is not mocked in that unit test set.