### PR TITLE
Fix xcodenative build (set LD path to latest curl version installed)

### DIFF
--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -893,11 +893,12 @@ jobs:
   displayName: "Xcode Native"
   steps:
   - script: |
-      export DYLD_LIBRARY_PATH=/usr/local/Cellar/curl/7.61.0/lib
+      curl --version
+      export DYLD_LIBRARY_PATH="/usr/local/Cellar/curl/$(ls -b /usr/local/Cellar/curl | grep -e '[0-9\.]')/lib"
       ./jenkins/osx_xcode_native.sh
     displayName: 'Build'
   - script: |
-      export DYLD_LIBRARY_PATH=/usr/local/Cellar/curl/7.61.0/lib
+      export DYLD_LIBRARY_PATH="/usr/local/Cellar/curl/$(ls -b /usr/local/Cellar/curl | grep -e '[0-9\.]')/lib"
       cd cmake && ctest -T test --no-compress-output -C "Debug" -V -j 8 --schedule-random
     displayName: "Run Tests"
     env:


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
xcodenative tests are failing on the gate (e2e tests):
```shell
8: Info: If using SecureTransport with the C SDK, please confirm cURL is also configured to use SecureTransport.
8: Error: Time:Sat Feb 17 04:38:40 2024 File:/Users/runner/work/1/s/c-utility/adapters/httpapi_curl.c Func:HTTPAPI_ExecuteRequest Line:770 curl_easy_perform() failed: SSL connect error
8: 
8: Error: Time:Sat Feb 17 04:38:40 2024 File:/Users/runner/work/1/s/c-utility/adapters/httpapi_curl.c Func:HTTPAPI_ExecuteRequest Line:772 (result = HTTPAPI_OPEN_REQUEST_FAILED (4))
8: Error: Time:Sat Feb 17 04:38:40 2024 File:/Users/runner/work/1/s/c-utility/src/httpapiex.c Func:HTTPAPIEX_ExecuteRequest Line:547 unable to recover sending to a working state
8: Error: Time:Sat Feb 17 04:38:40 2024 File:/Users/runner/work/1/s/iothub_service_client/src/iothub_registrymanager.c Func:sendHttpRequestCRUD Line:1228 HTTPAPIEX_SAS_ExecuteRequest failed. Host:iotsdk-c-production.azure-devices.net
8: Error: Time:Sat Feb 17 04:38:40 2024 File:/Users/runner/work/1/s/testtools/iothub_test/src/iothub_account.c Func:IoTHubAccount_deinit Line:863 IoTHubRegistryManager_DeleteDevice failed (8) for SAS Based Device "csdk_e2eDevice_sas_j_please_delete_033F103F-D163-48D0-87B7-619ED5E56E9F"
8: 
```

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Figured out that curl is not able to load shared libs, since we were passing a path to an old curl version (not present in the OSX image). Fixed by setting DYLD_LIBRARY_PATH to whatever version is installed in the system. 