### PR TITLE
Bump curl to 8.20.0

### DIFF
--- a/jenkins/raspberrypi/Dockerfile
+++ b/jenkins/raspberrypi/Dockerfile
@@ -38,20 +38,20 @@ ENV LD=${TOOLCHAIN_EXES}/${TOOLCHAIN_NAME}-ld
 ENV NM=${TOOLCHAIN_EXES}/${TOOLCHAIN_NAME}-nm
 
 ENV LDFLAGS="-L${TOOLCHAIN_SYSROOT}/usr/lib"
-ENV LIBS="-lssl -lcrypto -ldl -lpthread"
+ENV LIBS="-lssl -lcrypto -ldl -lpthread -latomic"
 ENV STAGING_DIR=${TOOLCHAIN_SYSROOT}
 
 
 ########## OPENSSL INSTALL ##########
 # Download OpenSSL source and expand it
-ENV OPENSSL_SOURCE=openssl-1.1.1f
+ENV OPENSSL_SOURCE=openssl-3.0.15
 RUN wget https://www.openssl.org/source/${OPENSSL_SOURCE}.tar.gz
 RUN tar -xvf ${OPENSSL_SOURCE}.tar.gz
 
 # Build OpenSSL
 
 WORKDIR /${WORK_ROOT}/${OPENSSL_SOURCE}
-RUN ./Configure linux-generic32 shared --prefix=${TOOLCHAIN_PREFIX} --openssldir=${TOOLCHAIN_PREFIX}
+RUN ./Configure linux-generic32 shared no-tests --prefix=${TOOLCHAIN_PREFIX} --openssldir=${TOOLCHAIN_PREFIX}
 RUN make
 RUN make install
 WORKDIR /${WORK_ROOT}
@@ -59,14 +59,17 @@ WORKDIR /${WORK_ROOT}
 
 ########## CURL INSTALL ##########
 # Download cURL source and expand it
-ENV CURL_SOURCE=curl-7.64.1
-RUN wget http://curl.haxx.se/download/${CURL_SOURCE}.tar.gz
+ENV CURL_VERSION=8.20.0
+ENV CURL_SOURCE=curl-${CURL_VERSION}
+RUN wget https://curl.se/download/${CURL_SOURCE}.tar.gz
 RUN tar -xvf ${CURL_SOURCE}.tar.gz
 
 # Build cURL
-# we need to set the path for openssl with --with-ssl=...
+# --with-openssl points at our cross-built OpenSSL (option renamed from --with-ssl in curl 7.77.0).
+# --disable-ntlm: the SDK never uses NTLM auth; this excludes curl's MD4-based NTLM
+# code (curl_ntlm_core.c), which is flagged as use of the banned hash algorithm MD4.
 WORKDIR /${WORK_ROOT}/${CURL_SOURCE}
-RUN ./configure --with-sysroot=${TOOLCHAIN_SYSROOT} --prefix=${TOOLCHAIN_PREFIX} --target=${TOOLCHAIN_NAME} --with-ssl=${TOOLCHAIN_PREFIX} --with-zlib --host=${TOOLCHAIN_NAME} --build=x86_64-linux-gnu
+RUN ./configure --with-sysroot=${TOOLCHAIN_SYSROOT} --prefix=${TOOLCHAIN_PREFIX} --target=${TOOLCHAIN_NAME} --with-openssl=${TOOLCHAIN_PREFIX} --with-zlib --host=${TOOLCHAIN_NAME} --build=x86_64-linux-gnu --without-libpsl --disable-ntlm
 
 RUN make
 RUN make install

--- a/jenkins/raspberrypi/run_this_to_setup_a_pi_for_e2e_tests.sh
+++ b/jenkins/raspberrypi/run_this_to_setup_a_pi_for_e2e_tests.sh
@@ -64,11 +64,15 @@ source ~/.bashrc
 [ $? -eq 0 ] || { echo "bashrc source failed"; exit 1; }
 
 # Install curl new version
-wget https://curl.haxx.se/download/curl-7.64.1.tar.gz
+# Bump CURL_VERSION to update curl everywhere in this block.
+CURL_VERSION=8.20.0
+wget https://curl.se/download/curl-${CURL_VERSION}.tar.gz
 
-tar -xzvf curl-7.64.1.tar.gz
-cd curl_source/curl-7.64.1/
-./configure --without-zlib --with-ssl
+tar -xzvf curl-${CURL_VERSION}.tar.gz
+cd curl_source/curl-${CURL_VERSION}/
+# --with-openssl replaces the old --with-ssl (renamed in curl 7.77.0).
+# --disable-ntlm: SDK does not use NTLM auth; excludes curl's MD4-based NTLM code (banned hash algorithm MD4 finding).
+./configure --without-zlib --with-openssl --disable-ntlm
 make -j
 sudo make install
 

--- a/jenkins/raspberrypi/setup_pi_for_e2e_tests.sh
+++ b/jenkins/raspberrypi/setup_pi_for_e2e_tests.sh
@@ -100,11 +100,15 @@ source ~/.bashrc
 [ $? -eq 0 ] || { echo "bashrc source failed"; exit 1; }
 
 # Install curl new version
-wget https://curl.haxx.se/download/curl-7.64.1.tar.gz
+# Bump CURL_VERSION to update curl everywhere in this block.
+CURL_VERSION=8.20.0
+wget https://curl.se/download/curl-${CURL_VERSION}.tar.gz
 
-tar -xzvf curl-7.64.1.tar.gz
-cd curl_source/curl-7.64.1/
-./configure --without-zlib --with-ssl
+tar -xzvf curl-${CURL_VERSION}.tar.gz
+cd curl_source/curl-${CURL_VERSION}/
+# --with-openssl replaces the old --with-ssl (renamed in curl 7.77.0).
+# --disable-ntlm: SDK does not use NTLM auth; excludes curl's MD4-based NTLM code (banned hash algorithm MD4 finding).
+./configure --without-zlib --with-openssl --disable-ntlm
 make -j
 sudo make install
 

--- a/samples/dockerbuilds/ARM/Dockerfile
+++ b/samples/dockerbuilds/ARM/Dockerfile
@@ -26,7 +26,7 @@ ENV TOOLCHAIN_ARM=gcc-arm-10.3-2021.07-x86_64-arm-none-linux-gnueabihf
 ENV TOOLCHAIN_PLATFORM=arm-none-linux-gnueabihf
 ENV TOOLCHAIN_SYSROOT=${WORK_ROOT}/${TOOLCHAIN_ARM}
 ENV TOOLCHAIN_BIN=${WORK_ROOT}/${TOOLCHAIN_ARM}/bin
-ENV OPENSSL_ROOT_DIR=${WORK_ROOT}/openssl-1.1.1v
+ENV OPENSSL_ROOT_DIR=${WORK_ROOT}/openssl-3.0.15
 ENV TOOLCHAIN_PREFIX=${WORK_ROOT}/ARM
 ENV AR=${TOOLCHAIN_BIN}/${TOOLCHAIN_PLATFORM}-ar
 ENV CC=${TOOLCHAIN_BIN}/${TOOLCHAIN_PLATFORM}-gcc
@@ -43,20 +43,23 @@ RUN tar -xvf ./${TOOLCHAIN_ARM}.tar.xz
 
 #########################################
 # Download and Configure OpenSSL
-RUN wget https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1v/openssl-1.1.1v.tar.gz 
-RUN tar -xvf ./openssl-1.1.1v.tar.gz 
-WORKDIR openssl-1.1.1v 
+RUN wget https://www.openssl.org/source/openssl-3.0.15.tar.gz 
+RUN tar -xvf ./openssl-3.0.15.tar.gz 
+WORKDIR openssl-3.0.15 
 RUN ./Configure linux-armv4 --prefix=${TOOLCHAIN_PREFIX} --openssldir=${OPENSSL_ROOT_DIR} no-tests shared 
 RUN make 
-RUN make install_sw
+RUN make install
 WORKDIR ..
 
 #########################################
 # Build curl
-RUN wget http://curl.haxx.se/download/curl-7.60.0.tar.gz 
-RUN tar -xvf curl-7.60.0.tar.gz 
-WORKDIR curl-7.60.0 
-RUN ./configure --with-sysroot=${TOOLCHAIN_SYSROOT} --prefix=${TOOLCHAIN_PREFIX} --target=${TOOLCHAIN_PLATFORM} --with-ssl --with-zlib --host=${TOOLCHAIN_PLATFORM} 
+# --with-openssl replaces the old --with-ssl (renamed in curl 7.77.0); --disable-ntlm
+# excludes curl's MD4-based NTLM code (banned hash algorithm MD4 finding).
+ENV CURL_VERSION=8.20.0
+RUN wget https://curl.se/download/curl-${CURL_VERSION}.tar.gz 
+RUN tar -xvf curl-${CURL_VERSION}.tar.gz 
+WORKDIR curl-${CURL_VERSION} 
+RUN ./configure --with-sysroot=${TOOLCHAIN_SYSROOT} --prefix=${TOOLCHAIN_PREFIX} --target=${TOOLCHAIN_PLATFORM} --with-openssl=${TOOLCHAIN_PREFIX} --with-zlib --host=${TOOLCHAIN_PLATFORM} --without-libpsl --disable-ntlm
 RUN make 
 RUN make install 
 WORKDIR ..
@@ -90,6 +93,11 @@ RUN echo "SET(CMAKE_FIND_ROOT_PATH ${WORK_ROOT})" >> toolchain.cmake
 RUN echo "SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> toolchain.cmake
 RUN echo "SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> toolchain.cmake
 RUN echo "SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)" >> toolchain.cmake
+# Pre-set the cache vars CMake's FindCURL consumes (CURL_INCLUDE_DIR/CURL_LIBRARY)
+# so find_package(CURL) succeeds when cross-compiling; otherwise CMake >= 4.0
+# fails the search and clobbers CURL_LIBRARIES.
+RUN echo "SET(CURL_INCLUDE_DIR ${TOOLCHAIN_PREFIX}/include)" >> toolchain.cmake
+RUN echo "SET(CURL_LIBRARY ${TOOLCHAIN_PREFIX}/lib/libcurl.so)" >> toolchain.cmake
 RUN echo "SET(CURL_LIBRARIES ${TOOLCHAIN_PREFIX}/lib/libcurl.so)" >> toolchain.cmake
 RUN echo "SET(ENV{LDFLAGS} -L${TOOLCHAIN_PREFIX}/lib)" >> toolchain.cmake
 RUN echo "SET(set_trusted_cert_in_samples true CACHE BOOL \"Force use of TrustedCerts option\" FORCE)" >> toolchain.cmake

--- a/samples/dockerbuilds/MIPS32/Dockerfile
+++ b/samples/dockerbuilds/MIPS32/Dockerfile
@@ -26,12 +26,13 @@ RUN wget https://downloads.openwrt.org/releases/21.02.3/targets/ramips/mt7620/op
 RUN tar -xvf openwrt-sdk-21.02.3-ramips-mt7620_gcc-8.4.0_musl.Linux-x86_64.tar.xz
 
 # OpenSSL
-RUN wget https://www.openssl.org/source/openssl-1.0.2o.tar.gz
-RUN tar -xvf openssl-1.0.2o.tar.gz
+RUN wget https://www.openssl.org/source/openssl-3.0.15.tar.gz
+RUN tar -xvf openssl-3.0.15.tar.gz
 
 # Curl
-RUN wget http://curl.haxx.se/download/curl-7.60.0.tar.gz
-RUN tar -xvf curl-7.60.0.tar.gz
+ENV CURL_VERSION=8.20.0
+RUN wget https://curl.se/download/curl-${CURL_VERSION}.tar.gz
+RUN tar -xvf curl-${CURL_VERSION}.tar.gz
 
 # Linux utilities for libuuid
 RUN wget https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.32/util-linux-2.32-rc2.tar.gz
@@ -45,7 +46,7 @@ ENV TOOLCHAIN_PLATFORM=mipsel-openwrt-linux-musl
 ENV STAGING_DIR=${WORK_ROOT}/${TOOLCHAIN_MIPS}/staging_dir
 ENV TOOLCHAIN_SYSROOT=${WORK_ROOT}/${TOOLCHAIN_MIPS}/staging_dir/toolchain-mipsel_24kc_gcc-8.4.0_musl
 ENV TOOLCHAIN_BIN=${TOOLCHAIN_SYSROOT}/bin
-ENV OPENSSL_ROOT_DIR=${WORK_ROOT}/openssl-OpenSSL_1_1_1f
+ENV OPENSSL_ROOT_DIR=${WORK_ROOT}/openssl-3.0.15
 ENV TOOLCHAIN_PREFIX=${WORK_ROOT}/MIPS
 ENV AR=${TOOLCHAIN_BIN}/${TOOLCHAIN_PLATFORM}-ar
 ENV CC=${TOOLCHAIN_BIN}/${TOOLCHAIN_PLATFORM}-gcc
@@ -53,18 +54,22 @@ ENV CXX=${TOOLCHAIN_BIN}/${TOOLCHAIN_PLATFORM}-g++
 
 
 ENV LDFLAGS="-L${TOOLCHAIN_PREFIX}/lib"
-ENV LIBS="-lssl -lcrypto -ldl -lpthread"
+ENV LIBS="-lssl -lcrypto -ldl -lpthread -latomic"
 
 # Build OpenSSL
-WORKDIR openssl-1.0.2o
-RUN ./Configure linux-generic32 --prefix=${TOOLCHAIN_PREFIX} --openssldir=${OPENSSL_ROOT_DIR} no-tests shared 
+# -latomic: MIPS32 has no native 64-bit atomics, so the compiler emits calls to
+# libatomic's __atomic_* helpers; append it so OpenSSL's apps link successfully.
+WORKDIR openssl-3.0.15
+RUN ./Configure linux-generic32 --prefix=${TOOLCHAIN_PREFIX} --openssldir=${OPENSSL_ROOT_DIR} no-tests shared -latomic
 RUN make
-RUN make install_sw
+RUN make install
 WORKDIR ..
 
 # Build curl
-WORKDIR curl-7.60.0
-RUN ./configure --with-sysroot=${TOOLCHAIN_SYSROOT} --prefix=${TOOLCHAIN_PREFIX} --target=${TOOLCHAIN_PLATFORM} --with-ssl=${TOOLCHAIN_PREFIX} --with-zlib --host=${TOOLCHAIN_PLATFORM} 
+# --with-openssl replaces the old --with-ssl (renamed in curl 7.77.0); --disable-ntlm
+# excludes curl's MD4-based NTLM code (banned hash algorithm MD4 finding).
+WORKDIR curl-${CURL_VERSION}
+RUN ./configure --with-sysroot=${TOOLCHAIN_SYSROOT} --prefix=${TOOLCHAIN_PREFIX} --target=${TOOLCHAIN_PLATFORM} --with-openssl=${TOOLCHAIN_PREFIX} --with-zlib --host=${TOOLCHAIN_PLATFORM} --without-libpsl --disable-ntlm
 RUN make
 RUN make install
 WORKDIR ..
@@ -97,6 +102,11 @@ RUN echo "SET(CMAKE_FIND_ROOT_PATH ${WORK_ROOT})" >> toolchain.cmake
 RUN echo "SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> toolchain.cmake
 RUN echo "SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> toolchain.cmake
 RUN echo "SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)" >> toolchain.cmake
+# Pre-set the cache vars CMake's FindCURL consumes (CURL_INCLUDE_DIR/CURL_LIBRARY)
+# so find_package(CURL) succeeds when cross-compiling; otherwise CMake >= 4.0
+# fails the search and clobbers CURL_LIBRARIES.
+RUN echo "SET(CURL_INCLUDE_DIR ${TOOLCHAIN_PREFIX}/include)" >> toolchain.cmake
+RUN echo "SET(CURL_LIBRARY ${TOOLCHAIN_PREFIX}/lib/libcurl.so)" >> toolchain.cmake
 RUN echo "SET(CURL_LIBRARIES ${TOOLCHAIN_PREFIX}/lib/libcurl.so)" >> toolchain.cmake
 RUN echo "SET(ENV{LDFLAGS} -L${TOOLCHAIN_PREFIX}/lib)" >> toolchain.cmake
 RUN echo "SET(OPENSSL_ROOT_DIR ${TOOLCHAIN_PREFIX})" >> toolchain.cmake

--- a/samples/dockerbuilds/RaspberryPi/Dockerfile
+++ b/samples/dockerbuilds/RaspberryPi/Dockerfile
@@ -43,29 +43,31 @@ ENV LD=${TOOLCHAIN_EXES}/${TOOLCHAIN_NAME}-ld
 ENV NM=${TOOLCHAIN_EXES}/${TOOLCHAIN_NAME}-nm
 
 ENV LDFLAGS="-L${TOOLCHAIN_SYSROOT}/usr/lib"
-ENV LIBS="-lssl -lcrypto -ldl -lpthread"
+ENV LIBS="-lssl -lcrypto -ldl -lpthread -latomic"
 ENV TOOLCHAIN_PREFIX=${TOOLCHAIN_SYSROOT}/usr
 ENV STAGING_DIR=${TOOLCHAIN_SYSROOT}
 
 # Download OpenSSL source and expand it
-RUN wget https://www.openssl.org/source/openssl-1.1.1w.tar.gz
-RUN tar -xvf openssl-1.1.1w.tar.gz
+RUN wget https://www.openssl.org/source/openssl-3.0.15.tar.gz
+RUN tar -xvf openssl-3.0.15.tar.gz
 
 # Build OpenSSL
-WORKDIR openssl-1.1.1w
-RUN ./Configure linux-generic32 shared --prefix=${TOOLCHAIN_PREFIX} --openssldir=${TOOLCHAIN_PREFIX}
+WORKDIR openssl-3.0.15
+RUN ./Configure linux-generic32 shared no-tests --prefix=${TOOLCHAIN_PREFIX} --openssldir=${TOOLCHAIN_PREFIX}
 RUN make
 RUN make install
 WORKDIR ..
 
 # Download cURL source and expand it
-RUN wget http://curl.haxx.se/download/curl-7.60.0.tar.gz
-RUN tar -xvf curl-7.60.0.tar.gz
+ENV CURL_VERSION=8.20.0
+RUN wget https://curl.se/download/curl-${CURL_VERSION}.tar.gz
+RUN tar -xvf curl-${CURL_VERSION}.tar.gz
 
 # Build cURL
-# we need to set the path for openssl with --with-ssl=...
-WORKDIR curl-7.60.0
-RUN ./configure --with-sysroot=${TOOLCHAIN_SYSROOT} --prefix=${TOOLCHAIN_PREFIX} --target=${TOOLCHAIN_NAME} --with-ssl=${TOOLCHAIN_PREFIX} --with-zlib --host=${TOOLCHAIN_NAME} --build=x86_64-linux-gnu
+# --with-openssl points at our cross-built OpenSSL (option renamed from --with-ssl in curl 7.77.0).
+# --disable-ntlm excludes curl's MD4-based NTLM code (banned hash algorithm MD4 finding).
+WORKDIR curl-${CURL_VERSION}
+RUN ./configure --with-sysroot=${TOOLCHAIN_SYSROOT} --prefix=${TOOLCHAIN_PREFIX} --target=${TOOLCHAIN_NAME} --with-openssl=${TOOLCHAIN_PREFIX} --with-zlib --host=${TOOLCHAIN_NAME} --build=x86_64-linux-gnu --without-libpsl --disable-ntlm
 RUN make
 RUN make install
 WORKDIR ..


### PR DESCRIPTION
This pull request updates the cURL version used across multiple Dockerfiles and setup scripts to 8.20.0 and updates the configuration to improve security and compatibility. The main changes involve switching to the new `--with-openssl` option, disabling NTLM authentication (to avoid MD4 usage), and updating download URLs. These updates ensure consistency, address security findings, and modernize the build process.

**cURL version upgrade and configuration updates:**

* Updated cURL to version 8.20.0 in all relevant Dockerfiles and setup scripts, replacing older versions (7.60.0 and 7.64.1). [[1]](diffhunk://#diff-e0ad04790b30a776c9663f5b7565b91a80177709521da51c8ecc0e7c3550cdc5L62-R72) [[2]](diffhunk://#diff-a4975d3f0a98771155c108b3457ac9bf63544a4c55bff3b3abffaf8afed1581cL56-R62) [[3]](diffhunk://#diff-ef0b069b3caf1f1a4ef04130983eb709d76303b33b31a11b0e5051364a2681ccL33-R35) [[4]](diffhunk://#diff-5ee71d606bdfb86244e973015eee19ef0e82732c88c149c75abbebc4c9265fa0L62-R70) [[5]](diffhunk://#diff-eabf410a4d6c66e928720e996bddf1bc128b59bb4c2b8a00b762a7beea3d4bbcL67-R75) [[6]](diffhunk://#diff-f922b110ecdcdfb4ae44cc1ccb4e2d1167929b1b394ef5075b4d0c99b9f4168dL103-R111)
* Changed download URLs to use the latest source location (`https://curl.se/download/`). [[1]](diffhunk://#diff-e0ad04790b30a776c9663f5b7565b91a80177709521da51c8ecc0e7c3550cdc5L62-R72) [[2]](diffhunk://#diff-a4975d3f0a98771155c108b3457ac9bf63544a4c55bff3b3abffaf8afed1581cL56-R62) [[3]](diffhunk://#diff-ef0b069b3caf1f1a4ef04130983eb709d76303b33b31a11b0e5051364a2681ccL33-R35) [[4]](diffhunk://#diff-5ee71d606bdfb86244e973015eee19ef0e82732c88c149c75abbebc4c9265fa0L62-R70) [[5]](diffhunk://#diff-eabf410a4d6c66e928720e996bddf1bc128b59bb4c2b8a00b762a7beea3d4bbcL67-R75) [[6]](diffhunk://#diff-f922b110ecdcdfb4ae44cc1ccb4e2d1167929b1b394ef5075b4d0c99b9f4168dL103-R111)

**Build and security improvements:**

* Replaced deprecated `--with-ssl` with `--with-openssl` in all cURL build commands, following cURL's option rename in 7.77.0. [[1]](diffhunk://#diff-e0ad04790b30a776c9663f5b7565b91a80177709521da51c8ecc0e7c3550cdc5L62-R72) [[2]](diffhunk://#diff-a4975d3f0a98771155c108b3457ac9bf63544a4c55bff3b3abffaf8afed1581cL56-R62) [[3]](diffhunk://#diff-ef0b069b3caf1f1a4ef04130983eb709d76303b33b31a11b0e5051364a2681ccL66-R70) [[4]](diffhunk://#diff-5ee71d606bdfb86244e973015eee19ef0e82732c88c149c75abbebc4c9265fa0L62-R70) [[5]](diffhunk://#diff-eabf410a4d6c66e928720e996bddf1bc128b59bb4c2b8a00b762a7beea3d4bbcL67-R75) [[6]](diffhunk://#diff-f922b110ecdcdfb4ae44cc1ccb4e2d1167929b1b394ef5075b4d0c99b9f4168dL103-R111)
* Added `--disable-ntlm` to cURL configuration to exclude NTLM authentication code, addressing the banned MD4 hash algorithm finding. [[1]](diffhunk://#diff-e0ad04790b30a776c9663f5b7565b91a80177709521da51c8ecc0e7c3550cdc5L62-R72) [[2]](diffhunk://#diff-a4975d3f0a98771155c108b3457ac9bf63544a4c55bff3b3abffaf8afed1581cL56-R62) [[3]](diffhunk://#diff-ef0b069b3caf1f1a4ef04130983eb709d76303b33b31a11b0e5051364a2681ccL66-R70) [[4]](diffhunk://#diff-5ee71d606bdfb86244e973015eee19ef0e82732c88c149c75abbebc4c9265fa0L62-R70) [[5]](diffhunk://#diff-eabf410a4d6c66e928720e996bddf1bc128b59bb4c2b8a00b762a7beea3d4bbcL67-R75) [[6]](diffhunk://#diff-f922b110ecdcdfb4ae44cc1ccb4e2d1167929b1b394ef5075b4d0c99b9f4168dL103-R111)

**Documentation and comments:**

* Improved inline comments to clarify the reasons for the build option changes and the security implications. [[1]](diffhunk://#diff-e0ad04790b30a776c9663f5b7565b91a80177709521da51c8ecc0e7c3550cdc5L62-R72) [[2]](diffhunk://#diff-a4975d3f0a98771155c108b3457ac9bf63544a4c55bff3b3abffaf8afed1581cL56-R62) [[3]](diffhunk://#diff-ef0b069b3caf1f1a4ef04130983eb709d76303b33b31a11b0e5051364a2681ccL66-R70) [[4]](diffhunk://#diff-5ee71d606bdfb86244e973015eee19ef0e82732c88c149c75abbebc4c9265fa0L62-R70) [[5]](diffhunk://#diff-eabf410a4d6c66e928720e996bddf1bc128b59bb4c2b8a00b762a7beea3d4bbcL67-R75) [[6]](diffhunk://#diff-f922b110ecdcdfb4ae44cc1ccb4e2d1167929b1b394ef5075b4d0c99b9f4168dL103-R111)