### PR TITLE
Use raw regex string in pre-doxygen script

### DIFF
--- a/.github/scripts/pre_doxygen.py
+++ b/.github/scripts/pre_doxygen.py
@@ -76,7 +76,7 @@ def convert_mockable_function_line(current_line):
 # later in the file parse where the .c file actually instantiates the enum.
 def add_new_values_enum(src_file_handle, current_line):
     # Remove the "define", trailing "/", and whitespace to get just value by itself
-    enum_value_name = re.sub(".*#define\s*", "", current_line)
+    enum_value_name = re.sub(r".*#define\s*", "", current_line)
     enum_value_name = enum_value_name.replace("\\","").replace("\n","").strip()
     
     # Read the file - unlike most functions, we actually advance file pointer


### PR DESCRIPTION
## Summary
- use a raw string literal for the `#define` regex in `.github/scripts/pre_doxygen.py`
- remove the invalid escape sequence `SyntaxWarning` on newer Python versions without changing the regex value

## Duplicate check
- No open PR or issue found for `pre_doxygen`.
- No open PR or issue found for `SyntaxWarning`.

## Validation
- `python -W error::SyntaxWarning -m py_compile .github/scripts/pre_doxygen.py`
- repository Python warning-as-error compile scan reports `TOTAL 0`
- `git diff --check`
- `git ls-files --eol .github/scripts/pre_doxygen.py`