### PR TITLE
Fix E2E wrapper build: emit azure_macro_utils forwarding header into deps inc folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,6 +417,21 @@ else ()
     file(WRITE ${CMAKE_BINARY_DIR}/azure_macro_utils/macro_utils_generated.h
         "#include \"macro_utils/macro_utils_generated.h\"\n")
 
+    # The forwarding headers above are only visible to targets in the SDK's
+    # own directory scope (via include_directories(${CMAKE_BINARY_DIR})).
+    # External consumers that add the deps directly to their include path -
+    # e.g. the IoT E2E test wrappers, which put deps/azure-macro-utils-c/inc
+    # on the compiler include path and build their own targets in the
+    # top-level scope - never see ${CMAKE_BINARY_DIR}. Emit the same
+    # forwarding headers inside the macro-utils-c include folder so the
+    # legacy "azure_macro_utils/..." includes used throughout the SDK's
+    # public headers keep resolving for those consumers too.
+    file(MAKE_DIRECTORY ${MACRO_UTILS_INC_FOLDER}/azure_macro_utils)
+    file(WRITE ${MACRO_UTILS_INC_FOLDER}/azure_macro_utils/macro_utils.h
+        "#include \"macro_utils/macro_utils.h\"\n")
+    file(WRITE ${MACRO_UTILS_INC_FOLDER}/azure_macro_utils/macro_utils_generated.h
+        "#include \"macro_utils/macro_utils_generated.h\"\n")
+
     # Install the forwarding headers so consumers of the installed SDK can
     # still #include "azure_macro_utils/macro_utils.h".
     install(FILES


### PR DESCRIPTION
## Problem

The Horton C E2E image build (`build docker image c`) currently fails on `main` for **every** PR while compiling the `edge_e2e_rest_server` test wrapper:

```
/sdk/iothub_client/inc/internal/iothub_client_edge.h:6:10: fatal error:
    azure_macro_utils/macro_utils.h: No such file or directory
```

## Root cause

The macro-utils-c migration (#2724) moved the submodule to `Azure/macro-utils-c`, which ships headers at `macro_utils/macro_utils.h`. The SDK still includes the legacy `azure_macro_utils/macro_utils.h` in 200+ files and keeps them working via a forwarding header generated into `${CMAKE_BINARY_DIR}` and added with `include_directories(${CMAKE_BINARY_DIR})`.

That shim is only visible to targets in the **SDK's own directory scope**. The E2E test wrappers build their own targets in the **top-level** CMake scope (the SDK is pulled in via `add_subdirectory`) and put `deps/azure-macro-utils-c/inc` directly on their include path — they never see `${CMAKE_BINARY_DIR}`, so the legacy include fails.

Bumping the submodule does not help: `Azure/macro-utils-c` has no `azure_macro_utils/` compatibility header even at latest `master`.

## Fix

Also emit the `azure_macro_utils/` forwarding headers **inside the macro-utils-c include folder** (`deps/azure-macro-utils-c/inc`) at configure time, so external/source-tree consumers that add that folder to their include path keep resolving the legacy `azure_macro_utils/...` includes used throughout the SDK's public headers.

Single-file change in `CMakeLists.txt` (15 lines), mirroring the existing build-dir forwarding logic. This unblocks the Horton C E2E image build for all PRs.