### PR TITLE
iothub_client: zero-init MESSENGER_SEND_EVENT_CALLER_INFORMATION on alloc

### DIFF
--- a/iothub_client/src/iothubtransport_amqp_telemetry_messenger.c
+++ b/iothub_client/src/iothubtransport_amqp_telemetry_messenger.c
@@ -1547,10 +1547,10 @@ int telemetry_messenger_send_async(TELEMETRY_MESSENGER_HANDLE messenger_handle, 
     }
     else
     {
-        MESSENGER_SEND_EVENT_CALLER_INFORMATION *caller_info;
         TELEMETRY_MESSENGER_INSTANCE *instance = (TELEMETRY_MESSENGER_INSTANCE*)messenger_handle;
+        MESSENGER_SEND_EVENT_CALLER_INFORMATION *caller_info = calloc(1, sizeof(MESSENGER_SEND_EVENT_CALLER_INFORMATION));
 
-        if ((caller_info = (MESSENGER_SEND_EVENT_CALLER_INFORMATION*)malloc(sizeof(MESSENGER_SEND_EVENT_CALLER_INFORMATION))) == NULL)
+        if (caller_info == NULL)
         {
             LogError("Failed sending event (failed to create struct for task; malloc failed)");
             result = MU_FAILURE;

--- a/iothub_client/tests/iothubtr_amqp_tel_msgr_ut/iothubtr_amqp_tel_msgr_ut.c
+++ b/iothub_client/tests/iothubtr_amqp_tel_msgr_ut/iothubtr_amqp_tel_msgr_ut.c
@@ -925,7 +925,7 @@ static void set_expected_calls_for_message_receiver_destroy()
 
 static void set_expected_calls_for_telemetry_messenger_send_async()
 {
-    EXPECTED_CALL(malloc(IGNORED_NUM_ARG));
+    EXPECTED_CALL(calloc(IGNORED_NUM_ARG, IGNORED_NUM_ARG));
     EXPECTED_CALL(singlylinkedlist_add(TEST_IN_PROGRESS_LIST, IGNORED_PTR_ARG));
 }
 


### PR DESCRIPTION
`telemetry_messenger_send_async()` allocated `MESSENGER_SEND_EVENT_CALLER_INFORMATION` with `malloc()` and relied on each field being assigned before use. Switch to `calloc()` so any future field added to the struct is zero-initialized by default and a partial-init failure path can't leak uninitialized pointers.

Update the matching unit-test expected-call to `calloc()`.