### PR TITLE
Fix potential Int wraparound in CopyPayloadToString

### DIFF
--- a/iothub_client/src/iothub_client_properties.c
+++ b/iothub_client/src/iothub_client_properties.c
@@ -401,7 +401,14 @@ static char* CopyPayloadToString(const unsigned char* payload, size_t size)
     char* jsonStr;
     size_t sizeToAllocate = size + 1;
 
-    if ((jsonStr = (char*)calloc(1, sizeToAllocate)) == NULL)
+    // If the result of sizeToAllocate is zero it means it had a type overflow (size_t is an unsigned type).
+    // It is very unlikely but could happen.
+    if (sizeToAllocate == 0)
+    {
+        LogError("Payload size exceeds maximum allocation");
+        jsonStr = NULL;
+    }
+    else if ((jsonStr = (char*)calloc(1, sizeToAllocate)) == NULL)
     {
         LogError("Unable to allocate %lu size buffer", (unsigned long)(sizeToAllocate));
     }


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
As described in IcM 31000000220103, "Integer wraparound, under-allocation, and heap buffer overflow in Azure IoT C SDK CopyPayloadToString() function"


# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Check if the size for allocation wraps around.