### PR TITLE
Document vcpkg build `use-prov-client` feature

### DIFF
--- a/doc/setting_up_vcpkg.md
+++ b/doc/setting_up_vcpkg.md
@@ -15,6 +15,13 @@ The Azure IoT C SDK uses [vcpkg](https://github.com/microsoft/vcpkg) primarily f
     -Dwarnings_as_errors=OFF
 ```
 
+Additionally, it is possible to enable the Provisioning Device client during installation by using the `vcpkg install azure-iot-sdk-c[use-prov-client]` command instead or by adding the `use-prov-client` feature in the [vcpkg manifest](https://learn.microsoft.com/en-us/vcpkg/concepts/manifest-mode) file. In any case, this build will also set the following CMake flags:
+
+```
+    -Duse_prov_client=ON
+    -Dhsm_type_symm_key=ON
+```
+
 There are no other configuration options via vcpkg available.
 
 > NOTE: If your application requires specific CMake flags not shown above, please build and install directly from the source code.  See [devbox_setup.md](https://github.com/Azure/azure-iot-sdk-c/blob/main/doc/devbox_setup.md) for further information.


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [x] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Description of the problem
In microsoft/vcpkg#38841 I added the `use-prov-client` feature to be able to enable the Provisioning Device client in a vcpkg build.

# Description of the solution
This PR reflects this change in the **Azure IoT C SDK vcpkg support** section of the documentation.