### PR TITLE
fix potential size_t overflow in twin serializer

### DIFF
--- a/serializer/inc/serializer_devicetwin.h
+++ b/serializer/inc/serializer_devicetwin.h
@@ -17,8 +17,13 @@
 static void serializer_ingest(DEVICE_TWIN_UPDATE_STATE update_state, const unsigned char* payLoad, size_t size, void* userContextCallback)
 {
     /*by convention, userContextCallback is a pointer to a model instance created with CodeFirst_CreateDevice*/
-
-    char* copyOfPayload = (char*)malloc(size + 1);
+    size_t sizeToAllocate = size + 1;
+    if (sizeToAllocate == 0)
+    {
+        LogError("Payload size exceeds maximum allocation\n");
+        return;
+    }
+    char* copyOfPayload = (char*)malloc(sizeToAllocate);
     if (copyOfPayload == NULL)
     {
         LogError("unable to malloc\n");


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
Integer wraparound, under-allocation, and heap buffer overflow in Azure IoT C SDK serializer_ingest() function

# Description of the solution
Check if the size for allocation wraps around.

