### PR TITLE
Configure .vsts-ci.yml pipeline to run Cleanup stage even if cancelled

### DIFF
--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -1170,8 +1170,10 @@ stages:
     - task: CodeQL3000Finalize@0
       condition: always()
 - stage: Cleanup 
+  condition: always() # Run stage even if the pipeline run is cancelled.
   jobs:
   - job: cleanup
+    condition: always() # Run job even if the pipeline run is cancelled.
     container: linux-c-ubuntu-2204
     pool:
       name: 'sdk-c--ubuntu-22'
@@ -1184,5 +1186,5 @@ stages:
       env:
         STORAGE_ACCOUNT_NAME: $(STORAGE-ACCOUNT-NAME)
         STORAGE_ACCOUNT_RESOURCE_GROUP: $(STORAGE-ACCOUNT-RESOURCE-GROUP)
-      condition: always() # Run even if the pipeline run is cancelled.
+      condition: always() # Run step even if the pipeline run is cancelled.
   


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
The previous declaration of the yaml file was defining the 'always()' condition only for the cleanup step. Since the stage itself was not configured as such as well, it would be skipped (including the cleanup step!) if a failure occured in any of the previous stages failed/were cancelled.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Configure the Cleanup stage, job and step to always run no matter the result of the previous stages.