### PR TITLE
Fix file upload openssl options with x509 authentication

### DIFF
--- a/iothub_client/src/iothub_client_ll_uploadtoblob.c
+++ b/iothub_client/src/iothub_client_ll_uploadtoblob.c
@@ -1315,7 +1315,7 @@ IOTHUB_CLIENT_RESULT IoTHubClient_LL_UploadToBlob_SetOption(IOTHUB_CLIENT_LL_UPL
         }
         else if (strcmp(OPTION_OPENSSL_PRIVATE_KEY_TYPE, optionName) == 0)
         {
-            if (upload_data->cred_type != IOTHUB_CREDENTIAL_TYPE_X509)
+            if (upload_data->cred_type != IOTHUB_CREDENTIAL_TYPE_X509 && upload_data->cred_type != IOTHUB_CREDENTIAL_TYPE_X509_ECC)
             {
                 LogError("trying to set a x509 private key type while the authentication scheme is not x509");
                 result = IOTHUB_CLIENT_INVALID_ARG;
@@ -1347,7 +1347,7 @@ IOTHUB_CLIENT_RESULT IoTHubClient_LL_UploadToBlob_SetOption(IOTHUB_CLIENT_LL_UPL
         }
         else if (strcmp(OPTION_OPENSSL_ENGINE, optionName) == 0)
         {
-            if (upload_data->cred_type != IOTHUB_CREDENTIAL_TYPE_X509)
+            if (upload_data->cred_type != IOTHUB_CREDENTIAL_TYPE_X509 && upload_data->cred_type != IOTHUB_CREDENTIAL_TYPE_X509_ECC)
             {
                 LogError("trying to set an openssl engine while the authentication scheme is not x509");
                 result = IOTHUB_CLIENT_INVALID_ARG;

--- a/iothub_client/tests/iothubclient_ll_u2b_ut/iothub_client_ll_u2b_ut.c
+++ b/iothub_client/tests/iothubclient_ll_u2b_ut/iothub_client_ll_u2b_ut.c
@@ -2266,7 +2266,7 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_SetOption_x509_cert_succeeds)
     IoTHubClient_LL_UploadToBlob_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_SetOption_openssl_private_key_type_succeeds)
+TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_SetOption_x509_openssl_private_key_type_succeeds)
 {
     int privateKeyType = 1;
     //arrange
@@ -2286,11 +2286,53 @@ TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_SetOption_openssl_private_key_type_su
     IoTHubClient_LL_UploadToBlob_Destroy(h);
 }
 
-TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_SetOption_openssl_engine_type_succeeds)
+TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_SetOption_x509_ecc_openssl_private_key_type_succeeds)
+{
+    int privateKeyType = 1;
+    //arrange
+    setExpectedCallsFor_IoTHubClient_LL_UploadToBlob_Create(IOTHUB_CREDENTIAL_TYPE_X509_ECC);
+    IOTHUB_CLIENT_LL_UPLOADTOBLOB_HANDLE h = IoTHubClient_LL_UploadToBlob_Create(&TEST_CONFIG_SAS, TEST_AUTH_HANDLE);
+    umock_c_reset_all_calls();
+
+    //act
+    STRICT_EXPECTED_CALL(gballoc_malloc(sizeof(privateKeyType)));
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_LL_UploadToBlob_SetOption(h, OPTION_OPENSSL_PRIVATE_KEY_TYPE, &privateKeyType);
+
+    //assert
+    ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    //cleanup
+    IoTHubClient_LL_UploadToBlob_Destroy(h);
+}
+
+TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_SetOption_x509_openssl_engine_type_succeeds)
 {
     const char* engine = "pkcs11";
     //arrange
     setExpectedCallsFor_IoTHubClient_LL_UploadToBlob_Create(IOTHUB_CREDENTIAL_TYPE_X509);
+    IOTHUB_CLIENT_LL_UPLOADTOBLOB_HANDLE h = IoTHubClient_LL_UploadToBlob_Create(&TEST_CONFIG_SAS, TEST_AUTH_HANDLE);
+
+    umock_c_reset_all_calls();
+    STRICT_EXPECTED_CALL(mallocAndStrcpy_s(IGNORED_PTR_ARG, engine));
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));  // Within mallocAndStrcpy_s hook.
+
+    //act
+    IOTHUB_CLIENT_RESULT result = IoTHubClient_LL_UploadToBlob_SetOption(h, OPTION_OPENSSL_ENGINE, engine);
+
+    //assert
+    ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    //cleanup
+    IoTHubClient_LL_UploadToBlob_Destroy(h);
+}
+
+TEST_FUNCTION(IoTHubClient_LL_UploadToBlob_SetOption_x509_ecc_openssl_engine_type_succeeds)
+{
+    const char* engine = "pkcs11";
+    //arrange
+    setExpectedCallsFor_IoTHubClient_LL_UploadToBlob_Create(IOTHUB_CREDENTIAL_TYPE_X509_ECC);
     IOTHUB_CLIENT_LL_UPLOADTOBLOB_HANDLE h = IoTHubClient_LL_UploadToBlob_Create(&TEST_CONFIG_SAS, TEST_AUTH_HANDLE);
 
     umock_c_reset_all_calls();


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
For x509 authenticated devices, setting `OPTION_OPENSSL_ENGINE` and `OPTION_OPENSSL_PRIVATE_KEY_TYPE` with IoT device and provisioning handle does not work with file upload functionality. Rather than handing over the encrypted private key to custom openssl engine, it throws an error `failure creating private key evp_key` during file upload.

# Description of the solution
While setting openssl options, `IoTHubClient_LL_UploadToBlob_SetOption` checks for credential type `IOTHUB_CREDENTIAL_TYPE_X509_ECC` as well as `IOTHUB_CREDENTIAL_TYPE_X509` to allow these options to be used by file upload handle