### PR TITLE
Fix upload to blob when using DPS with x509 certificate

### DIFF
--- a/iothub_client/src/iothub_client_core_ll.c
+++ b/iothub_client/src/iothub_client_core_ll.c
@@ -398,9 +398,10 @@ static int create_blob_upload_module(IOTHUB_CLIENT_CORE_LL_HANDLE_DATA* handle_d
     }
     else
     {
+        IOTHUB_CREDENTIAL_TYPE credential_type = IoTHubClient_Auth_Get_Credential_Type(handle_data->authorization_module);
+
         if (use_dev_auth &&
-            (IoTHubClient_Auth_Get_Credential_Type(handle_data->authorization_module) == IOTHUB_CREDENTIAL_TYPE_X509 ||
-             IoTHubClient_Auth_Get_Credential_Type(handle_data->authorization_module) == IOTHUB_CREDENTIAL_TYPE_X509_ECC))
+            (credential_type == IOTHUB_CREDENTIAL_TYPE_X509 || credential_type == IOTHUB_CREDENTIAL_TYPE_X509_ECC))
         {
             char* x509_certificate;
             char* x509_private_key;

--- a/iothub_client/src/iothub_client_core_ll.c
+++ b/iothub_client/src/iothub_client_core_ll.c
@@ -42,7 +42,6 @@
 #define INDEFINITE_TIME ((time_t)(-1))
 #define ERROR_CODE_BECAUSE_DESTROY 0
 
-
 MU_DEFINE_ENUM_STRINGS_WITHOUT_INVALID(IOTHUB_CLIENT_FILE_UPLOAD_RESULT, IOTHUB_CLIENT_FILE_UPLOAD_RESULT_VALUES);
 MU_DEFINE_ENUM_STRINGS_WITHOUT_INVALID(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_RESULT_VALUES);
 MU_DEFINE_ENUM_STRINGS_WITHOUT_INVALID(IOTHUB_CLIENT_RETRY_POLICY, IOTHUB_CLIENT_RETRY_POLICY_VALUES);
@@ -385,7 +384,7 @@ static int create_edge_handle(IOTHUB_CLIENT_CORE_LL_HANDLE_DATA* handle_data, co
     return result;
 }
 
-static int create_blob_upload_module(IOTHUB_CLIENT_CORE_LL_HANDLE_DATA* handle_data, const IOTHUB_CLIENT_CONFIG* config)
+static int create_blob_upload_module(IOTHUB_CLIENT_CORE_LL_HANDLE_DATA* handle_data, const IOTHUB_CLIENT_CONFIG* config, bool use_dev_auth)
 {
     int result;
     (void)handle_data;
@@ -399,7 +398,43 @@ static int create_blob_upload_module(IOTHUB_CLIENT_CORE_LL_HANDLE_DATA* handle_d
     }
     else
     {
-        result = 0;
+        if (use_dev_auth &&
+            (IoTHubClient_Auth_Get_Credential_Type(handle_data->authorization_module) == IOTHUB_CREDENTIAL_TYPE_X509 ||
+             IoTHubClient_Auth_Get_Credential_Type(handle_data->authorization_module) == IOTHUB_CREDENTIAL_TYPE_X509_ECC))
+        {
+            char* x509_certificate;
+            char* x509_private_key;
+
+            if (IoTHubClient_Auth_Get_x509_info(handle_data->authorization_module, &x509_certificate, &x509_private_key) != 0)
+            {
+                LogError("Failed retrieving x509 client certificate and/or private key for upload to blob.");
+                result = MU_FAILURE;
+            }
+            else
+            {
+                if (IoTHubClient_LL_UploadToBlob_SetOption(handle_data->uploadToBlobHandle, OPTION_X509_CERT, x509_certificate) != IOTHUB_CLIENT_OK)
+                {
+                    LogError("Failed setting x509 client certificate for upload to blob.");
+                    result = MU_FAILURE;
+                }
+                else if (IoTHubClient_LL_UploadToBlob_SetOption(handle_data->uploadToBlobHandle, OPTION_X509_PRIVATE_KEY, x509_private_key) != IOTHUB_CLIENT_OK)
+                {
+                    LogError("Failed setting x509 client private key for upload to blob.");
+                    result = MU_FAILURE;
+                }
+                else
+                {
+                    result = 0;
+                }
+                
+                free(x509_certificate);
+                free(x509_private_key);
+            }
+        }
+        else
+        {
+            result = 0;
+        }
     }
 #else
     result = 0;
@@ -1022,7 +1057,7 @@ static IOTHUB_CLIENT_CORE_LL_HANDLE_DATA* initialize_iothub_client(const IOTHUB_
         }
         if (result != NULL)
         {
-            if (create_blob_upload_module(result, config) != 0)
+            if (create_blob_upload_module(result, config, use_dev_auth) != 0)
             {
                 LogError("unable to create blob upload");
                 if (!result->isSharedTransport)

--- a/iothub_client/src/iothub_client_core_ll.c
+++ b/iothub_client/src/iothub_client_core_ll.c
@@ -389,6 +389,7 @@ static int create_blob_upload_module(IOTHUB_CLIENT_CORE_LL_HANDLE_DATA* handle_d
     int result;
     (void)handle_data;
     (void)config;
+    (void)use_dev_auth;
 #ifndef DONT_USE_UPLOADTOBLOB
     handle_data->uploadToBlobHandle = IoTHubClient_LL_UploadToBlob_Create(config, handle_data->authorization_module);
     if (handle_data->uploadToBlobHandle == NULL)
@@ -403,8 +404,8 @@ static int create_blob_upload_module(IOTHUB_CLIENT_CORE_LL_HANDLE_DATA* handle_d
         if (use_dev_auth &&
             (credential_type == IOTHUB_CREDENTIAL_TYPE_X509 || credential_type == IOTHUB_CREDENTIAL_TYPE_X509_ECC))
         {
-            char* x509_certificate;
-            char* x509_private_key;
+            char* x509_certificate = NULL;
+            char* x509_private_key = NULL;
 
             if (IoTHubClient_Auth_Get_x509_info(handle_data->authorization_module, &x509_certificate, &x509_private_key) != 0)
             {

--- a/iothub_client/src/iothub_client_ll_uploadtoblob.c
+++ b/iothub_client/src/iothub_client_ll_uploadtoblob.c
@@ -1261,7 +1261,7 @@ IOTHUB_CLIENT_RESULT IoTHubClient_LL_UploadToBlob_SetOption(IOTHUB_CLIENT_LL_UPL
 
         if (strcmp(optionName, OPTION_X509_CERT) == 0)
         {
-            if (upload_data->cred_type != IOTHUB_CREDENTIAL_TYPE_X509)
+            if (upload_data->cred_type != IOTHUB_CREDENTIAL_TYPE_X509 && upload_data->cred_type != IOTHUB_CREDENTIAL_TYPE_X509_ECC)
             {
                 LogError("trying to set a x509 certificate while the authentication scheme is not x509");
                 result = IOTHUB_CLIENT_INVALID_ARG;
@@ -1288,7 +1288,7 @@ IOTHUB_CLIENT_RESULT IoTHubClient_LL_UploadToBlob_SetOption(IOTHUB_CLIENT_LL_UPL
         }
         else if (strcmp(optionName, OPTION_X509_PRIVATE_KEY) == 0)
         {
-            if (upload_data->cred_type != IOTHUB_CREDENTIAL_TYPE_X509)
+            if (upload_data->cred_type != IOTHUB_CREDENTIAL_TYPE_X509 && upload_data->cred_type != IOTHUB_CREDENTIAL_TYPE_X509_ECC)
             {
                 LogError("trying to set a x509 privatekey while the authentication scheme is not x509");
                 result = IOTHUB_CLIENT_INVALID_ARG;

--- a/iothub_client/tests/iothubclientcore_ll_ut/iothub_client_core_ll_ut.c
+++ b/iothub_client/tests/iothubclientcore_ll_ut/iothub_client_core_ll_ut.c
@@ -805,6 +805,8 @@ TEST_SUITE_INITIALIZE(suite_init)
 
     REGISTER_UMOCK_ALIAS_TYPE(IOTHUB_CLIENT_DEVICE_TWIN_CALLBACK, void*);
 
+    REGISTER_UMOCK_ALIAS_TYPE(IOTHUB_CREDENTIAL_TYPE, int);
+
 #ifndef DONT_USE_UPLOADTOBLOB
     REGISTER_UMOCK_ALIAS_TYPE(IOTHUB_CLIENT_LL_UPLOADTOBLOB_HANDLE, void*);
     REGISTER_UMOCK_ALIAS_TYPE(IOTHUB_CLIENT_LL_UPLOADTOBLOB_CONTEXT_HANDLE, void*);
@@ -1041,6 +1043,26 @@ static void setup_IoTHubClientCore_LL_create_mocks(bool use_device_config, bool 
 #else
         (void)is_edge_module;
 #endif /*USE_EDGE_MODULES*/
+
+#ifndef DONT_USE_UPLOADTOBLOB
+    if (use_device_config)
+    {
+        STRICT_EXPECTED_CALL(IoTHubClient_Auth_Get_Credential_Type(IGNORED_PTR_ARG))
+            .SetReturn(IOTHUB_CREDENTIAL_TYPE_X509_ECC)
+            .CallCannotFail();
+        STRICT_EXPECTED_CALL(IoTHubClient_Auth_Get_x509_info(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(IoTHubClient_LL_UploadToBlob_SetOption(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(IoTHubClient_LL_UploadToBlob_SetOption(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+    }
+    else
+    {
+        STRICT_EXPECTED_CALL(IoTHubClient_Auth_Get_Credential_Type(IGNORED_PTR_ARG))
+            .SetReturn(IOTHUB_CREDENTIAL_TYPE_DEVICE_KEY)
+            .CallCannotFail();
+    }
+#endif /*DONT_USE_UPLOADTOBLOB*/
 
     STRICT_EXPECTED_CALL(tickcounter_create());
 
@@ -1703,6 +1725,8 @@ TEST_FUNCTION(IoTHubClientCore_LL_CreateWithTransport_Succeeds)
     STRICT_EXPECTED_CALL(STRING_delete(IGNORED_PTR_ARG));
 #ifndef DONT_USE_UPLOADTOBLOB
     STRICT_EXPECTED_CALL(IoTHubClient_LL_UploadToBlob_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(IoTHubClient_Auth_Get_Credential_Type(IGNORED_PTR_ARG))
+        .SetReturn(IOTHUB_CREDENTIAL_TYPE_DEVICE_KEY);
 #endif /*DONT_USE_UPLOADTOBLOB*/
     STRICT_EXPECTED_CALL(tickcounter_create());
     PLATFORM_INFO_OPTION supportedPlatformInfo = PLATFORM_INFO_OPTION_RETRIEVE_SQM;
@@ -1877,6 +1901,8 @@ TEST_FUNCTION(IoTHubClientCore_LL_CreateWithTransport_create_tickcounter_fails_s
 
 #ifndef DONT_USE_UPLOADTOBLOB
     STRICT_EXPECTED_CALL(IoTHubClient_LL_UploadToBlob_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(IoTHubClient_Auth_Get_Credential_Type(IGNORED_PTR_ARG))
+        .SetReturn(IOTHUB_CREDENTIAL_TYPE_DEVICE_KEY);
 #endif /*DONT_USE_UPLOADTOBLOB*/
 
     STRICT_EXPECTED_CALL(tickcounter_create())
@@ -1925,6 +1951,8 @@ TEST_FUNCTION(IoTHubClientCore_LL_CreateWithTransport_register_fails_shared_tran
 
 #ifndef DONT_USE_UPLOADTOBLOB
     STRICT_EXPECTED_CALL(IoTHubClient_LL_UploadToBlob_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(IoTHubClient_Auth_Get_Credential_Type(IGNORED_PTR_ARG))
+        .SetReturn(IOTHUB_CREDENTIAL_TYPE_DEVICE_KEY);
 #endif /*DONT_USE_UPLOADTOBLOB*/
 
     STRICT_EXPECTED_CALL(tickcounter_create());
@@ -1988,6 +2016,8 @@ TEST_FUNCTION(IoTHubClientCore_LL_CreateWithTransport_set_retry_policy_fails_sha
 
 #ifndef DONT_USE_UPLOADTOBLOB
     STRICT_EXPECTED_CALL(IoTHubClient_LL_UploadToBlob_Create(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(IoTHubClient_Auth_Get_Credential_Type(IGNORED_PTR_ARG))
+        .SetReturn(IOTHUB_CREDENTIAL_TYPE_DEVICE_KEY);
 #endif /*DONT_USE_UPLOADTOBLOB*/
 
     STRICT_EXPECTED_CALL(tickcounter_create());


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
The credentials were not being propagated to the upload to blob layer when
using device provisioning with x509 certificate.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Implement passing the x509 information from the hsm framework to the upload to blob layer.