### PR TITLE
CI: speed up C-canary with self-sufficient hosted-agent optimizations

### DIFF
--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -334,11 +334,17 @@ stages:
         ut_e2e:
           RUN_TESTS_ARGS: '--e2e'
           NEEDS_E2E_CONFIG: 'true'
-        valgrind:
-          RUN_TESTS_ARGS: '--valgrind --e2e'
+        valgrind_ut:
+          RUN_TESTS_ARGS: '--valgrind --ut-only'
           NEEDS_E2E_CONFIG: 'true'
-        helgrind:
-          RUN_TESTS_ARGS: '--helgrind --e2e'
+        valgrind_e2e:
+          RUN_TESTS_ARGS: '--valgrind --e2e --e2e-only'
+          NEEDS_E2E_CONFIG: 'true'
+        helgrind_ut:
+          RUN_TESTS_ARGS: '--helgrind --ut-only'
+          NEEDS_E2E_CONFIG: 'true'
+        helgrind_e2e:
+          RUN_TESTS_ARGS: '--helgrind --e2e --e2e-only'
           NEEDS_E2E_CONFIG: 'true'
         drd:
           RUN_TESTS_ARGS: '--drd --e2e'

--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -5,6 +5,8 @@ resources:
 
 variables:
   AZURE_LOCATION: centraluseuap
+  CCACHE_DIR: /tmp/ccache_cache
+  CCACHE_UMASK: '000'
 
 stages:
 - stage: Requirements
@@ -29,13 +31,18 @@ stages:
         sudo curl -sL https://deb.nodesource.com/setup_16.x | bash -
         sudo apt-get install -y nodejs
       displayName: 'Setup'
+    - task: Cache@2
+      inputs:
+        key: 'npm | check_submodules | "v1"'
+        path: $(System.DefaultWorkingDirectory)/node_modules
+      displayName: 'Cache node_modules'
     - script: |
         npm install check_submodules
         node_modules/.bin/check_submodules . main
       displayName: 'Check Submodules Match'
 
 - stage: Setup
-  dependsOn: Requirements
+  dependsOn: [] # Run in parallel with Requirements to save ~3-5 min
   jobs:
   - job: create_azure_resources
     pool:
@@ -76,6 +83,9 @@ stages:
       displayName: Publish artifact (test config scripts)
       condition: always()
 - stage: Tests
+  dependsOn:
+  - Requirements
+  - Setup
   jobs:
   - job: windowsx64debug
     timeoutInMinutes: 190
@@ -85,6 +95,7 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - download: current
       artifact: test_config_scripts
       displayName: Download artifact (test config scripts)
@@ -112,6 +123,7 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - download: current
       artifact: test_config_scripts
       displayName: Download artifact (test config scripts)
@@ -142,6 +154,7 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - download: current
       artifact: test_config_scripts
       displayName: Download artifact (test config scripts)
@@ -172,6 +185,7 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - download: current
       artifact: test_config_scripts
       displayName: Download artifact (test config scripts)
@@ -186,9 +200,10 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - script: |
         set -e
-        sudo apt-get update && sudo apt-get upgrade
+        sudo apt-get update -qq
         sudo ./build_all/linux/setup.sh
       displayName: 'Host setup'
       condition: always()
@@ -203,6 +218,7 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - script: |
         source ./testtools/scripts/linux-setup-raspberry.sh
       displayName: 'Host setup'
@@ -232,6 +248,7 @@ stages:
     steps:
     - checkout: self
       submodules: false
+      fetchDepth: 1
     - script: |
         # Microsoft-hosted ubuntu-24.04 ships with docker + containerd preinstalled.
         # Installing docker.io from apt would conflict with containerd.io and fail
@@ -255,6 +272,7 @@ stages:
     steps:
     - checkout: self
       submodules: false
+      fetchDepth: 1
     - script: |
         # Microsoft-hosted ubuntu-24.04 ships with docker + containerd preinstalled.
         # Installing docker.io from apt would conflict with containerd.io and fail
@@ -278,11 +296,22 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - script: |
         set -e
-        sudo apt-get update && sudo apt-get upgrade
+        sudo apt-get update -qq
         sudo ./build_all/linux/setup.sh
       displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
     - script: |
         sudo -E ./jenkins/ubuntu_c.sh
       displayName: 'Build'
@@ -317,6 +346,7 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - download: current
       artifact: test_config_scripts
       displayName: Download artifact (test config scripts)
@@ -325,7 +355,7 @@ stages:
       displayName: Download artifact (build output)
     - script: |
         set -e
-        sudo apt-get update && sudo apt-get upgrade
+        sudo apt-get update -qq
         sudo ./build_all/linux/setup.sh
       displayName: 'Host setup'
     - script: |
@@ -353,15 +383,26 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - download: current
       artifact: test_config_scripts
       displayName: Download artifact (test config scripts)
     - script: |
         set -e
-        sudo apt-get update && sudo apt-get upgrade
+        sudo apt-get update -qq
         sudo ./build_all/linux/setup.sh
         sudo apt-get install -y clang
       displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
     - script: |
         export OPENSSL_ia32cap=0x00000000
         sudo chmod -R 755 .
@@ -390,15 +431,26 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - download: current
       artifact: test_config_scripts
       displayName: Download artifact (test config scripts)
     - script: |
         set -e
-        sudo apt-get update && sudo apt-get upgrade
+        sudo apt-get update -qq
         sudo ./build_all/linux/setup.sh
         sudo apt-get install -y clang
       displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
     - script: |
         export OPENSSL_ia32cap=0x00000000
         sudo chmod -R 755 .
@@ -441,6 +493,7 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - script: |
         set -e
         sudo dpkg --add-architecture arm64
@@ -526,14 +579,25 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - download: current
       artifact: test_config_scripts
       displayName: Download artifact (test config scripts)
     - script: |
         set -e
-        sudo apt-get update && sudo apt-get upgrade
+        sudo apt-get update -qq
         sudo ./build_all/linux/setup.sh
       displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
     - script: |
         sudo -E ./jenkins/ubuntu_c_riot.sh
       displayName: 'Build'
@@ -560,14 +624,25 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - download: current
       artifact: test_config_scripts
       displayName: Download artifact (test config scripts)
     - script: |
         set -e
-        sudo apt-get update && sudo apt-get upgrade
+        sudo apt-get update -qq
         sudo ./build_all/linux/setup.sh
       displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
     - script: |
         cat /etc/*release | grep VERSION*
         gcc --version
@@ -598,14 +673,25 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - download: current
       artifact: test_config_scripts
       displayName: Download artifact (test config scripts)
     - script: |
         set -e
-        sudo apt-get update && sudo apt-get upgrade
+        sudo apt-get update -qq
         sudo ./build_all/linux/setup.sh
       displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
     - script: |
         sudo ./jenkins/debian_c.sh
       displayName: 'Build'
@@ -631,9 +717,10 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - script: |
         set -e
-        sudo apt-get update && sudo apt-get upgrade
+        sudo apt-get update -qq
         sudo ./build_all/linux/setup.sh
       displayName: 'Host setup'
     - script: |
@@ -650,16 +737,27 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - download: current
       artifact: test_config_scripts
       displayName: Download artifact (test config scripts)
     - script: |
         set -e
-        sudo apt-get update && sudo apt-get upgrade
+        sudo apt-get update -qq
         sudo ./build_all/linux/setup.sh
         # wolfSSL is not in Ubuntu main; install dev headers from universe.
         sudo apt-get install -y libwolfssl-dev || true
       displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
     - script: |
         sudo -E jenkins/linux_wolfssl.sh
       displayName: 'Build'
@@ -684,16 +782,27 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - download: current
       artifact: test_config_scripts
       displayName: Download artifact (test config scripts)
     - script: |
         set -e
-        sudo apt-get update && sudo apt-get upgrade
+        sudo apt-get update -qq
         sudo ./build_all/linux/setup.sh
         # Ensure BearSSL dev package is present so CMake can resolve libbearssl.
         sudo apt-get install -y libbearssl-dev
       displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
     - script: |
         sudo -E bash jenkins/linux_bearssl.sh
       displayName: 'Build'
@@ -721,23 +830,44 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - download: current
       artifact: test_config_scripts
       displayName: Download artifact (test config scripts)
     - script: |
         set -e
-        sudo apt-get update && sudo apt-get upgrade
+        sudo apt-get update -qq
         sudo ./build_all/linux/setup.sh
       displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
+    - task: Cache@2
+      inputs:
+        key: 'mbedtls | "2.16.12" | "v1"'
+        path: /tmp/mbedtls-2.16-install
+        cacheHitVar: MBEDTLS_CACHE_RESTORED
+      displayName: 'Restore cached mbedTLS 2.16'
     - script: |
         set -e
-        # Install mbedTLS 2.16.x from source (latest 2.16 point release).
-        git clone --depth 1 -b mbedtls-2.16.12 https://github.com/Mbed-TLS/mbedtls /tmp/mbedtls-2.16
-        cd /tmp/mbedtls-2.16
-        mkdir build && cd build
-        cmake -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DCMAKE_INSTALL_PREFIX=/usr/local ..
-        make -j$(nproc)
-        sudo make install
+        if [ "$MBEDTLS_CACHE_RESTORED" = "true" ]; then
+          echo "mbedTLS 2.16 restored from cache"
+        else
+          git clone --depth 1 -b mbedtls-2.16.12 https://github.com/Mbed-TLS/mbedtls /tmp/mbedtls-2.16
+          cd /tmp/mbedtls-2.16
+          mkdir build && cd build
+          cmake -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DCMAKE_INSTALL_PREFIX=/tmp/mbedtls-2.16-install ..
+          make -j$(nproc)
+          make install
+        fi
+        sudo cp -a /tmp/mbedtls-2.16-install/* /usr/local/
         sudo ldconfig
       displayName: 'Install mbedTLS 2.16'
     - script: |
@@ -769,23 +899,44 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - download: current
       artifact: test_config_scripts
       displayName: Download artifact (test config scripts)
     - script: |
         set -e
-        sudo apt-get update && sudo apt-get upgrade
+        sudo apt-get update -qq
         sudo ./build_all/linux/setup.sh
       displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
+    - task: Cache@2
+      inputs:
+        key: 'mbedtls | "2.28.10" | "v1"'
+        path: /tmp/mbedtls-2.28-install
+        cacheHitVar: MBEDTLS_CACHE_RESTORED
+      displayName: 'Restore cached mbedTLS 2.28'
     - script: |
         set -e
-        # Install mbedTLS 2.28.x from source (latest long-term-support 2.28 release).
-        git clone --depth 1 -b mbedtls-2.28.10 https://github.com/Mbed-TLS/mbedtls /tmp/mbedtls-2.28
-        cd /tmp/mbedtls-2.28
-        mkdir build && cd build
-        cmake -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DCMAKE_INSTALL_PREFIX=/usr/local ..
-        make -j$(nproc)
-        sudo make install
+        if [ "$MBEDTLS_CACHE_RESTORED" = "true" ]; then
+          echo "mbedTLS 2.28 restored from cache"
+        else
+          git clone --depth 1 -b mbedtls-2.28.10 https://github.com/Mbed-TLS/mbedtls /tmp/mbedtls-2.28
+          cd /tmp/mbedtls-2.28
+          mkdir build && cd build
+          cmake -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DCMAKE_INSTALL_PREFIX=/tmp/mbedtls-2.28-install ..
+          make -j$(nproc)
+          make install
+        fi
+        sudo cp -a /tmp/mbedtls-2.28-install/* /usr/local/
         sudo ldconfig
       displayName: 'Install mbedTLS 2.28'
     - script: |
@@ -816,24 +967,45 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - download: current
       artifact: test_config_scripts
       displayName: Download artifact (test config scripts)
     - script: |
         set -e
-        sudo apt-get update && sudo apt-get upgrade
+        sudo apt-get update -qq
         sudo ./build_all/linux/setup.sh
       displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
+    - task: Cache@2
+      inputs:
+        key: 'mbedtls | "3.6.2" | "v1"'
+        path: /tmp/mbedtls-3x-install
+        cacheHitVar: MBEDTLS_CACHE_RESTORED
+      displayName: 'Restore cached mbedTLS 3.x'
     - script: |
         set -e
-        # Install mbedTLS 3.6.x from source, matching the old linux-c-ubuntu-2404 image.
-        git clone --depth 1 -b v3.6.2 https://github.com/Mbed-TLS/mbedtls /tmp/mbedtls-3x
-        cd /tmp/mbedtls-3x
-        git submodule update --init --depth 1
-        mkdir build && cd build
-        cmake -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DCMAKE_INSTALL_PREFIX=/usr/local ..
-        make -j$(nproc)
-        sudo make install
+        if [ "$MBEDTLS_CACHE_RESTORED" = "true" ]; then
+          echo "mbedTLS 3.x restored from cache"
+        else
+          git clone --depth 1 -b v3.6.2 https://github.com/Mbed-TLS/mbedtls /tmp/mbedtls-3x
+          cd /tmp/mbedtls-3x
+          git submodule update --init --depth 1
+          mkdir build && cd build
+          cmake -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DCMAKE_INSTALL_PREFIX=/tmp/mbedtls-3x-install ..
+          make -j$(nproc)
+          make install
+        fi
+        sudo cp -a /tmp/mbedtls-3x-install/* /usr/local/
         sudo ldconfig
       displayName: 'Install mbedTLS 3.x'
     - script: |
@@ -862,15 +1034,26 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - download: current
       artifact: test_config_scripts
       displayName: Download artifact (test config scripts)
     - script: |
         set -e
-        sudo apt-get update && sudo apt-get upgrade
+        sudo apt-get update -qq
         sudo ./build_all/linux/setup.sh
         sudo apt-get install -y libc-ares-dev
       displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
     - script: |
         sudo -E bash jenkins/linux_cares.sh
       displayName: 'Build'
@@ -895,15 +1078,26 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - download: current
       artifact: test_config_scripts
       displayName: Download artifact (test config scripts)
     - script: |
         set -e
-        sudo apt-get update && sudo apt-get upgrade
+        sudo apt-get update -qq
         sudo ./build_all/linux/setup.sh
         sudo apt-get install -y softhsm2 libengine-pkcs11-openssl opensc libp11-dev
       displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
     - script: |
         # Use dynamically generated E2E variables from Setup stage to avoid unresolved placeholders.
         sudo bash -c 'source "$(Pipeline.Workspace)/test_config_scripts/set_e2e_test_env_vars.sh" && ./jenkins/linux_openssl_engine.sh'
@@ -930,6 +1124,7 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - download: current
       artifact: test_config_scripts
       displayName: Download artifact (test config scripts)
@@ -963,6 +1158,7 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - download: current
       artifact: test_config_scripts
       displayName: Download artifact (test config scripts)
@@ -1000,6 +1196,7 @@ stages:
     steps:
     - checkout: self
       submodules: true
+      fetchDepth: 1
     - task: CodeQL3000Init@0
     - task: NuGetCommand@2
       inputs:

--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -361,8 +361,12 @@ stages:
       displayName: Download artifact (build output)
     - script: |
         set -e
-        sudo apt-get update -qq
-        sudo ./build_all/linux/setup.sh
+        if command -v valgrind >/dev/null 2>&1; then
+          echo "Using preinstalled valgrind on hosted agent"
+        else
+          sudo apt-get update -qq
+          sudo ./build_all/linux/setup.sh
+        fi
       displayName: 'Host setup'
     - script: |
         set -e
@@ -395,9 +399,15 @@ stages:
       displayName: Download artifact (test config scripts)
     - script: |
         set -e
-        sudo apt-get update -qq
-        sudo ./build_all/linux/setup.sh
-        sudo apt-get install -y clang
+        if command -v clang >/dev/null 2>&1 && command -v valgrind >/dev/null 2>&1; then
+          echo "Using preinstalled clang and valgrind on hosted agent"
+        else
+          sudo apt-get update -qq
+          sudo ./build_all/linux/setup.sh
+          if ! command -v clang >/dev/null 2>&1; then
+            sudo apt-get install -y clang
+          fi
+        fi
       displayName: 'Host setup'
     - task: Cache@2
       inputs:
@@ -443,9 +453,15 @@ stages:
       displayName: Download artifact (test config scripts)
     - script: |
         set -e
-        sudo apt-get update -qq
-        sudo ./build_all/linux/setup.sh
-        sudo apt-get install -y clang
+        if command -v clang >/dev/null 2>&1 && command -v valgrind >/dev/null 2>&1; then
+          echo "Using preinstalled clang and valgrind on hosted agent"
+        else
+          sudo apt-get update -qq
+          sudo ./build_all/linux/setup.sh
+          if ! command -v clang >/dev/null 2>&1; then
+            sudo apt-get install -y clang
+          fi
+        fi
       displayName: 'Host setup'
     - task: Cache@2
       inputs:

--- a/build_all/linux/build.sh
+++ b/build_all/linux/build.sh
@@ -139,7 +139,15 @@ rm -r -f $build_folder
 mkdir -m777 -p $build_folder
 pushd $build_folder
 echo "Generating Build Files"
-cmake $toolchainfile $cmake_install_prefix $build_root -Drun_valgrind:BOOL=$run_valgrind -DcompileOption_C:STRING="$extracloptions" -Drun_e2e_tests:BOOL=$run_e2e_tests -Drun_sfc_tests:BOOL=$run_sfc_tests -Drun_longhaul_tests=$run_longhaul_tests -Duse_amqp:BOOL=$build_amqp -Duse_http:BOOL=$build_http -Duse_mqtt:BOOL=$build_mqtt -Ddont_use_uploadtoblob:BOOL=$no_blob -Drun_unittests:BOOL=$run_unittests -Dno_logging:BOOL=$no_logging -Duse_prov_client:BOOL=$prov_auth -Duse_tpm_simulator:BOOL=$prov_use_tpm_simulator -Duse_edge_modules=$use_edge_modules -Dhsm_type_riot=$hsm_type_riot -Dhsm_type_x509=$hsm_type_x509 -Dhsm_type_symm_key=$hsm_type_symm_key -Dhsm_type_sastoken=$hsm_type_sastoken -Denable_ipv6=$enable_ipv6 -DCMAKE_BUILD_TYPE=$build_config
+
+# Use ccache as compiler launcher when available for faster rebuilds.
+CCACHE_LAUNCHER=""
+if command -v ccache >/dev/null 2>&1; then
+  CCACHE_LAUNCHER="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+  echo "ccache found — enabling CMAKE_*_COMPILER_LAUNCHER"
+fi
+
+cmake $toolchainfile $cmake_install_prefix $build_root $CCACHE_LAUNCHER -Drun_valgrind:BOOL=$run_valgrind -DcompileOption_C:STRING="$extracloptions" -Drun_e2e_tests:BOOL=$run_e2e_tests -Drun_sfc_tests:BOOL=$run_sfc_tests -Drun_longhaul_tests=$run_longhaul_tests -Duse_amqp:BOOL=$build_amqp -Duse_http:BOOL=$build_http -Duse_mqtt:BOOL=$build_mqtt -Ddont_use_uploadtoblob:BOOL=$no_blob -Drun_unittests:BOOL=$run_unittests -Dno_logging:BOOL=$no_logging -Duse_prov_client:BOOL=$prov_auth -Duse_tpm_simulator:BOOL=$prov_use_tpm_simulator -Duse_edge_modules=$use_edge_modules -Dhsm_type_riot=$hsm_type_riot -Dhsm_type_x509=$hsm_type_x509 -Dhsm_type_symm_key=$hsm_type_symm_key -Dhsm_type_sastoken=$hsm_type_sastoken -Denable_ipv6=$enable_ipv6 -DCMAKE_BUILD_TYPE=$build_config
 chmod --recursive ugo+rw ../cmake
 
 # Set the default cores

--- a/build_all/linux/run_tests.sh
+++ b/build_all/linux/run_tests.sh
@@ -24,6 +24,8 @@ run_e2e=false
 run_valgrind=false
 run_helgrind=false
 run_drd=false
+ut_only=false
+e2e_only=false
 
 for arg in "$@"; do
     case "$arg" in
@@ -31,9 +33,16 @@ for arg in "$@"; do
         --valgrind)  run_valgrind=true ;;
         --helgrind)  run_helgrind=true ;;
         --drd)       run_drd=true ;;
+        --ut-only)   ut_only=true ;;
+        --e2e-only)  e2e_only=true ;;
         *)           echo "Unknown option: $arg"; exit 1 ;;
     esac
 done
+
+if $ut_only && $e2e_only; then
+    echo "Cannot use --ut-only and --e2e-only together"
+    exit 1
+fi
 
 # If no instrumentation flags are set, run plain (non-valgrind) tests.
 run_plain=true
@@ -46,39 +55,53 @@ sudo ldconfig
 
 if $run_plain; then
     if $run_e2e; then
-        # Unit tests + E2E, no valgrind/helgrind/drd
-        # iothubclient_mqtt_dt_e2e is quarantined: see GitHub issue (twin PATCH never
-        # delivered to device after subscribe; pre-existing flake, not pipeline-related).
-        ctest -T test --no-compress-output -C "Debug" -V -j $E2E_CORES --schedule-random -E "_(valgrind|helgrind|drd)$|^iothubclient_mqtt_dt_e2e$"
+        if ! $ut_only; then
+            # Unit tests + E2E, no valgrind/helgrind/drd
+            # iothubclient_mqtt_dt_e2e is quarantined: see GitHub issue (twin PATCH never
+            # delivered to device after subscribe; pre-existing flake, not pipeline-related).
+            ctest -T test --no-compress-output -C "Debug" -V -j $E2E_CORES --schedule-random -E "_(valgrind|helgrind|drd)$|^iothubclient_mqtt_dt_e2e$"
+        fi
     else
-        # Unit tests only, no E2E, no valgrind/helgrind/drd
-        ctest -T test --no-compress-output -C "Debug" -V -j $UT_CORES --schedule-random -E "_(valgrind|helgrind|drd)|e2e"
+        if ! $e2e_only; then
+            # Unit tests only, no E2E, no valgrind/helgrind/drd
+            ctest -T test --no-compress-output -C "Debug" -V -j $UT_CORES --schedule-random -E "_(valgrind|helgrind|drd)|e2e"
+        fi
     fi
 fi
 
 if $run_valgrind; then
-    # Unit tests under valgrind
-    ctest -T test --no-compress-output -C "Debug" -V -j $VALGRIND_UT_CORES --schedule-random -R "_valgrind$" -E "e2e"
+    if ! $e2e_only; then
+        # Unit tests under valgrind
+        ctest -T test --no-compress-output -C "Debug" -V -j $VALGRIND_UT_CORES --schedule-random -R "_valgrind$" -E "e2e"
+    fi
     if $run_e2e; then
-        # E2E tests under valgrind. Quarantined:
-        #   iothubclient_mqtt_dt_e2e: see GitHub issue (twin PATCH delivery flake).
-        ctest -T test --no-compress-output -C "Debug" -V -j $VALGRIND_E2E_CORES --schedule-random -R "e2e_valgrind$" -E "^iothubclient_mqtt_dt_e2e_valgrind$"
+        if ! $ut_only; then
+            # E2E tests under valgrind. Quarantined:
+            #   iothubclient_mqtt_dt_e2e: see GitHub issue (twin PATCH delivery flake).
+            ctest -T test --no-compress-output -C "Debug" -V -j $VALGRIND_E2E_CORES --schedule-random -R "e2e_valgrind$" -E "^iothubclient_mqtt_dt_e2e_valgrind$"
+        fi
     fi
 fi
 
 if $run_helgrind; then
-    # Unit tests under helgrind
-    ctest -T test --no-compress-output -C "Debug" -V -j $VALGRIND_UT_CORES --schedule-random -R "_helgrind$" -E "e2e"
+    if ! $e2e_only; then
+        # Unit tests under helgrind
+        ctest -T test --no-compress-output -C "Debug" -V -j $VALGRIND_UT_CORES --schedule-random -R "_helgrind$" -E "e2e"
+    fi
     if $run_e2e; then
-        # E2E tests under helgrind. Quarantined:
-        #   iothubclient_mqtt_dt_e2e: see GitHub issue (twin PATCH delivery flake).
-        ctest -T test --no-compress-output -C "Debug" -V -j $VALGRIND_E2E_CORES --schedule-random -R "e2e_helgrind$" -E "^iothubclient_mqtt_dt_e2e_helgrind$"
+        if ! $ut_only; then
+            # E2E tests under helgrind. Quarantined:
+            #   iothubclient_mqtt_dt_e2e: see GitHub issue (twin PATCH delivery flake).
+            ctest -T test --no-compress-output -C "Debug" -V -j $VALGRIND_E2E_CORES --schedule-random -R "e2e_helgrind$" -E "^iothubclient_mqtt_dt_e2e_helgrind$"
+        fi
     fi
 fi
 
 if $run_drd; then
-    # Unit tests under drd
-    ctest -T test --no-compress-output -C "Debug" -V -j $VALGRIND_UT_CORES --schedule-random -R "_drd$" -E "e2e"
+    if ! $e2e_only; then
+        # Unit tests under drd
+        ctest -T test --no-compress-output -C "Debug" -V -j $VALGRIND_UT_CORES --schedule-random -R "_drd$" -E "e2e"
+    fi
     # NOTE: E2E tests are intentionally not run under drd.  drd's thread instrumentation adds
     # 20-50x performance overhead, which makes libcurl's TLS handshakes to Azure services fail
     # with "SSL connect error".  Each failed IoTHubDeviceMethod_Invoke then cascades through

--- a/build_all/linux/setup.sh
+++ b/build_all/linux/setup.sh
@@ -9,7 +9,7 @@ repo_name_from_uri()
 }
 
 scriptdir=$(cd "$(dirname "$0")" && pwd)
-deps="curl build-essential pkg-config libcurl4-openssl-dev git cmake libssl-dev uuid-dev valgrind"
+deps="curl build-essential pkg-config libcurl4-openssl-dev git cmake libssl-dev uuid-dev valgrind ccache"
 repo="https://github.com/Azure/azure-iot-sdk-c.git"
 repo_name=$(repo_name_from_uri $repo)
 

--- a/testtools/scripts/linux-setup-raspberry.sh
+++ b/testtools/scripts/linux-setup-raspberry.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sudo apt-get update && sudo apt-get upgrade
+sudo apt-get update -qq
 sudo apt install --fix-missing -y wget git build-essential cmake xz-utils ca-certificates pkg-config sudo
 
 export WORK_ROOT="$(pwd)/toolchain"


### PR DESCRIPTION
## Summary
This PR reduces C-canary wall-clock time while keeping the pipeline self-sufficient (no dependency on prebuilt custom images).

## What changed
- Added ccache integration for Linux builds and configured cache restore/save across Linux jobs.
- Added mbedTLS source-build caching for 2.16, 2.28, and 3.x jobs.
- Removed expensive apt upgrade usage from setup paths where safe.
- Enabled shallow checkout where safe and kept full checkout where required (`check_submodules`).
- Parallelized stages so `Setup` can run alongside `Requirements`.
- Split Ubuntu debug valgrind/helgrind lanes into UT and E2E shards (same coverage, better overlap).
- In Ubuntu debug tests + clang jobs, use preinstalled hosted-agent tools when available and provision only when missing.

## Why this is self-sufficient
- The pipeline provisions everything it needs at runtime if the hosted image does not have it.
- No external private/custom prebuilt build image is required.
- Existing Docker-based ARM/MIPS jobs continue to build from repo Dockerfiles during the run.

## Validation
- C-canary 158668: **succeeded** (~86.6 min)
- C-canary 158675: **in progress** (same branch, latest commit)

## Notes
- ARM/MIPS non-main branch behavior is a separate pre-existing limitation and not introduced by this PR.