### PR TITLE
CODEOWNERS: assign to @Azure/iot-c-sdk-team team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,3 @@
-###########
-# Azure IoT SDK C
-###########
-
-# Catch all for whole project
-* @avishekpant @ewertons @RLeclair @vaavva @cartertinney
-
-# README Files
-*.md @avishekpant @ewertons @RLeclair @vaavva @cartertinney
+# Auto-assign C SDK team for all PRs
+* @Azure/iot-c-sdk-team
 


### PR DESCRIPTION
Replaces the per-individual reviewer list with the `@Azure/iot-c-sdk-team` team, matching the convention used by sibling repos in the C SDK family (`azure-uamqp-c`, `azure-umqtt-c`, `azure-uhttp-c`, `azure-utpm-c`).

Auto-assigning to the team avoids stalls when individual reviewers are unavailable and keeps ownership in one place.