### PR TITLE
Extend the expiration of LTS release LTS_03_2025

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -276,8 +276,7 @@ Below is a table showing the mapping of the LTS branches to the packages release
 
   | Package | GitHub Branch | LTS Tag | LTS Start Date | Maintenance End Date |
   | :-----: | :-----------: | :-----: | :------------: | :------------------: |
-  | vcpkg: 2025-03-31 | lts_03_2025 | LTS_03_2025 | 2025-03-31 | 2026-03-31 |
-  | vcpkg: 2024-08-12 | lts_08_2024 | LTS_08_2024 | 2024-08-12 | 2025-08-12 |
+  | vcpkg: 2025-03-31 | lts_03_2025 | LTS_03_2025 | 2025-03-31 | 2026-10-07 |
 
 'Maintenance End Date' refers to the end of life support of the related version.
 


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [x] This pull-request is submitted against the `main` branch. 
  - [x] I have merged the latest `main` branch prior to submission and re-merged as needed after I took any feedback.
  - [x] I have squashed my changes into one with a clear description of the change.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
The azure-iot-sdk-c has not had any recent changes to justify a new LTS release, and the latest one is about to expire.

# Description of the solution
Extend the latest LTS release expiration.