### PR TITLE
Fix possible UAF in readApplicationPropertiesFromuAMQPMessage

### DIFF
--- a/iothub_client/src/uamqp_messaging.c
+++ b/iothub_client/src/uamqp_messaging.c
@@ -1101,29 +1101,25 @@ static int readApplicationPropertiesFromuAMQPMessage(IOTHUB_MESSAGE_HANDLE iothu
                         result = MU_FAILURE;
                     }
 
-                    else if ((result = amqpvalue_get_string(map_key_name, &key_name)) != 0)
+                    else
                     {
-                        LogError("Failed parsing the uAMQP property name (return code %d).", result);
-                        result = MU_FAILURE;
-                    }
-                    else if ((result = amqpvalue_get_string(map_key_value, &key_value)) != 0)
-                    {
-                        LogError("Failed parsing the uAMQP property value (return code %d).", result);
-                        result = MU_FAILURE;
-                    }
-                    else if (Map_AddOrUpdate(iothub_message_properties_map, key_name, key_value) != MAP_OK)
-                    {
-                        LogError("Failed to add/update IoTHub message property map.");
-                        result = MU_FAILURE;
-                    }
+                        if ((result = amqpvalue_get_string(map_key_name, &key_name)) != 0)
+                        {
+                            LogError("Failed parsing the uAMQP property name (return code %d).", result);
+                            result = MU_FAILURE;
+                        }
+                        else if ((result = amqpvalue_get_string(map_key_value, &key_value)) != 0)
+                        {
+                            LogError("Failed parsing the uAMQP property value (return code %d).", result);
+                            result = MU_FAILURE;
+                        }
+                        else if (Map_AddOrUpdate(iothub_message_properties_map, key_name, key_value) != MAP_OK)
+                        {
+                            LogError("Failed to add/update IoTHub message property map.");
+                            result = MU_FAILURE;
+                        }
 
-                    if (map_key_name != NULL)
-                    {
                         amqpvalue_destroy(map_key_name);
-                    }
-
-                    if (map_key_value != NULL)
-                    {
                         amqpvalue_destroy(map_key_value);
                     }
                 }


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
readApplicationPropertiesFromuAMQPMessage tries to free `map_key_name` without checking if it was allocated (it does not check the result of amqpvalue_get_map_key_value_pair), possibly causing an user-after-free failure.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Only try to free `map_key_name` if amqpvalue_get_map_key_value_pair succeeds