### PR TITLE
run_tests.sh: drop iothubclient_uploadtoblob_e2e_helgrind quarantine

### DIFF
--- a/build_all/linux/run_tests.sh
+++ b/build_all/linux/run_tests.sh
@@ -72,10 +72,7 @@ if $run_helgrind; then
     if $run_e2e; then
         # E2E tests under helgrind. Quarantined:
         #   iothubclient_mqtt_dt_e2e: see GitHub issue (twin PATCH delivery flake).
-        #   iothubclient_uploadtoblob_e2e: helgrind instrumentation makes
-        #     IoTHubClient_Destroy() exceed the test's 30s deadline on the
-        #     Microsoft-hosted 4-vCPU agents (similar to E2E_CORES tuning).
-        ctest -T test --no-compress-output -C "Debug" -V -j $VALGRIND_E2E_CORES --schedule-random -R "e2e_helgrind$" -E "^(iothubclient_mqtt_dt_e2e|iothubclient_uploadtoblob_e2e)_helgrind$"
+        ctest -T test --no-compress-output -C "Debug" -V -j $VALGRIND_E2E_CORES --schedule-random -R "e2e_helgrind$" -E "^iothubclient_mqtt_dt_e2e_helgrind$"
     fi
 fi
 


### PR DESCRIPTION
Follow-up to #2705.

PR #2705 raised `TEST_MAXIMUM_TIME_FOR_DESTROY_ON_BLOCKED_THREADS_TO_COMPLETE_SECONDS` from 30s to 240s, which is enough headroom for the helgrind-instrumented `IoTHubClient_Destroy()` on the Microsoft-hosted 4-vCPU agents. The temporary `-E iothubclient_uploadtoblob_e2e_helgrind` quarantine added in #2701 is no longer needed and is removed here, restoring helgrind coverage for the upload-to-blob client.

The `iothubclient_mqtt_dt_e2e` quarantine (tracking #2702 - twin PATCH delivery flake) stays in place.