### PR TITLE
Fix mqtt transport to attempt to send DISCONNECT also when in CONNECTING state

### DIFF
--- a/iothub_client/src/iothubtransport_mqtt_common.c
+++ b/iothub_client/src/iothubtransport_mqtt_common.c
@@ -2241,7 +2241,8 @@ static void DisconnectFromClient(PMQTTTRANSPORT_HANDLE_DATA transport_data)
             setSavedTlsOptions(transport_data, options);
         }
         // Ensure the disconnect message is sent
-        if (transport_data->mqttClientStatus == MQTT_CLIENT_STATUS_CONNECTED)
+        if (transport_data->mqttClientStatus == MQTT_CLIENT_STATUS_CONNECTED ||
+            transport_data->mqttClientStatus == MQTT_CLIENT_STATUS_CONNECTING)
         {
             transport_data->disconnect_recv_flag = 0;
             (void)mqtt_client_disconnect(transport_data->mqttClient, processDisconnectCallback, &transport_data->disconnect_recv_flag);

--- a/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
+++ b/iothub_client/tests/iothubtransport_mqtt_common_ut/iothubtransport_mqtt_common_ut.c
@@ -5613,6 +5613,11 @@ TEST_FUNCTION(IoTHubTransport_MQTT_Common_DoWork_mqtt_client_connecting_times_ou
 
     STRICT_EXPECTED_CALL(tickcounter_get_current_ms(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(xio_retrieveoptions(IGNORED_PTR_ARG));
+
+    STRICT_EXPECTED_CALL(mqtt_client_disconnect(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(mqtt_client_dowork(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(ThreadAPI_Sleep(IGNORED_NUM_ARG));
+
     STRICT_EXPECTED_CALL(mqtt_client_clear_xio(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(xio_destroy(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(tickcounter_get_current_ms(IGNORED_PTR_ARG, IGNORED_PTR_ARG));


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

- mqttClientStatus is set to MQTT_CLIENT_STATUS_CONNECTING when the CONNECT packet is sent
- In file iothubtransport_mqtt_common.c, method UpdateMqttConnectionStateIfNeeded, when mqttClientStatus is MQTT_CLIENT_STATUS_CONNECTING, the time since the CONNECT packet was sent is compared to the 30 second timeout value, and in normal operation sometimes this times out (CONNACK timeout); when the timeout occurs, DisconnectFromClient is called with mqttClientStatus remaining set to MQTT_CLIENT_STATUS_CONNECTING.
- In file iothubtransport_mqtt_common.c, method DisconnectFromClient, when mqttClientStatus is MQTT_CLIENT_STATUS_CONNECTED, the correct disconnect code is executed to set up properly for the next CONNECT packet; however, when mqttClientStatus is MQTT_CLIENT_STATUS_CONNECTING this disconnect code is not executed and improper behavior occurs in the code from then on – another CONNECT packet is not sent.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 

Change `DisconnectFromClient` to send DISCONNECT also when transport is in CONNECTING state.