### PR TITLE
horton-c-gate: skip the SDK checkout in create_azure_resources

### DIFF
--- a/build/.horton-e2e.yml
+++ b/build/.horton-e2e.yml
@@ -21,6 +21,10 @@ stages:
     pool:
       vmImage: 'windows-latest'
     steps:
+    # create_azure_resources only needs the e2e-fx framework, not this SDK.
+    # `self` here is azure-iot-sdk-c, whose recursive submodule graph exceeds
+    # MAX_PATH on the windows-latest agent and fails the implicit checkout.
+    - checkout: none
     - template: vsts/templates/steps-create-azure-resources.yaml@e2e_fx
 
 - stage: build_and_test


### PR DESCRIPTION
The nightly C gate (ADO definition 204) has failed every run since 2026-08-07 — builds [161530](https://dev.azure.com/azure-iot-sdks/azure-iot-sdks/_build/results?buildId=161530), 161551, 161565, 161581, [161591](https://dev.azure.com/azure-iot-sdks/azure-iot-sdks/_build/results?buildId=161591) — and it never reaches a test. The `setup` stage dies in the auto-injected checkout:

```
##[error]Git submodule update failed with exit code: 1
```

underneath which git reports:

```
fatal: cannot write keep file 'D:/a/1/s/.git/modules/azure-umqtt-c/modules/deps/c-utility/
modules/deps/umock-c/modules/deps/c-testrunnerswitcher/modules/deps/ctest/modules/deps/
c-logging/modules/deps/macro-utils-c/modules/deps/c-build-tools/objects/pack/
pack-<sha>.keep': Filename too long
fatal: '$GIT_DIR' too big
```

That is roughly 270 characters, against a `MAX_PATH` of 260. The `setup` stage failing takes the `test_config` artifact with it, so `build_and_test` and `cleanup` fail too, and the summary points at "Destroy Azure Resource Group" rather than at the checkout.

## Why now

Nothing in this repository changed. iot-sdks-e2e-fx [`69468cc`](https://github.com/Azure/iot-sdks-e2e-fx/commit/69468cc717a336374cf780ea15c7700206efa908) removed

```yaml
- checkout: none
```

from `vsts/templates/steps-create-azure-resources.yaml`, and this pipeline consumes that template from `refs/heads/master`, so the next nightly picked it up. The last green run of the job, 161454, shows `Checkout` as **skipped**; 161530 onward runs it in full.

The removal is right for the pipelines that live in iot-sdks-e2e-fx — there `self` is iot-sdks-e2e-fx, which is exactly what the job needs. But this pipeline's `self` is azure-iot-sdk-c, and definition 204 has `checkoutNestedSubmodules` enabled. So the job began recursively cloning the whole submodule graph of an SDK it does not use: `create_azure_resources` imports `Azure.Iot.Sdk.Test.psm1` from `Horton.FrameworkRoot` and provisions an IoT Hub. It reads nothing from this repository.

The graph only recently got deep enough to matter. #2724 moved c-utility, uamqp and umqtt to masters that carry their own `deps/` chains, so `umqtt/deps/c-utility/deps/umock-c/deps/c-testrunnerswitcher/deps/ctest/deps/c-logging/deps/macro-utils-c` is now reachable, and `.git/modules` doubles every segment. A Linux agent would not notice; this job runs on `windows-latest`.

## The change

```yaml
   - job: create_azure_resources
     pool:
       vmImage: 'windows-latest'
     steps:
+    - checkout: none
     - template: vsts/templates/steps-create-azure-resources.yaml@e2e_fx
```

Restoring `checkout: none` here, rather than reverting it in iot-sdks-e2e-fx, keeps that fix intact: the consumer is the only place that knows what `self` is. `steps-ensure-e2e-fx-repo.yaml` then takes its clone path, which this pipeline already satisfies — `Horton.FrameworkRef` is set to `master` at the top of the file, so the guard added alongside the removal is met.

The other language gates consume the same template with their own repo as `self` and will want the same one-liner, but only C has submodules deep enough to fail rather than merely waste a clone.

## Not in scope

Two earlier reds on this pipeline were unrelated and are already fixed upstream: 161454 failed in "Create new identites and deploy containers" because azure-iot 0.32.0b1 returned the *device* hostname for the `iothubowner` connection string, and 161294 failed in "build docker image c".

## Validation

The gate build on this PR exercises the change directly: `create_azure_resources` should complete without a checkout step and publish `test_config`.
