### PR TITLE
fix: compare result to IOTHUB_CLIENT_CONNECTION_AUTHENTICATED

### DIFF
--- a/provisioning_client/samples/iothub_client_sample_hsm/iothub_client_sample_hsm.c
+++ b/provisioning_client/samples/iothub_client_sample_hsm/iothub_client_sample_hsm.c
@@ -42,7 +42,7 @@ static void connection_status_callback(IOTHUB_CLIENT_CONNECTION_STATUS result, I
     IOTHUB_CLIENT_SAMPLE_INFO* iothub_info = (IOTHUB_CLIENT_SAMPLE_INFO*)user_context;
     if (iothub_info != NULL)
     {
-        if (reason == IOTHUB_CLIENT_CONNECTION_OK && result == IOTHUB_CLIENT_CONFIRMATION_OK)
+        if (reason == IOTHUB_CLIENT_CONNECTION_OK && result == IOTHUB_CLIENT_CONNECTION_AUTHENTICATED)
         {
             iothub_info->connected = 1;
         }


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Description of the problem
I work on Microsoft's Visual C++ compiler. A recently implemented warning detected this instance of implicit enum conversion (comparing two values of different enum types). 

This appears to be a theoretical bug. The enumerators that are being used in the comparison have the same values (and so the comparison behavior is unchanged), but other uses of this enumeration type in the repo suggest that this coercion was unintentional. 

# Description of the solution
I modified the comparison to use the `IOTHUB_CLIENT_CONNECTION_AUTHENTICATED` enumerator, as other instances of the repo seem to do. 