### PR TITLE
Update CODEOWNERS and ubuntu-20.04 runner pool (deprecated)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,8 @@
 ###########
 
 # Catch all for whole project
-* @ericwol-msft @ewertons @RLeclair @vaavva @zhen9910
+* @avishekpant @ewertons @RLeclair @vaavva @cartertinney
 
 # README Files
-*.md @ericwol-msft @ewertons @RLeclair @vaavva @zhkon
+*.md @avishekpant @ewertons @RLeclair @vaavva @cartertinney
 

--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -58,7 +58,7 @@ stages:
     variables:
       CodeQL.Enabled: false
     pool:
-      vmImage: 'ubuntu-20.04'
+      vmImage: 'ubuntu-24.04'
     displayName: "Check Submodules"
     steps:
     - script: |
@@ -1106,7 +1106,7 @@ stages:
       displayName: 'Build'
   - job: crosscompile_mips32
     pool:
-      vmImage: 'ubuntu-20.04'
+      vmImage: 'ubuntu-24.04'
     displayName: "Cross Compile (MIPS32)"
     steps:
     - script: |
@@ -1128,7 +1128,7 @@ stages:
       displayName: 'Build MIPS32'
   - job: crosscompile_arm
     pool:
-      vmImage: 'ubuntu-20.04'
+      vmImage: 'ubuntu-24.04'
     displayName: "Cross Compile (ARM)"
     steps:
     - script: |


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
CODEOWNERS is not up-to-date.
ubuntu-20.04 runner pool is being deprecated.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Updated CODEOWNERS.
Moved runner pools ubuntu-20.04 to 24.04