### PR TITLE
cmake: keep strict-prototypes on C flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,6 @@ endif()
 
 if (${strict_prototypes})
     if (NOT MSVC)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-prototypes")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wstrict-prototypes")
     endif()
 endif()


### PR DESCRIPTION
## Summary

- Keep `-Wstrict-prototypes` on C compiler flags only.

## Details

The `strict_prototypes` option enables GCC/Clang's `-Wstrict-prototypes`, which is a C-only diagnostic. The current CMake logic appends it to both `CMAKE_C_FLAGS` and `CMAKE_CXX_FLAGS`, so enabling the option also passes a C-only warning flag to C++ targets.

This leaves the C behavior unchanged and avoids adding the C-only option to C++ compiler invocations.

## Testing

- `git diff --check HEAD~1..HEAD`
- Reviewed the `strict_prototypes` CMake option path and C++ test/sample targets that consume `CMAKE_CXX_FLAGS`.

Not run: local CMake configure/build, because this Windows environment does not have `cmake` or a C/C++ compiler installed.