### PR TITLE
Point Horton e2e at iot-sdks-e2e-fx master

### DIFF
--- a/build/.horton-e2e.yml
+++ b/build/.horton-e2e.yml
@@ -14,7 +14,29 @@ resources:
     ref: refs/heads/ewertons/horton-fixes
     endpoint: 'azure-iot-sdk-python-github'
 
-jobs:
-- template: vsts/templates/jobs-gate-c.yaml@e2e_fx
+stages:
+- stage: setup
+  jobs:
+  - job: create_azure_resources
+    pool:
+      vmImage: 'windows-latest'
+    steps:
+    - template: vsts/templates/steps-create-azure-resources.yaml@e2e_fx
 
-  
+- stage: build_and_test
+  dependsOn: setup
+  jobs:
+  - template: vsts/templates/jobs-gate-c.yaml@e2e_fx
+
+- stage: cleanup
+  dependsOn:
+  - setup
+  - build_and_test
+  condition: always()
+  jobs:
+  - job: destroy_azure_resource_group
+    condition: always()
+    pool:
+      vmImage: 'ubuntu-24.04'
+    steps:
+    - template: vsts/templates/steps-destroy-azure-resources.yaml@e2e_fx

--- a/build/.horton-e2e.yml
+++ b/build/.horton-e2e.yml
@@ -1,6 +1,6 @@
 variables:
   Horton.FrameworkRoot: $(Agent.BuildDirectory)/e2e-fx
-  Horton.FrameworkRef: ewertons/horton-fixes
+  Horton.FrameworkRef: master
   Horton.Language: c
   Horton.Repo: $(Build.Repository.Uri)
   Horton.Commit: $(Build.SourceBranch)
@@ -11,7 +11,7 @@ resources:
   - repository: e2e_fx
     type: github
     name: Azure/iot-sdks-e2e-fx
-    ref: refs/heads/ewertons/horton-fixes
+    ref: refs/heads/master
     endpoint: 'azure-iot-sdk-python-github'
 
 stages:

--- a/build/.horton-e2e.yml
+++ b/build/.horton-e2e.yml
@@ -1,6 +1,6 @@
 variables:
   Horton.FrameworkRoot: $(Agent.BuildDirectory)/e2e-fx
-  Horton.FrameworkRef: master
+  Horton.FrameworkRef: ewertons/horton-fixes
   Horton.Language: c
   Horton.Repo: $(Build.Repository.Uri)
   Horton.Commit: $(Build.SourceBranch)

--- a/build/.horton-e2e.yml
+++ b/build/.horton-e2e.yml
@@ -11,7 +11,7 @@ resources:
   - repository: e2e_fx
     type: github
     name: Azure/iot-sdks-e2e-fx
-    ref: refs/heads/master
+    ref: refs/heads/ewertons/horton-fixes
     endpoint: 'azure-iot-sdk-python-github'
 
 jobs:

--- a/build/.horton-e2e.yml
+++ b/build/.horton-e2e.yml
@@ -12,7 +12,7 @@ resources:
     type: github
     name: Azure/iot-sdks-e2e-fx
     ref: refs/heads/master
-    endpoint: 'GitHub OAuth - az-iot-builder-01'
+    endpoint: 'azure-iot-sdk-python-github'
 
 jobs:
 - template: vsts/templates/jobs-gate-c.yaml@e2e_fx


### PR DESCRIPTION
Switches Horton.FrameworkRef and the e2e_fx repository ref in build/.horton-e2e.yml from `ewertons/horton-fixes` to `master` so the gate consumes the merged Horton fixes from the framework's mainline.