### PR TITLE
Re-enable IoTHubMessage_Properties

### DIFF
--- a/iothub_client/inc/iothub_message.h
+++ b/iothub_client/inc/iothub_message.h
@@ -177,7 +177,6 @@ MOCKABLE_FUNCTION(, IOTHUB_MESSAGE_RESULT, IoTHubMessage_SetContentEncodingSyste
 MOCKABLE_FUNCTION(, const char*, IoTHubMessage_GetContentEncodingSystemProperty, IOTHUB_MESSAGE_HANDLE, iotHubMessageHandle);
 
 /**
-** DEPRECATED: Use IoTHubMessage_SetProperty and IoTHubMessage_GetProperty instead. **
 * @brief   Gets a handle to the message's properties map.
 *          Note that when sending messages via the HTTP transport, the key names in the map must not contain spaces.
 *

--- a/iothub_client/samples/iothub_ll_c2d_sample/iothub_ll_c2d_sample.c
+++ b/iothub_client/samples/iothub_ll_c2d_sample/iothub_ll_c2d_sample.c
@@ -153,13 +153,37 @@ static IOTHUBMESSAGE_DISPOSITION_RESULT receive_msg_callback(IOTHUB_MESSAGE_HAND
             (void)printf("Received String Message\r\nMessage ID: %s\r\n Correlation ID: %s\r\n Data: <<<%s>>>\r\n", messageId, correlationId, string_msg);
         }
     }
-    const char* property_value = "property_value";
-    const char* property_key = IoTHubMessage_GetProperty(message, property_value);
-    if (property_key != NULL)
+    const char* property_name = "property_name";
+    const char* property_value = IoTHubMessage_GetProperty(message, property_name);
+    if (property_value != NULL)
     {
-        printf("\r\nMessage Properties:\r\n");
-        printf("\tKey: %s Value: %s\r\n", property_value, property_key);
+        printf("\r\nMessage \"%s\" property:\r\n", property_name);
+        printf("\tKey: %s Value: %s\r\n", property_name, property_value);
     }
+
+    MAP_HANDLE non_system_properties = IoTHubMessage_Properties(message);
+
+    if (non_system_properties != NULL)
+    {
+        const char*const* keys;
+        const char*const* values;
+        size_t count;
+
+        if (Map_GetInternals(non_system_properties, &keys, &values, &count) != MAP_OK)
+        {
+            printf("\r\nFailed retrieving message non-system properties.\r\n");
+        }
+        else
+        {
+            printf("\r\nMessage properties:\r\n");
+
+            for (size_t i = 0; i < count; i++)
+            {
+                printf("\tKey: %s Value: %s\r\n", (char*)keys[i], (char*)values[i]);
+            }
+        }
+    }
+
     g_message_recv_count++;
 
 #ifdef USE_C2D_ASYNC_ACK

--- a/iothub_client/samples/iothub_ll_c2d_sample/iothub_ll_c2d_sample.c
+++ b/iothub_client/samples/iothub_ll_c2d_sample/iothub_ll_c2d_sample.c
@@ -157,8 +157,8 @@ static IOTHUBMESSAGE_DISPOSITION_RESULT receive_msg_callback(IOTHUB_MESSAGE_HAND
     const char* property_value = IoTHubMessage_GetProperty(message, property_name);
     if (property_value != NULL)
     {
-        printf("\r\nMessage \"%s\" property:\r\n", property_name);
-        printf("\tKey: %s Value: %s\r\n", property_name, property_value);
+        (void)printf("\r\nMessage \"%s\" property:\r\n", property_name);
+        (void)printf("\tKey: %s Value: %s\r\n", property_name, property_value);
     }
 
     MAP_HANDLE non_system_properties = IoTHubMessage_Properties(message);
@@ -171,15 +171,15 @@ static IOTHUBMESSAGE_DISPOSITION_RESULT receive_msg_callback(IOTHUB_MESSAGE_HAND
 
         if (Map_GetInternals(non_system_properties, &keys, &values, &count) != MAP_OK)
         {
-            printf("\r\nFailed retrieving message non-system properties.\r\n");
+            (void)printf("\r\nFailed retrieving message non-system properties.\r\n");
         }
         else
         {
-            printf("\r\nMessage properties:\r\n");
+            (void)printf("\r\nMessage properties:\r\n");
 
             for (size_t i = 0; i < count; i++)
             {
-                printf("\tKey: %s Value: %s\r\n", (char*)keys[i], (char*)values[i]);
+                (void)printf("\tKey: %s Value: %s\r\n", (char*)keys[i], (char*)values[i]);
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)
https://github.com/Azure/azure-iot-sdk-c/issues/2668

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
https://github.com/Azure/azure-iot-sdk-c/issues/2668

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Re-enable IoTHubMessage_Properties for public use.