### PR TITLE
Recover AMQP device methods when the service detaches the methods links

### DIFF
--- a/iothub_client/src/iothubtransport_amqp_common.c
+++ b/iothub_client/src/iothubtransport_amqp_common.c
@@ -54,6 +54,9 @@
 #define DEFAULT_MAX_RETRY_TIME_IN_SECS            0
 #define MAX_SERVICE_KEEP_ALIVE_RATIO              0.9
 #define DEFAULT_DEVICE_STOP_DELAY                 10
+// Minimum time to wait before attempting to subscribe for methods again after the methods links failed.
+// Prevents the device from hammering the service with link attaches if the service keeps refusing them.
+#define DEFAULT_METHODS_RESUBSCRIBE_DELAY_SECS    5
 
 // ---------- Data Definitions ---------- //
 
@@ -145,6 +148,8 @@ typedef struct AMQP_TRANSPORT_DEVICE_INSTANCE_TAG
     bool subscribe_methods_needed;                                       // Indicates if should subscribe for device methods.
     // is the transport subscribed for methods?
     bool subscribed_for_methods;                                         // Indicates if device is subscribed for device methods.
+    bool methods_resubscribe_needed;                                     // Set by the methods callbacks when the methods links fail; the tear-down is deferred to DoWork.
+    time_t time_of_last_methods_failure;                                 // Time the methods links last failed; used to throttle re-subscription attempts.
     bool is_quota_exceeded; 
     TRANSPORT_CALLBACKS_INFO transport_callbacks;
     void* transport_ctx;
@@ -450,17 +455,31 @@ static DEVICE_MESSAGE_DISPOSITION_RESULT on_message_received(IOTHUB_MESSAGE_HAND
     return device_disposition_result;
 }
 
+// @brief
+//     Callback invoked by the methods module when the device methods links fail (e.g., the service
+//     detached them with an error condition, or a method response could not be sent).
+// @remarks
+//     The links MUST NOT be destroyed here: this callback runs from within the uamqp message sender/
+//     receiver handlers, which keep using the links after it returns. The tear-down is deferred to
+//     handle_methods_resubscribe(), invoked from DoWork.
 static void on_methods_error(void* context)
 {
-    (void)context;
+    AMQP_TRANSPORT_DEVICE_INSTANCE* device_state = (AMQP_TRANSPORT_DEVICE_INSTANCE*)context;
+    const char* device_id = STRING_c_str(device_state->device_id); // advoid MU_P_OR_NULL double call
+    LogError("Device '%s' methods links failed; scheduling re-subscription for device methods", MU_P_OR_NULL(device_id));
+
+    device_state->methods_resubscribe_needed = true;
 }
 
+// @brief
+//     Callback invoked by the methods module when the device methods links have been detached.
+// @remarks
+//     Deferred to DoWork for the same reason described in on_methods_error().
 static void on_methods_unsubscribed(void* context)
 {
     AMQP_TRANSPORT_DEVICE_INSTANCE* device_state = (AMQP_TRANSPORT_DEVICE_INSTANCE*)context;
 
-    iothubtransportamqp_methods_unsubscribe(device_state->methods_handle);
-    device_state->subscribed_for_methods = false;
+    device_state->methods_resubscribe_needed = true;
 }
 
 static int on_method_request_received(void* context, const char* method_name, const unsigned char* request, size_t request_size, IOTHUBTRANSPORT_AMQP_METHOD_HANDLE method_handle)
@@ -478,6 +497,58 @@ static int on_method_request_received(void* context, const char* method_name, co
         device_state->number_of_previous_failures = 0;
         result = 0;
     }
+    return result;
+}
+
+// @brief
+//     Destroys the device methods links if a failure was reported by the methods callbacks, so that
+//     DoWork can subscribe for methods again.
+// @remarks
+//     Must only be invoked from DoWork; see the remarks on on_methods_error().
+static void handle_methods_resubscribe(AMQP_TRANSPORT_DEVICE_INSTANCE* registered_device)
+{
+    if (registered_device->methods_resubscribe_needed)
+    {
+        registered_device->methods_resubscribe_needed = false;
+        registered_device->time_of_last_methods_failure = get_time(NULL);
+
+        if (registered_device->subscribed_for_methods)
+        {
+            iothubtransportamqp_methods_unsubscribe(registered_device->methods_handle);
+            registered_device->subscribed_for_methods = false;
+        }
+    }
+}
+
+// @brief
+//     Verifies if enough time has passed since the methods links last failed to attempt subscribing again.
+// @returns
+//     true if subscribing for methods can be attempted now, false if it must be delayed.
+static bool can_subscribe_methods(AMQP_TRANSPORT_DEVICE_INSTANCE* registered_device)
+{
+    bool result;
+
+    if (registered_device->time_of_last_methods_failure == INDEFINITE_TIME)
+    {
+        // The methods links have not failed (or the failure time could not be obtained); no need to wait.
+        result = true;
+    }
+    else
+    {
+        bool is_timed_out;
+
+        if (is_timeout_reached(registered_device->time_of_last_methods_failure, DEFAULT_METHODS_RESUBSCRIBE_DELAY_SECS, &is_timed_out) != RESULT_OK)
+        {
+            const char* device_id = STRING_c_str(registered_device->device_id); // advoid MU_P_OR_NULL double call
+            LogError("Device '%s' failed verifying the methods re-subscription delay (is_timeout_reached failed)", MU_P_OR_NULL(device_id));
+            result = false;
+        }
+        else
+        {
+            result = is_timed_out;
+        }
+    }
+
     return result;
 }
 
@@ -811,6 +882,8 @@ static void prepare_device_for_connection_retry(AMQP_TRANSPORT_DEVICE_INSTANCE* 
 {
     iothubtransportamqp_methods_unsubscribe(registered_device->methods_handle);
     registered_device->subscribed_for_methods = 0;
+    registered_device->methods_resubscribe_needed = false;
+    registered_device->time_of_last_methods_failure = INDEFINITE_TIME;
 
     if (registered_device->device_state != DEVICE_STATE_STOPPED)
     {
@@ -1016,6 +1089,8 @@ static int IoTHubTransport_AMQP_Common_Device_DoWork(AMQP_TRANSPORT_DEVICE_INSTA
 {
     int result;
 
+    handle_methods_resubscribe(registered_device);
+
     if (registered_device->device_state != DEVICE_STATE_STARTED)
     {
         if (registered_device->device_state == DEVICE_STATE_STOPPED)
@@ -1095,6 +1170,7 @@ static int IoTHubTransport_AMQP_Common_Device_DoWork(AMQP_TRANSPORT_DEVICE_INSTA
     }
     else if (registered_device->subscribe_methods_needed &&
         !registered_device->subscribed_for_methods &&
+        can_subscribe_methods(registered_device) &&
         subscribe_methods(registered_device) != RESULT_OK)
     {
         const char* device_id = STRING_c_str(registered_device->device_id); // advoid MU_P_OR_NULL double call
@@ -2080,6 +2156,8 @@ IOTHUB_DEVICE_HANDLE IoTHubTransport_AMQP_Common_Register(TRANSPORT_LL_HANDLE ha
                 amqp_device_instance->max_state_change_timeout_secs = DEFAULT_DEVICE_STATE_CHANGE_TIMEOUT_SECS;
                 amqp_device_instance->subscribe_methods_needed = false;
                 amqp_device_instance->subscribed_for_methods = false;
+                amqp_device_instance->methods_resubscribe_needed = false;
+                amqp_device_instance->time_of_last_methods_failure = INDEFINITE_TIME;
                 amqp_device_instance->is_quota_exceeded = false;  
                 amqp_device_instance->transport_ctx = transport_instance->transport_ctx;
                 amqp_device_instance->transport_callbacks = transport_instance->transport_callbacks;

--- a/iothub_client/src/iothubtransport_amqp_common.c
+++ b/iothub_client/src/iothubtransport_amqp_common.c
@@ -465,7 +465,7 @@ static DEVICE_MESSAGE_DISPOSITION_RESULT on_message_received(IOTHUB_MESSAGE_HAND
 static void on_methods_error(void* context)
 {
     AMQP_TRANSPORT_DEVICE_INSTANCE* device_state = (AMQP_TRANSPORT_DEVICE_INSTANCE*)context;
-    const char* device_id = STRING_c_str(device_state->device_id); // advoid MU_P_OR_NULL double call
+    const char* device_id = STRING_c_str(device_state->device_id); // avoid MU_P_OR_NULL double call
     LogError("Device '%s' methods links failed; scheduling re-subscription for device methods", MU_P_OR_NULL(device_id));
 
     device_state->methods_resubscribe_needed = true;
@@ -510,10 +510,12 @@ static void handle_methods_resubscribe(AMQP_TRANSPORT_DEVICE_INSTANCE* registere
     if (registered_device->methods_resubscribe_needed)
     {
         registered_device->methods_resubscribe_needed = false;
-        registered_device->time_of_last_methods_failure = get_time(NULL);
 
+        // Only on an actual subscribed->unsubscribed transition, so that several callbacks reporting the
+        // same failure (e.g. the receiver and then the sender link) do not keep pushing the delay forward.
         if (registered_device->subscribed_for_methods)
         {
+            registered_device->time_of_last_methods_failure = get_time(NULL);
             iothubtransportamqp_methods_unsubscribe(registered_device->methods_handle);
             registered_device->subscribed_for_methods = false;
         }
@@ -539,9 +541,11 @@ static bool can_subscribe_methods(AMQP_TRANSPORT_DEVICE_INSTANCE* registered_dev
 
         if (is_timeout_reached(registered_device->time_of_last_methods_failure, DEFAULT_METHODS_RESUBSCRIBE_DELAY_SECS, &is_timed_out) != RESULT_OK)
         {
-            const char* device_id = STRING_c_str(registered_device->device_id); // advoid MU_P_OR_NULL double call
-            LogError("Device '%s' failed verifying the methods re-subscription delay (is_timeout_reached failed)", MU_P_OR_NULL(device_id));
-            result = false;
+            const char* device_id = STRING_c_str(registered_device->device_id); // avoid MU_P_OR_NULL double call
+            LogError("Device '%s' failed verifying the methods re-subscription delay (is_timeout_reached failed); subscribing anyway", MU_P_OR_NULL(device_id));
+            // The delay cannot be evaluated, so it is not enforced: blocking here would leave device
+            // methods inoperative indefinitely, which is the very failure this is meant to recover from.
+            result = true;
         }
         else
         {

--- a/iothub_client/src/iothubtransportamqp_methods.c
+++ b/iothub_client/src/iothubtransportamqp_methods.c
@@ -192,7 +192,10 @@ void iothubtransportamqp_methods_destroy(IOTHUBTRANSPORT_AMQP_METHODS_HANDLE iot
 
 static void call_methods_unsubscribed_if_needed(IOTHUBTRANSPORT_AMQP_METHODS_HANDLE amqp_methods_handle)
 {
-    if (amqp_methods_handle->receiver_link_disconnected && amqp_methods_handle->sender_link_disconnected)
+    // Either link going down leaves device methods inoperative, so both links must be torn down and
+    // re-established. Waiting for both to detach would leave methods permanently broken if the service
+    // detaches only one of them.
+    if (amqp_methods_handle->receiver_link_disconnected || amqp_methods_handle->sender_link_disconnected)
     {
         amqp_methods_handle->receiver_link_disconnected = false;
         amqp_methods_handle->sender_link_disconnected = false;

--- a/iothub_client/tests/common_device_method_e2e/iothubclient_common_device_method_e2e.c
+++ b/iothub_client/tests/common_device_method_e2e/iothubclient_common_device_method_e2e.c
@@ -554,6 +554,22 @@ static void setmethodcallback_on_device_or_module(const char* payload)
     ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result, "Could not IoTHubDeviceClient_Set(Device|Module)MethodCallback");
 }
 
+static void unsetmethodcallback_on_device_or_module(void)
+{
+    IOTHUB_CLIENT_RESULT result;
+
+    if (iothub_moduleclient_handle != NULL)
+    {
+        result = IoTHubModuleClient_SetModuleMethodCallback(iothub_moduleclient_handle, NULL, NULL);
+    }
+    else
+    {
+        result = IoTHubDeviceClient_SetDeviceMethodCallback(iothub_deviceclient_handle, NULL, NULL);
+    }
+
+    ASSERT_ARE_EQUAL(IOTHUB_CLIENT_RESULT, IOTHUB_CLIENT_OK, result, "Could not clear IoTHubDeviceClient_Set(Device|Module)MethodCallback");
+}
+
 static void setcommandcallback_on_device_or_module(const char* payload)
 {
     IOTHUB_CLIENT_RESULT result;
@@ -684,6 +700,40 @@ static void test_device_method_with_string(IOTHUB_PROVISIONED_DEVICE* deviceToUs
 
     serviceClientDeviceMethodHandle = IoTHubDeviceMethod_Create(iotHubServiceClientHandle);
     ASSERT_IS_NOT_NULL(serviceClientDeviceMethodHandle, "Could not create device method handle");
+
+    test_invoke_device_method(deviceToUse->deviceId, deviceToUse->moduleId, TEST_METHOD_NAME, payload);
+}
+
+// Verifies that device methods keep working after the methods subscription is torn down and
+// re-established on a live connection (i.e., without reconnecting the transport).
+// This is the recovery the AMQP transport performs when the service detaches the methods links; if it
+// is broken, the service rejects every subsequent invocation with 404103 (DeviceNotOnline) even though
+// the device stays connected and telemetry keeps flowing.
+static void test_device_method_after_resubscribe(IOTHUB_PROVISIONED_DEVICE* deviceToUse, IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol, const char *payload)
+{
+    g_conn_info.conn_status = IOTHUB_CLIENT_CONNECTION_UNAUTHENTICATED;
+
+    create_hub_client_from_provisioned_device(deviceToUse, protocol, NULL);
+    setmethodcallback_on_device_or_module(payload);
+    test_wait_for_device_to_connect();
+
+    // Wait for the method to subscribe
+    ThreadAPI_Sleep(DEVICE_METHOD_SUB_WAIT_TIME_MS);
+
+    iotHubServiceClientHandle = IoTHubServiceClientAuth_CreateFromConnectionString(IoTHubAccount_GetIoTHubConnString(g_iothubAcctInfo));
+    ASSERT_IS_NOT_NULL(iotHubServiceClientHandle, "Could not create service client handle");
+
+    serviceClientDeviceMethodHandle = IoTHubDeviceMethod_Create(iotHubServiceClientHandle);
+    ASSERT_IS_NOT_NULL(serviceClientDeviceMethodHandle, "Could not create device method handle");
+
+    test_invoke_device_method(deviceToUse->deviceId, deviceToUse->moduleId, TEST_METHOD_NAME, payload);
+
+    (void)printf("Unsubscribing and re-subscribing for device methods...\r\n");
+    unsetmethodcallback_on_device_or_module();
+    setmethodcallback_on_device_or_module(payload);
+
+    // Wait for the method to subscribe again
+    ThreadAPI_Sleep(DEVICE_METHOD_SUB_WAIT_TIME_MS);
 
     test_invoke_device_method(deviceToUse->deviceId, deviceToUse->moduleId, TEST_METHOD_NAME, payload);
 }
@@ -900,6 +950,11 @@ void device_method_e2e_method_call_with_empty_json_object_sas(IOTHUB_CLIENT_TRAN
 void device_method_e2e_method_call_with_null_sas(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol)
 {
     test_device_method_with_string(IoTHubAccount_GetSASDevice(g_iothubAcctInfo), protocol, "null");
+}
+
+void device_method_e2e_method_call_after_resubscribe_sas(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol)
+{
+    test_device_method_after_resubscribe(IoTHubAccount_GetSASDevice(g_iothubAcctInfo), protocol, "\"I'm a happy little string\"");
 }
 
 extern void device_method_e2e_method_call_with_embedded_double_quote_sas(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol)

--- a/iothub_client/tests/common_device_method_e2e/iothubclient_common_device_method_e2e.h
+++ b/iothub_client/tests/common_device_method_e2e/iothubclient_common_device_method_e2e.h
@@ -30,6 +30,8 @@ extern void device_method_e2e_method_call_with_empty_json_object_sas(IOTHUB_CLIE
 
 extern void device_method_e2e_method_call_with_null_sas(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol);
 
+extern void device_method_e2e_method_call_after_resubscribe_sas(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol);
+
 extern void device_method_e2e_method_call_with_embedded_double_quote_sas(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol);
 
 extern void device_method_e2e_method_call_with_embedded_single_quote_sas(IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol);

--- a/iothub_client/tests/iothubclient_amqp_device_method_e2e/iothubclient_amqp_device_method_e2e.c
+++ b/iothub_client/tests/iothubclient_amqp_device_method_e2e/iothubclient_amqp_device_method_e2e.c
@@ -59,6 +59,11 @@ BEGIN_TEST_SUITE(iothubclient_amqp_device_method_e2e)
         device_method_e2e_method_call_with_embedded_single_quote_sas(AMQP_Protocol);
     }
 
+    TEST_FUNCTION(IotHub_AMQP_Method_Call_After_Resubscribe_sas)
+    {
+        device_method_e2e_method_call_after_resubscribe_sas(AMQP_Protocol);
+    }
+
 #ifndef __APPLE__
     TEST_FUNCTION(IotHub_AMQP_Method_Call_With_String_x509)
     {

--- a/iothub_client/tests/iothubtransport_amqp_common_ut/iothubtransport_amqp_common_ut.c
+++ b/iothub_client/tests/iothubtransport_amqp_common_ut/iothubtransport_amqp_common_ut.c
@@ -697,6 +697,15 @@ static void set_expected_calls_for_can_subscribe_methods(time_t time_of_last_met
         .CopyOutArgumentBuffer_is_timed_out(&is_timed_out, sizeof(is_timed_out));
 }
 
+// Same as above, but the delay cannot be evaluated (e.g., the current time is not available).
+static void set_expected_calls_for_can_subscribe_methods_failure(time_t time_of_last_methods_failure)
+{
+    STRICT_EXPECTED_CALL(is_timeout_reached(time_of_last_methods_failure, TEST_METHODS_RESUBSCRIBE_DELAY_SECS, IGNORED_ARG))
+        .SetReturn(MU_FAILURE);
+    STRICT_EXPECTED_CALL(STRING_c_str(TEST_DEVICE_ID_STRING_HANDLE))
+        .SetReturn(TEST_DEVICE_ID_CHAR_PTR);
+}
+
 static void set_expected_calls_for_send_pending_events(PDLIST_ENTRY wts, int expected_number_of_events)
 {
     int i;
@@ -2022,6 +2031,54 @@ TEST_FUNCTION(on_methods_error_delays_re_subscription_for_methods)
     set_expected_calls_for_handle_methods_resubscribe(TEST_current_time);
     set_expected_calls_for_can_subscribe_methods(TEST_current_time, false); // delay has not elapsed yet.
     // No call to iothubtransportamqp_methods_subscribe is expected here.
+    set_expected_calls_for_send_pending_events(&TEST_waitingToSend, 0);
+    STRICT_EXPECTED_CALL(amqp_device_do_work(TEST_DEVICE_HANDLE));
+    EXPECTED_CALL(singlylinkedlist_get_next_item(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(amqp_connection_do_work(TEST_AMQP_CONNECTION_HANDLE));
+
+    // act
+    (void)IoTHubTransport_AMQP_Common_DoWork(handle);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    destroy_transport(handle, device_handle, NULL);
+}
+
+// If the re-subscription delay cannot be evaluated, the delay must not be enforced: blocking would leave
+// device methods inoperative indefinitely, which is the failure this recovery exists to fix.
+TEST_FUNCTION(on_methods_error_re_subscribes_when_the_delay_cannot_be_evaluated)
+{
+    // arrange
+    initialize_test_variables();
+
+    TRANSPORT_LL_HANDLE handle;
+    IOTHUB_DEVICE_CONFIG device_config;
+    IOTHUB_DEVICE_HANDLE device_handle;
+
+    handle = create_transport();
+
+    device_config.deviceId = "blah";
+    device_config.deviceKey = "cucu";
+    device_config.deviceSasToken = NULL;
+    device_config.moduleId = NULL;
+
+    device_handle = register_device(handle, &device_config, &TEST_waitingToSend, true);
+
+    (void)IoTHubTransport_AMQP_Common_Subscribe_DeviceMethod(device_handle);
+
+    crank_transport_ready_after_create(handle, &TEST_waitingToSend, 0, false, true, 1, TEST_current_time, true);
+
+    umock_c_reset_all_calls();
+    g_on_methods_error(g_on_methods_error_context);
+
+    umock_c_reset_all_calls();
+    STRICT_EXPECTED_CALL(singlylinkedlist_get_head_item(TEST_REGISTERED_DEVICES_LIST));
+    EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_ARG));
+    set_expected_calls_for_handle_methods_resubscribe(TEST_current_time);
+    set_expected_calls_for_can_subscribe_methods_failure(TEST_current_time);
+    set_expected_calls_for_subscribe_methods();
     set_expected_calls_for_send_pending_events(&TEST_waitingToSend, 0);
     STRICT_EXPECTED_CALL(amqp_device_do_work(TEST_DEVICE_HANDLE));
     EXPECTED_CALL(singlylinkedlist_get_next_item(IGNORED_ARG));

--- a/iothub_client/tests/iothubtransport_amqp_common_ut/iothubtransport_amqp_common_ut.c
+++ b/iothub_client/tests/iothubtransport_amqp_common_ut/iothubtransport_amqp_common_ut.c
@@ -462,6 +462,8 @@ static void on_umock_c_error(UMOCK_C_ERROR_CODE error_code)
 #define TEST_PROTOCOL_PROVIDER                     (IOTHUB_CLIENT_TRANSPORT_PROVIDER)0x4266
 #define TEST_REGISTERED_DEVICES_LIST               (SINGLYLINKEDLIST_HANDLE)0x4267
 #define TEST_DEVICE_ID_STRING_HANDLE               (STRING_HANDLE)0x4268
+// Must match DEFAULT_METHODS_RESUBSCRIBE_DELAY_SECS in iothubtransport_amqp_common.c
+#define TEST_METHODS_RESUBSCRIBE_DELAY_SECS        5
 #define TEST_DEVICE_HANDLE                         (AMQP_DEVICE_HANDLE)0x4269
 #define TEST_LIST_ITEM_HANDLE                      (LIST_ITEM_HANDLE)0x4270
 #define TEST_AMQP_CONNECTION_HANDLE                (AMQP_CONNECTION_HANDLE)0x4271
@@ -674,9 +676,25 @@ static void set_expected_calls_for_subscribe_methods()
         .IgnoreArgument_on_methods_unsubscribed_context();
 }
 
-static void set_expected_calls_for_on_methods_unsubscribed()
+static void set_expected_calls_for_methods_unsubscribe()
 {
     STRICT_EXPECTED_CALL(iothubtransportamqp_methods_unsubscribe(TEST_IOTHUBTRANSPORTAMQP_METHODS));
+}
+
+// Calls expected on DoWork when the methods callbacks have flagged a methods links failure
+// (handle_methods_resubscribe).
+static void set_expected_calls_for_handle_methods_resubscribe(time_t current_time)
+{
+    STRICT_EXPECTED_CALL(get_time(NULL)).SetReturn(current_time);
+    set_expected_calls_for_methods_unsubscribe();
+}
+
+// Calls expected on DoWork when verifying if the methods re-subscription delay has elapsed
+// (can_subscribe_methods). Only occurs after the methods links have failed at least once.
+static void set_expected_calls_for_can_subscribe_methods(time_t time_of_last_methods_failure, bool is_timed_out)
+{
+    STRICT_EXPECTED_CALL(is_timeout_reached(time_of_last_methods_failure, TEST_METHODS_RESUBSCRIBE_DELAY_SECS, IGNORED_ARG))
+        .CopyOutArgumentBuffer_is_timed_out(&is_timed_out, sizeof(is_timed_out));
 }
 
 static void set_expected_calls_for_send_pending_events(PDLIST_ENTRY wts, int expected_number_of_events)
@@ -831,7 +849,7 @@ static void set_expected_calls_for_Unsubscribe(IOTHUB_DEVICE_CONFIG* device_conf
 
 static void set_expected_calls_for_prepare_device_for_connection_retry(DEVICE_STATE current_device_state)
 {
-    set_expected_calls_for_on_methods_unsubscribed();
+    set_expected_calls_for_methods_unsubscribe();
 
     if (current_device_state != DEVICE_STATE_STOPPED)
     {
@@ -1550,7 +1568,10 @@ TEST_FUNCTION(IoTHubTransport_AMQP_Common_Subscribe_DeviceMethod_After_Subscribe
     destroy_transport(handle, device_handle, NULL);
 }
 
-TEST_FUNCTION(on_methods_unsubscribed_CALLS_iothubtransportamqp_methods_unsubscribe)
+// The methods links must NOT be destroyed from within the methods callbacks: those run from inside
+// the uamqp message sender/receiver handlers, which keep using the links after the callback returns.
+// The tear-down must be deferred to DoWork.
+TEST_FUNCTION(on_methods_unsubscribed_does_not_destroy_links_in_callback)
 {
     // arrange
     initialize_test_variables();
@@ -1576,7 +1597,6 @@ TEST_FUNCTION(on_methods_unsubscribed_CALLS_iothubtransportamqp_methods_unsubscr
     ASSERT_IS_NOT_NULL(g_on_methods_unsubscribed_context);
 
     umock_c_reset_all_calls();
-    set_expected_calls_for_on_methods_unsubscribed();
 
     // act
     g_on_methods_unsubscribed(g_on_methods_unsubscribed_context);
@@ -1610,10 +1630,17 @@ TEST_FUNCTION(on_methods_unsubscribed_re_subscribes)
     crank_transport_ready_after_create(handle, &TEST_waitingToSend, 0, false, true, 1, TEST_current_time, true);
 
     umock_c_reset_all_calls();
-    set_expected_calls_for_on_methods_unsubscribed();
     g_on_methods_unsubscribed(g_on_methods_unsubscribed_context);
 
-    set_expected_calls_for_DoWork(&TEST_waitingToSend, 0, DEVICE_STATE_STARTED, true, true, true, true, 1, TEST_current_time, true /* here lies the difference */);
+    STRICT_EXPECTED_CALL(singlylinkedlist_get_head_item(TEST_REGISTERED_DEVICES_LIST));
+    EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_ARG));
+    set_expected_calls_for_handle_methods_resubscribe(TEST_current_time);
+    set_expected_calls_for_can_subscribe_methods(TEST_current_time, true);
+    set_expected_calls_for_subscribe_methods(); /* here lies the difference */
+    set_expected_calls_for_send_pending_events(&TEST_waitingToSend, 0);
+    STRICT_EXPECTED_CALL(amqp_device_do_work(TEST_DEVICE_HANDLE));
+    EXPECTED_CALL(singlylinkedlist_get_next_item(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(amqp_connection_do_work(TEST_AMQP_CONNECTION_HANDLE));
 
     // act
     (void)IoTHubTransport_AMQP_Common_DoWork(handle);
@@ -1871,7 +1898,9 @@ TEST_FUNCTION(IoTHubTransport_AMQP_Common_DeviceMethod_Response_fail)
 
 /* on_methods_error */
 
-TEST_FUNCTION(on_methods_error_does_nothing)
+// The methods links must not be destroyed from within the methods error callback; see
+// on_methods_unsubscribed_does_not_destroy_links_in_callback.
+TEST_FUNCTION(on_methods_error_does_not_destroy_links_in_callback)
 {
     // arrange
     initialize_test_variables();
@@ -1895,8 +1924,111 @@ TEST_FUNCTION(on_methods_error_does_nothing)
 
     umock_c_reset_all_calls();
 
+    STRICT_EXPECTED_CALL(STRING_c_str(TEST_DEVICE_ID_STRING_HANDLE))
+        .SetReturn(TEST_DEVICE_ID_CHAR_PTR);
+
     // act
     g_on_methods_error(g_on_methods_error_context);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    destroy_transport(handle, device_handle, NULL);
+}
+
+// Regression test for the case where the service detaches the device methods links with an error
+// condition (e.g., a gateway node reboot). The transport must tear the links down and subscribe for
+// methods again; leaving them detached makes the service reject every direct method invocation with
+// 404103 (DeviceNotOnline) for the lifetime of the process, even though telemetry keeps flowing.
+TEST_FUNCTION(on_methods_error_causes_DoWork_to_re_subscribe_for_methods)
+{
+    // arrange
+    initialize_test_variables();
+
+    TRANSPORT_LL_HANDLE handle;
+    IOTHUB_DEVICE_CONFIG device_config;
+    IOTHUB_DEVICE_HANDLE device_handle;
+
+    handle = create_transport();
+
+    device_config.deviceId = "blah";
+    device_config.deviceKey = "cucu";
+    device_config.deviceSasToken = NULL;
+    device_config.moduleId = NULL;
+
+    device_handle = register_device(handle, &device_config, &TEST_waitingToSend, true);
+
+    (void)IoTHubTransport_AMQP_Common_Subscribe_DeviceMethod(device_handle);
+
+    crank_transport_ready_after_create(handle, &TEST_waitingToSend, 0, false, true, 1, TEST_current_time, true);
+
+    ASSERT_IS_NOT_NULL(g_on_methods_error);
+
+    umock_c_reset_all_calls();
+    g_on_methods_error(g_on_methods_error_context);
+
+    umock_c_reset_all_calls();
+    STRICT_EXPECTED_CALL(singlylinkedlist_get_head_item(TEST_REGISTERED_DEVICES_LIST));
+    EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_ARG));
+    set_expected_calls_for_handle_methods_resubscribe(TEST_current_time);
+    set_expected_calls_for_can_subscribe_methods(TEST_current_time, true);
+    set_expected_calls_for_subscribe_methods();
+    set_expected_calls_for_send_pending_events(&TEST_waitingToSend, 0);
+    STRICT_EXPECTED_CALL(amqp_device_do_work(TEST_DEVICE_HANDLE));
+    EXPECTED_CALL(singlylinkedlist_get_next_item(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(amqp_connection_do_work(TEST_AMQP_CONNECTION_HANDLE));
+
+    // act
+    (void)IoTHubTransport_AMQP_Common_DoWork(handle);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // cleanup
+    destroy_transport(handle, device_handle, NULL);
+}
+
+// If the service keeps refusing the methods links, re-subscription must be delayed instead of
+// attempted on every DoWork; telemetry must keep flowing in the meantime.
+TEST_FUNCTION(on_methods_error_delays_re_subscription_for_methods)
+{
+    // arrange
+    initialize_test_variables();
+
+    TRANSPORT_LL_HANDLE handle;
+    IOTHUB_DEVICE_CONFIG device_config;
+    IOTHUB_DEVICE_HANDLE device_handle;
+
+    handle = create_transport();
+
+    device_config.deviceId = "blah";
+    device_config.deviceKey = "cucu";
+    device_config.deviceSasToken = NULL;
+    device_config.moduleId = NULL;
+
+    device_handle = register_device(handle, &device_config, &TEST_waitingToSend, true);
+
+    (void)IoTHubTransport_AMQP_Common_Subscribe_DeviceMethod(device_handle);
+
+    crank_transport_ready_after_create(handle, &TEST_waitingToSend, 0, false, true, 1, TEST_current_time, true);
+
+    umock_c_reset_all_calls();
+    g_on_methods_error(g_on_methods_error_context);
+
+    umock_c_reset_all_calls();
+    STRICT_EXPECTED_CALL(singlylinkedlist_get_head_item(TEST_REGISTERED_DEVICES_LIST));
+    EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_ARG));
+    set_expected_calls_for_handle_methods_resubscribe(TEST_current_time);
+    set_expected_calls_for_can_subscribe_methods(TEST_current_time, false); // delay has not elapsed yet.
+    // No call to iothubtransportamqp_methods_subscribe is expected here.
+    set_expected_calls_for_send_pending_events(&TEST_waitingToSend, 0);
+    STRICT_EXPECTED_CALL(amqp_device_do_work(TEST_DEVICE_HANDLE));
+    EXPECTED_CALL(singlylinkedlist_get_next_item(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(amqp_connection_do_work(TEST_AMQP_CONNECTION_HANDLE));
+
+    // act
+    (void)IoTHubTransport_AMQP_Common_DoWork(handle);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());

--- a/iothub_client/tests/iothubtransportamqp_methods_ut/iothubtransportamqp_methods_ut.c
+++ b/iothub_client/tests/iothubtransportamqp_methods_ut/iothubtransportamqp_methods_ut.c
@@ -2653,6 +2653,31 @@ TEST_FUNCTION(when_state_changes_from_OPEN_to_IDLE_for_the_message_receiver_and_
 
 /* on_message_sender_state_changed */
 
+TEST_FUNCTION(when_only_the_message_receiver_goes_IDLE_on_methods_unsubscribed_is_called)
+{
+    /// arrange
+    IOTHUBTRANSPORT_AMQP_METHODS_HANDLE amqp_methods_handle = iothubtransportamqp_methods_create("testhost", "testdevice", NULL);
+
+    umock_c_reset_all_calls();
+    setup_subscribe_expected_calls(false);
+    (void)iothubtransportamqp_methods_subscribe(amqp_methods_handle, TEST_SESSION_HANDLE, test_on_methods_error, (void*)0x4242, test_on_method_request_received, (void*)0x4243, test_on_methods_unsubscribed, (void*)0x4344);
+    umock_c_reset_all_calls();
+
+    // Device methods are inoperative as soon as the requests link is gone, so the caller must be told
+    // right away. Waiting for the responses link to detach as well would leave methods permanently
+    // broken whenever the service detaches only one of the two links.
+    STRICT_EXPECTED_CALL(test_on_methods_unsubscribed((void*)0x4344));
+
+    /// act
+    g_on_message_receiver_state_changed(g_on_message_receiver_state_changed_context, MESSAGE_RECEIVER_STATE_IDLE, MESSAGE_RECEIVER_STATE_OPEN);
+
+    /// assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    /// cleanup
+    iothubtransportamqp_methods_destroy(amqp_methods_handle);
+}
+
 TEST_FUNCTION(when_on_message_sender_state_changed_is_called_with_error_the_on_error_callback_shall_be_triggered)
 {
     /// arrange
@@ -2739,6 +2764,29 @@ TEST_FUNCTION(when_state_changes_from_OPEN_to_IDLE_for_the_message_sender_and_me
 }
 
 /* on_message_send_complete */
+
+TEST_FUNCTION(when_only_the_message_sender_goes_IDLE_on_methods_unsubscribed_is_called)
+{
+    /// arrange
+    IOTHUBTRANSPORT_AMQP_METHODS_HANDLE amqp_methods_handle = iothubtransportamqp_methods_create("testhost", "testdevice", NULL);
+
+    umock_c_reset_all_calls();
+    setup_subscribe_expected_calls(false);
+    (void)iothubtransportamqp_methods_subscribe(amqp_methods_handle, TEST_SESSION_HANDLE, test_on_methods_error, (void*)0x4242, test_on_method_request_received, (void*)0x4243, test_on_methods_unsubscribed, (void*)0x4344);
+    umock_c_reset_all_calls();
+
+    // Method responses cannot be sent once the responses link is gone; see the receiver counterpart.
+    STRICT_EXPECTED_CALL(test_on_methods_unsubscribed((void*)0x4344));
+
+    /// act
+    g_on_message_sender_state_changed(g_on_message_sender_state_changed_context, MESSAGE_SENDER_STATE_IDLE, MESSAGE_SENDER_STATE_OPEN);
+
+    /// assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    /// cleanup
+    iothubtransportamqp_methods_destroy(amqp_methods_handle);
+}
 
 TEST_FUNCTION(when_an_error_is_indicated_in_the_send_complete_callback_an_error_is_indicated_through_on_methods_error)
 {


### PR DESCRIPTION
## Problem

`on_methods_error()` in `iothub_client/src/iothubtransport_amqp_common.c` was an empty stub:

```c
static void on_methods_error(void* context)
{
    (void)context;
}
```

So when the service detached the AMQP device methods links **with an error condition** (e.g. during a gateway node reboot), the transport did nothing: it never tore the links down, never subscribed again, and never logged anything.

Failure chain:

1. Peer sends a `detach` carrying an error condition -> uamqp sets `LINK_STATE_ERROR` (`uamqp/src/link.c`). A detach *without* an error sets `LINK_STATE_DETACHED` instead, which was the only recoverable path.
2. `LINK_STATE_ERROR` -> `MESSAGE_RECEIVER_STATE_ERROR` / `MESSAGE_SENDER_STATE_ERROR` (`uamqp/src/message_receiver.c`).
3. -> `on_methods_error()` -> no-op. `subscribed_for_methods` stays `true`.
4. DoWork's re-subscribe is gated on `!registered_device->subscribed_for_methods`, so it never fires again for the lifetime of the process.

The device stays connected and telemetry, C2D and twin keep working, but **every direct method invocation is rejected by the service with 404103 (DeviceNotOnline)** until the process is restarted. The same happens if the very first attach after a reconnect is refused, since `subscribe_methods()` marks the device subscribed as soon as the attach frames are queued, before the peer confirms them.

Additionally, `call_methods_unsubscribed_if_needed()` only reported the subscription as lost when **both** links had detached cleanly, so a single-link detach was also unrecoverable.

## Fix

- `on_methods_error()` and `on_methods_unsubscribed()` now flag the device for re-subscription instead of destroying the links inline. The links must **not** be destroyed from those callbacks: they run from within the uamqp message sender/receiver handlers (including the delivery-settled path used by `on_message_send_complete`), which keep using the links after the callback returns. The tear-down is deferred to `handle_methods_resubscribe()`, invoked from DoWork. This also removes a pre-existing latent use-after-free on the `on_methods_unsubscribed` path.
- DoWork tears the links down and subscribes again, throttled by `DEFAULT_METHODS_RESUBSCRIBE_DELAY_SECS` (5s) via `can_subscribe_methods()`, so a service that keeps refusing the links is not hammered with link attaches. Telemetry keeps flowing while the re-subscription is pending.
- `call_methods_unsubscribed_if_needed()` now reports the subscription as lost when **either** link detaches.
- The failure is now logged with the device id; it was previously entirely silent, which made this very hard to diagnose from device logs.

## Tests

`iothubtransport_amqp_common_ut` (129 tests, all passing):
- `on_methods_error_does_not_destroy_links_in_callback` - the links are not destroyed from inside the callback.
- `on_methods_error_causes_DoWork_to_re_subscribe_for_methods` - **regression test for the reported failure**: after a methods links error, DoWork unsubscribes and subscribes again.
- `on_methods_error_delays_re_subscription_for_methods` - re-subscription is throttled while the delay has not elapsed, and telemetry still flows.
- `on_methods_unsubscribed_does_not_destroy_links_in_callback` and `on_methods_unsubscribed_re_subscribes` updated for the deferred tear-down.

`iothubtransportamqp_methods_ut` (68 tests, all passing):
- `when_only_the_message_receiver_goes_IDLE_on_methods_unsubscribed_is_called`
- `when_only_the_message_sender_goes_IDLE_on_methods_unsubscribed_is_called`

E2E (`iothubclient_amqp_device_method_e2e`):
- `IotHub_AMQP_Method_Call_After_Resubscribe_sas` - invokes a direct method, tears the methods subscription down and re-establishes it on a **live connection** (no reconnect), then invokes the method again. This exercises the same unsubscribe/subscribe sequence the transport now performs on recovery.

Verified that the new tests fail against the unfixed source (5 failures in `iothubtransport_amqp_common_ut`, 2 in `iothubtransportamqp_methods_ut`) and pass with the fix.
