### PR TITLE
Add ADR and symmetric key env vars to C SDK test config

### DIFF
--- a/testtools/scripts/Azure.Iot.Sdk.Test.psm1
+++ b/testtools/scripts/Azure.Iot.Sdk.Test.psm1
@@ -1858,6 +1858,21 @@ function New-AzIotCSDKE2ETestConfig {
     $DpsPrivateKeyBase64 = $(ConvertTo-Base64 -Content $TestEnvInfo.Dps.Enrollments.IndividualX509[0].Certificate.PrivateKey.ToPem())
     $DpsRegistrationId = $($TestEnvInfo.Dps.Enrollments.IndividualX509[0].Id)
 
+    # Root CA certificate for CSR/ADR tests (create one if not already present)
+    if ($TestEnvInfo.Dps.RootCaCertificates.Count -eq 0) {
+        $TestEnvInfo.Dps.AddRootCaCertificate() | Out-Null
+    }
+    $DpsRootCACertificateBase64 = ConvertTo-Base64 -Content $($TestEnvInfo.Dps.RootCaCertificates[0].ToPem())
+    $DpsRootCAPrivateKeyBase64 = ConvertTo-Base64 -Content $($TestEnvInfo.Dps.RootCaCertificates[0].PrivateKey.ToPem())
+
+    # Symmetric key group enrollment (optional)
+    $SymmKeyGroupEnrollmentId = $null
+    $SymmKeyGroupPrimaryKey = $null
+    if ($TestEnvInfo.Dps.Enrollments.GroupSymmetricKey.Count -gt 0) {
+        $SymmKeyGroupEnrollmentId = $TestEnvInfo.Dps.Enrollments.GroupSymmetricKey[0].Id
+        $SymmKeyGroupPrimaryKey = $TestEnvInfo.Dps.Enrollments.GroupSymmetricKey[0].PrimaryKey
+    }
+
     if ($Target -eq "powershell") {
         $Lines = @(
             "`$env:IOTHUB_CONNECTION_STRING = `"$($TestEnvInfo.IotHub.ConnectionString)`""
@@ -1877,6 +1892,11 @@ function New-AzIotCSDKE2ETestConfig {
             "`$env:IOT_DPS_INDIVIDUAL_X509_CERTIFICATE = `"$DpsCertificateBase64`""
             "`$env:IOT_DPS_INDIVIDUAL_X509_KEY = `"$DpsPrivateKeyBase64`""
             "`$env:IOT_DPS_INDIVIDUAL_REGISTRATION_ID = `"$DpsRegistrationId`""
+            "`$env:PROVISIONING_ROOT_CERT = `"$DpsRootCACertificateBase64`""
+            "`$env:PROVISIONING_ROOT_CERT_KEY = `"$DpsRootCAPrivateKeyBase64`""
+            "`$env:ADR_CERT_MGMT_POLICY_NAME = `"$($TestEnvInfo.AzureAdrPolicyName)`""
+            $(if ($SymmKeyGroupEnrollmentId) { "`$env:IOT_DPS_SYMM_KEY_GROUP_ENROLLMENT_ID = `"$SymmKeyGroupEnrollmentId`"" })
+            $(if ($SymmKeyGroupPrimaryKey) { "`$env:IOT_DPS_SYMM_KEY_GROUP_PRIMARY_KEY = `"$SymmKeyGroupPrimaryKey`"" })
             "`$env:AZURE_RESOURCE_GROUP = `"$($TestEnvInfo.AzureResourceGroup)`""
         )
     } else { # bash
@@ -1899,6 +1919,11 @@ function New-AzIotCSDKE2ETestConfig {
             "export IOT_DPS_INDIVIDUAL_X509_CERTIFICATE=`"$DpsCertificateBase64`""
             "export IOT_DPS_INDIVIDUAL_X509_KEY=`"$DpsPrivateKeyBase64`""
             "export IOT_DPS_INDIVIDUAL_REGISTRATION_ID=`"$DpsRegistrationId`""
+            "export PROVISIONING_ROOT_CERT=`"$DpsRootCACertificateBase64`""
+            "export PROVISIONING_ROOT_CERT_KEY=`"$DpsRootCAPrivateKeyBase64`""
+            "export ADR_CERT_MGMT_POLICY_NAME=`"$($TestEnvInfo.AzureAdrPolicyName)`""
+            $(if ($SymmKeyGroupEnrollmentId) { "export IOT_DPS_SYMM_KEY_GROUP_ENROLLMENT_ID=`"$SymmKeyGroupEnrollmentId`"" })
+            $(if ($SymmKeyGroupPrimaryKey) { "export IOT_DPS_SYMM_KEY_GROUP_PRIMARY_KEY=`"$SymmKeyGroupPrimaryKey`"" })
             "export AZURE_RESOURCE_GROUP=`"$($TestEnvInfo.AzureResourceGroup)`""
         )
     }

--- a/testtools/scripts/Azure.Iot.Sdk.Test.psm1
+++ b/testtools/scripts/Azure.Iot.Sdk.Test.psm1
@@ -1384,7 +1384,7 @@ function New-AzIotTestEnvironment {
         $AzureAdrNamespaceName = "azure-adr-ns"
         $AzureAdrPolicyName = "azure-adr-policy"
         Write-Host "Creating ADR Namespace (ns=$AzureAdrNamespaceName; policy=$AzureAdrPolicyName)"
-        $AzureAdrNamespace = az iot adr ns create --name "$AzureAdrNamespaceName" --enable-credential-policy --resource-group "$ResourceGroup" --location "$AzureLocation" --policy-name "$AzureAdrPolicyName" 2>$null | ConvertFrom-Json
+        $AzureAdrNamespace = az iot adr ns create --name "$AzureAdrNamespaceName" --enable-certificate-management --resource-group "$ResourceGroup" --location "$AzureLocation" --policy-name "$AzureAdrPolicyName" 2>$null | ConvertFrom-Json
         Stop-OnError -Step "Create ADR Namespace"    
 
         Write-Host "Assigning ADR custom role to UAMI (a5c3590a-3a1a-4cd4-9648-ea0a32b15137)"


### PR DESCRIPTION
## Summary
- Add root CA certificate (`PROVISIONING_ROOT_CERT`, `PROVISIONING_ROOT_CERT_KEY`) env vars to `New-AzIotCSDKE2ETestConfig`
- Add ADR cert management policy name (`ADR_CERT_MGMT_POLICY_NAME`) env var
- Add symmetric key group enrollment env vars (`IOT_DPS_SYMM_KEY_GROUP_ENROLLMENT_ID`, `IOT_DPS_SYMM_KEY_GROUP_PRIMARY_KEY`) — conditional, only emitted when group enrollment exists
