### PR TITLE
Fix check on output of vsnprintf

### DIFF
--- a/iothub_client/src/iothub_client_properties.c
+++ b/iothub_client/src/iothub_client_properties.c
@@ -72,14 +72,14 @@ static void AdvanceCountersAfterWrite(int currentOutputBytes, char** currentWrit
 }
 
 // To correctly check snprintf for success, we need to check both it's not negative AND 
-// that the (number of bytes written ) != (sizeof buffer).
+// that the (number of bytes written ) !>= (sizeof buffer).
 static int PropertySnprintf(char* buffer, size_t count, const char* format, ...)
 {
     va_list arg_list;
     va_start(arg_list, format);
 
     int currentOutputBytes = vsnprintf(buffer, count, format, arg_list);
-    if ((currentOutputBytes < 0) || (currentOutputBytes == (int)count))
+    if ((currentOutputBytes < 0) || (currentOutputBytes >= (int)count))
     {
         return -1;
     }


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
The snprintf() API function returns the total length of the string it tried to create; if the attacker is able to craft input so that `count` becomes larger than the available space in &#180;buffer` and if the return value is used unsafely such as in the `AdvanceCountersAfterWrite()` function, memory corruption might occur.

# Description of the solution
Checked that the return value of snprintf is not >= count instead of just != count