### PR TITLE
Make CodeQL opt-in per job instead of auto-injected everywhere

### DIFF
--- a/build/.horton-e2e.yml
+++ b/build/.horton-e2e.yml
@@ -5,6 +5,11 @@ variables:
   Horton.Repo: $(Build.Repository.Uri)
   Horton.Commit: $(Build.SourceBranch)
   Horton.ForcedImage: ''
+  # This is an e2e gate, not the SDL scanning pipeline. Auto-injected CodeQL here
+  # was uploading incidental python/javascript/powershell/iac databases that
+  # displaced the ones produced by build/.vsts-ci.yml, which is where the SDL
+  # snapshot for this repo is owned. See https://aka.ms/codeql3000.
+  Codeql.Enabled: false
 
 resources:
   repositories:

--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -8,13 +8,24 @@ variables:
   CCACHE_UMASK: '000'
   DEFAULT_AZURE_LOCATION: centraluseuap
   AZURE_LOCATION_EFFECTIVE: $[ coalesce(variables['AZURE_LOCATION'], variables['DEFAULT_AZURE_LOCATION']) ]
+  # CodeQL is auto-injected into every job by the 1ES policy decorator. Turn it
+  # off globally here and opt in per job, because S360 records the *latest*
+  # snapshot per (repo, language) - so a database produced incidentally by a
+  # cross-compile or test job silently replaces the one produced by the job that
+  # actually builds the product. Exactly two jobs opt back in, and together they
+  # cover every language this repo is graded on
+  # (Microsoft.Security.CodeQL.10000: cpp, csharp, python):
+  #   windowsx64release -> cpp     (full x64 Release build of the SDK)
+  #   DotNET            -> csharp, python
+  # Leaving injection on elsewhere also cost ~102 agent-minutes per run in
+  # Init/Finalize alone, on top of the build-tracer overhead inside each build.
+  # See https://aka.ms/codeql3000 and https://aka.ms/sdlfaqcodeql.
+  Codeql.Enabled: false
 
 stages:
 - stage: Requirements
   jobs:
   - job: checksubmodule
-    variables:
-      CodeQL.Enabled: false
     pool:
       vmImage: 'ubuntu-24.04'
     displayName: "Check Submodules"
@@ -166,8 +177,10 @@ stages:
   - job: windowsx64release
     timeoutInMinutes: 190
     variables:
-      CodeQL.Enabled: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
-      CodeQL.Language: cpp
+      # Owns the 'cpp' CodeQL snapshot for this repo. Overrides the pipeline-level
+      # Codeql.Enabled: false. Only on main, so PR builds stay fast.
+      Codeql.Enabled: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
+      Codeql.Language: cpp
     pool:
       vmImage: 'windows-2022'
     displayName: 'Windows x64 (Release)'
@@ -1158,8 +1171,6 @@ stages:
       condition: succeededOrFailed()
 
   - job: OSX
-    variables:
-      CodeQL.Enabled: false
     pool:
       vmImage: 'macOS-14'
     displayName: 'OSX'
@@ -1192,8 +1203,6 @@ stages:
       condition: always()
 
   - job: xcodenative
-    variables:
-      CodeQL.Enabled: false
     pool:
       vmImage: 'macOS-14'
     displayName: 'Xcode Native'
@@ -1231,6 +1240,10 @@ stages:
   - job: DotNET
     displayName: '.NET'
     variables:
+      # Owns the 'csharp' and 'python' CodeQL snapshots for this repo. csharp comes
+      # from tracing the traceabilitytool build below; python is an interpreted
+      # language, so CodeQL extracts it straight from the checked-out sources.
+      # Overrides the pipeline-level Codeql.Enabled: false.
       Codeql.Enabled: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
       Codeql.Language: csharp,python
     pool:

--- a/build/arduino-esp.yml
+++ b/build/arduino-esp.yml
@@ -1,5 +1,10 @@
 name: $(BuildID)_$(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 
+variables:
+  # Device-lab build only; the SDL CodeQL snapshot is produced by
+  # build/.vsts-ci.yml. See https://aka.ms/codeql3000.
+  Codeql.Enabled: false
+
 jobs:
 - job: test_esp8266
   pool:

--- a/build/linux_back_compat.yml
+++ b/build/linux_back_compat.yml
@@ -2,6 +2,9 @@ name: $(BuildID)_$(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Re
 
 variables:
   runCodesignValidationInjection: false
+  # Back-compat build only; the SDL CodeQL snapshot is produced by
+  # build/.vsts-ci.yml. See https://aka.ms/codeql3000.
+  Codeql.Enabled: false
 resources:
   containers:
   - container: linux-c-ubuntu-2004

--- a/build/longhaul.vsts-ci.yml
+++ b/build/longhaul.vsts-ci.yml
@@ -3,6 +3,9 @@ variables:
   runCodesignValidationInjection: false
   iotHubLonghaulTotalDurationSecs: 43200
   iotHubLonghaulLoopDurationSecs: 60
+  # Longhaul runs for hours; the SDL CodeQL snapshot is produced by
+  # build/.vsts-ci.yml. See https://aka.ms/codeql3000.
+  Codeql.Enabled: false
 resources:
   containers:
   - container: linux-c-ubuntu-2004


### PR DESCRIPTION
## Problem

The 1ES policy decorator injects CodeQL into **every** job of `build/.vsts-ci.yml`. In build [161548](https://dev.azure.com/azure-iot-sdks/azure-iot-sdks/_build/results?buildId=161548) that was **33 jobs / 66 Init+Finalize tasks = ~102 agent-minutes per run**, before counting the build-tracer overhead inside each build step (Windows x64 Debug 25.7 min and x86 25.3 min were spent in injected CodeQL alone).

The cost is the smaller half of the problem. S360 records `arg_max(SnapshotDate)` per `(repo, language)`, so **a database produced incidentally by a job that does not build the product silently replaces the one from the job that does**:

- the recorded `cpp` database came from the **Raspberry Pi cross-compile** job, not the full x64 Release build;
- the recorded `python` database came from **horton-c-gate**, the e2e gate;
- incidental databases for `actions`, `iac`, `javascript` and `powershell` were uploaded as well.

That accidental-coverage pattern is exactly the failure mode already visible on the sibling SDK repos in S360 (*"Database failed to finalize or no source code was built!"*).

## Change

Turn CodeQL off at pipeline level and opt back in on the two jobs that deliberately build for it. Together they cover every language this repo is graded on for `Microsoft.Security.CodeQL.10000`:

| Job | `Codeql.Language` |
| --- | --- |
| `windowsx64release` | `cpp` (full x64 Release build of the SDK) |
| `DotNET` | `csharp,python` |

Both jobs already upload successfully today (build 161548: cpp `3f642507`, csharp `7b6df039`, python `fdaf57e4`), so this only removes the competing uploads. Job-level variables override the pipeline-level default and stay gated on `refs/heads/main`, so PR builds are unaffected.

Injection is also disabled in the pipelines that are not the SDL scanning pipeline: `.horton-e2e.yml`, `longhaul.vsts-ci.yml`, `linux_back_compat.yml`, `arduino-esp.yml`. The now-redundant per-job `CodeQL.Enabled: false` entries on `checksubmodule`, `OSX` and `xcodenative` were removed.

## Verification

- All five YAML files parse.
- With `Enabled = false` the injected task still appears in the timeline but no-ops in ~20 s (confirmed from the `OSX` job log, which already used this opt-out).
- Default `Cadence = 72` hours, so the daily `C-canary` (def 86) and weekday `C-production` (def 85) runs produce a snapshot roughly every 3 days -- comfortably inside the 30-day recurrent SLA.
- Graded languages come from `set_intersect(LanguagesCodeQL, Languages)` = `cpp, csharp, python`; `java`/`javascript` are reported by CodeQL for this repo but are not graded.

## Trade-off

The two opted-in jobs become load-bearing: if either fails, that language has no accidental fallback. This is intended -- a partial cross-compile database is worse than a missing one, because it goes green in S360 while covering only a fraction of the code.

Related: [AB#39214253](https://dev.azure.com/msazure/One/_workitems/edit/39214253)
