### PR TITLE
Bump uploadtoblob destroy-deadline to accommodate helgrind on hosted agents (#2704)

### DIFF
--- a/iothub_client/tests/iothubclient_uploadtoblob_e2e/iothubclient_uploadtoblob_e2e.c
+++ b/iothub_client/tests/iothubclient_uploadtoblob_e2e/iothubclient_uploadtoblob_e2e.c
@@ -72,10 +72,15 @@ UPLOADTOBLOB_CALLBACK_STATUS g_uploadToBlobStatus;
 #define TEST_SLEEP_BEFORE_EARLY_HANDLE_CLOSE 1000
 #define TEST_SLEEP_SLOW_WORKER_THREAD 5000
 
-// In normal operation we should only need a few seconds for the workers to complete.
-// On Valgrind test runs, however, there's a significant performance degradation because
-// of all the simultaneous threads the test creates.  Allow ample time (but not forever).
-#define TEST_MAXIMUM_TIME_FOR_DESTROY_ON_BLOCKED_THREADS_TO_COMPLETE_SECONDS 30
+// In normal operation we should only need a few seconds for the workers to complete
+// (TEST_SLEEP_SLOW_WORKER_THREAD ~= 5s). On instrumented test runs (valgrind/helgrind/drd)
+// the SDK's lock-protected shutdown path -- IoTHubClient_Destroy() joining its worker
+// threads -- is slowed substantially by the tool's pthread instrumentation, especially on
+// Microsoft-hosted 4-vCPU agents. The previous 30s ceiling was tight even for non-helgrind
+// runs and routinely fired under helgrind (see Azure/azure-iot-sdk-c#2704). Keep the
+// ceiling generous (still well under the per-test ctest timeout, which catches genuine
+// hangs) so the assertion only fires for true multi-orders-of-magnitude regressions.
+#define TEST_MAXIMUM_TIME_FOR_DESTROY_ON_BLOCKED_THREADS_TO_COMPLETE_SECONDS 240
 
 #define INDEFINITE_TIME ((time_t)(-1))
 


### PR DESCRIPTION
Fixes #2704.

## What
Bumps `TEST_MAXIMUM_TIME_FOR_DESTROY_ON_BLOCKED_THREADS_TO_COMPLETE_SECONDS` in `iothubclient_uploadtoblob_e2e.c` from **30s** to **240s**.

## Why
The Helgrind variant of this E2E test asserts that `IoTHubClient_Destroy` completes within the ceiling. Helgrind serializes thread scheduling and adds substantial overhead to every mutex op, so a path that takes ~5s natively can take dozens of seconds under Helgrind on the 4-vCPU Microsoft-hosted Linux agents. The 30s ceiling was tight enough that minor scheduling variance pushed the join past it.

In the failing CI run from build 158424 the observed Destroy time was **29.8s** (`23:46:58.6` "Invoking call" → `23:47:28.4` Assert failed at line 474), barely overshooting 30s.

## Magnitude
240s gives **~8x** headroom over the observed 29.8s worst case and **~48x** over the expected ~5s native path. Genuine destroy-hangs are still caught: the surrounding `ctest --timeout 1500` will fail the test long before the assertion would, and a true deadlock would never reach the destroy assert at all.

## Validation
Validated locally on a 4-vCPU Ubuntu 22.04 host (matching MS-hosted agent geometry) using a freshly provisioned IoT Hub created via the same `Azure.Iot.Sdk.Test.psm1` flow the pipeline uses:

- Stock `main` + 240s patch: Helgrind run completed in **284.87s**, all 5 sub-tests reported `result = Succeeded`, **`ERROR SUMMARY: 0 errors from 0 contexts`**, ctest verdict **Passed**.
- The destroy-deadline assertion no longer trips.

## Notes
- Single-file change (`+9 -4`), comment updated to explain the Helgrind context and reference issue #2704.
- Once #2701 merges, the redundant `-E iothubclient_uploadtoblob_e2e_helgrind` quarantine in `build_all/linux/run_tests.sh` can be removed in a tiny follow-up.