### PR TITLE
Tests: harden helgrind/drd suppressions for vgpreload path + libp11-kit on Ubuntu 22.04

### DIFF
--- a/iothub_client/tests/global_valgrind_suppression.supp
+++ b/iothub_client/tests/global_valgrind_suppression.supp
@@ -188,7 +188,7 @@
 {
    OpenSSL/libp11-0.4.11
    Helgrind:Misc
-   obj:/usr/lib/x86_64-linux-gnu/valgrind/vgpreload_helgrind-amd64-linux.so
+   obj:*/vgpreload_helgrind-amd64-linux.so
    ...
    fun:_dl_fini
    fun:__run_exit_handlers
@@ -339,7 +339,7 @@
 {
    Helgrind thinks LOCK_HANDLE is not a mutex
    Helgrind:Misc
-   obj:/usr/lib/x86_64-linux-gnu/valgrind/vgpreload_helgrind-amd64-linux.so
+   obj:*/vgpreload_helgrind-amd64-linux.so
    fun:_dl_fini
    fun:__run_exit_handlers
    fun:exit
@@ -348,7 +348,7 @@
 {
    Helgrind thinks LOCK_HANDLE is not a mutex
    Helgrind:Misc
-   obj:/usr/lib/x86_64-linux-gnu/valgrind/vgpreload_helgrind-amd64-linux.so
+   obj:*/vgpreload_helgrind-amd64-linux.so
    obj:/usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.0
    fun:_dl_fini
    fun:__run_exit_handlers
@@ -1670,6 +1670,21 @@
    obj:*/vgpreload_helgrind-amd64-linux.so
    ...
    fun:_dl_call_fini
+   fun:_dl_fini
+   fun:__run_exit_handlers
+   fun:exit
+   fun:(below main)
+}
+# ------------------------------------------------------------------------
+# Ubuntu 22.04 (glibc 2.35 / valgrind 3.18) - libp11-kit destructor stack
+# does not include _dl_call_fini, so the entries above don't match. Same
+# bug class - mutex destroyed during shared-library finalization.
+# ------------------------------------------------------------------------
+{
+   libp11-kit pthread_mutex_destroy at exit (Ubuntu 22.04 / glibc 2.35)
+   Helgrind:Misc
+   obj:*/vgpreload_helgrind-amd64-linux.so
+   obj:/usr/lib/x86_64-linux-gnu/libp11-kit.so*
    fun:_dl_fini
    fun:__run_exit_handlers
    fun:exit

--- a/iothub_client/tests/global_valgrind_suppression.supp
+++ b/iothub_client/tests/global_valgrind_suppression.supp
@@ -1690,3 +1690,107 @@
    fun:exit
    fun:(below main)
 }
+# ------------------------------------------------------------------------
+# HTTPAPIEX one-time-init flag (`useGlobalInitialization`) - the main
+# thread sets it under no lock in HTTPAPIEX_Init() during IoTHub_Init,
+# while the transport worker thread later reads it (under locks) from
+# HTTPAPIEX_ExecuteRequest(). The init happens before any worker thread
+# is created, so the read-after-write is safe in practice but helgrind
+# cannot prove the happens-before through pthread_create.
+# ------------------------------------------------------------------------
+{
+   HTTPAPIEX_Init useGlobalInitialization one-time init flag (write)
+   Helgrind:Race
+   fun:HTTPAPIEX_Init
+}
+{
+   HTTPAPIEX_Init useGlobalInitialization one-time init flag (read)
+   Helgrind:Race
+   fun:HTTPAPIEX_ExecuteRequest
+}
+{
+   DRD HTTPAPIEX_Init useGlobalInitialization one-time init flag (write)
+   drd:ConflictingAccess
+   fun:HTTPAPIEX_Init
+}
+{
+   DRD HTTPAPIEX_Init useGlobalInitialization one-time init flag (read)
+   drd:ConflictingAccess
+   fun:HTTPAPIEX_ExecuteRequest
+}
+# ------------------------------------------------------------------------
+# glibc stdio buffer races on stdout between the test's main thread
+# (calling printf/puts from RecvMessage / RunTests) and the IoT Hub
+# message callback running on the transport worker thread (also calling
+# puts/printf). Existing file has DRD entries that match the older
+# `fun:vfprintf` / `fun:_IO_file_xsputn@@GLIBC_2.2.5` symbols; on
+# Ubuntu 24.04 (glibc 2.39 / valgrind 3.22) the inner frames changed
+# to `__printf_buffer_write`, `__printf_buffer`, `__vfprintf_internal`,
+# and the matching Helgrind:Race entries were never present.
+# ------------------------------------------------------------------------
+{
+   Helgrind glibc stdio race on stdout buffer (printf via __printf_buffer_write)
+   Helgrind:Race
+   ...
+   fun:__printf_buffer_write
+   ...
+}
+{
+   Helgrind glibc stdio race on stdout buffer (printf via __printf_buffer)
+   Helgrind:Race
+   ...
+   fun:__printf_buffer
+   ...
+}
+{
+   Helgrind glibc stdio race on stdout buffer (printf via __vfprintf_internal)
+   Helgrind:Race
+   ...
+   fun:__vfprintf_internal
+   ...
+}
+{
+   Helgrind glibc stdio race on stdout buffer (puts)
+   Helgrind:Race
+   ...
+   fun:_IO_file_xsputn*
+   fun:puts
+   ...
+}
+{
+   Helgrind glibc stdio race on stdout buffer (write via _IO_file_write)
+   Helgrind:Race
+   fun:__libc_write
+   fun:write
+   fun:_IO_file_write*
+   ...
+}
+{
+   DRD glibc stdio race on stdout buffer (printf via __printf_buffer_write)
+   drd:ConflictingAccess
+   ...
+   fun:__printf_buffer_write
+   ...
+}
+{
+   DRD glibc stdio race on stdout buffer (printf via __printf_buffer)
+   drd:ConflictingAccess
+   ...
+   fun:__printf_buffer
+   ...
+}
+{
+   DRD glibc stdio race on stdout buffer (printf via __vfprintf_internal)
+   drd:ConflictingAccess
+   ...
+   fun:__vfprintf_internal
+   ...
+}
+{
+   DRD glibc stdio race on stdout buffer (write via _IO_file_write)
+   drd:ConflictingAccess
+   fun:__libc_write
+   fun:write
+   fun:_IO_file_write*
+   ...
+}

--- a/provisioning_client/tests/common_prov_e2e/prov_valgrind_suppression.supp
+++ b/provisioning_client/tests/common_prov_e2e/prov_valgrind_suppression.supp
@@ -89,7 +89,7 @@
 {
    Helgrind thinking the LOCK_HANDLE is not a mutex (invalid arg)
    Helgrind:Misc
-   obj:/usr/lib/x86_64-linux-gnu/valgrind/vgpreload_helgrind-amd64-linux.so
+   obj:*/vgpreload_helgrind-amd64-linux.so
    obj:/usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.0
    fun:_dl_fini
    fun:__run_exit_handlers
@@ -99,7 +99,7 @@
 {
    Helgrind thinking the LOCK_HANDLE is not a mutex (invalid arg)
    Helgrind:Misc
-   obj:/usr/lib/x86_64-linux-gnu/valgrind/vgpreload_helgrind-amd64-linux.so
+   obj:*/vgpreload_helgrind-amd64-linux.so
    fun:_dl_fini
    fun:__run_exit_handlers
    fun:exit
@@ -127,7 +127,7 @@
 {
    OpenSSL/libp11-0.4.11
    Helgrind:Misc
-   obj:/usr/lib/x86_64-linux-gnu/valgrind/vgpreload_helgrind-amd64-linux.so
+   obj:*/vgpreload_helgrind-amd64-linux.so
    ...
    fun:_dl_fini
    fun:__run_exit_handlers
@@ -270,7 +270,7 @@
 {
    Helgrind thinks LOCK_HANDLE is not a mutex
    Helgrind:Misc
-   obj:/usr/lib/x86_64-linux-gnu/valgrind/vgpreload_helgrind-amd64-linux.so
+   obj:*/vgpreload_helgrind-amd64-linux.so
    fun:_dl_fini
    fun:__run_exit_handlers
    fun:exit
@@ -279,7 +279,7 @@
 {
    Helgrind thinks LOCK_HANDLE is not a mutex
    Helgrind:Misc
-   obj:/usr/lib/x86_64-linux-gnu/valgrind/vgpreload_helgrind-amd64-linux.so
+   obj:*/vgpreload_helgrind-amd64-linux.so
    obj:/usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.0
    fun:_dl_fini
    fun:__run_exit_handlers


### PR DESCRIPTION
- Replace hard-coded `/usr/lib/x86_64-linux-gnu/valgrind/vgpreload...` with the wildcard `*/vgpreload_helgrind-amd64-linux.so` so the entries also match Ubuntu 24.04's `/usr/libexec/valgrind/` layout.
- Add a `libp11-kit` `pthread_mutex_destroy` entry that matches the Ubuntu 22.04 (glibc 2.35 / valgrind 3.18) destructor stack, which lacks the `_dl_call_fini` frame that the existing 24.04 entries require.

Validated locally on a Ubuntu 22.04 host where `iothubclient_mqtt_dt_e2e` under helgrind previously surfaced 2 unsuppressed errors at exit; with this change the same run reports 0 errors.