### PR TITLE
docs: fix two typos

### DIFF
--- a/doc/Docker_SDK_Cross_Compile.md
+++ b/doc/Docker_SDK_Cross_Compile.md
@@ -208,7 +208,7 @@ include_directories(${OPENSSL_INCLUDE_DIR})
 target_link_libraries(myapp iothub_client prov_device_client iothub_client_mqtt_transport prov_auth_client umqtt hsm_security_client utpm dl aziotsharedutil parson pthread curl OpenSSL::SSL OpenSSL::Crypto m )
 ```
 ### Using a Separate Docker Script to Build the Application
-Though one could append the application build steps to the Docker script above, this will demonstrate how to use the existing image and build the application in a seperate Docker script. This will keep the original image clean so it may be used for building multiple applications.
+Though one could append the application build steps to the Docker script above, this will demonstrate how to use the existing image and build the application in a separate Docker script. This will keep the original image clean so it may be used for building multiple applications.
 
 This sample script assumes you have your source files and the ```CMakeLists.txt``` in a directory called ```myapp```.
 ```docker

--- a/provisioning_client/devdoc/using_provisioning_client.md
+++ b/provisioning_client/devdoc/using_provisioning_client.md
@@ -78,7 +78,7 @@ To enroll a device in the azure portal you will need to either get the Registrat
 
 ### Provisioning Samples
 
-There are two provisioning samples in the SDK and two HSM samples.  The provisioning samples, `prov_dev_client_ll_sample` and `prov_dev_client_sample` show how to use the provisioning client to connect to DPS and recieve your IoTHub credentials.  The HSM samples include `iothub_client_sample_hsm`, which shows the us of the IoThub device client on an previously provisioned device and `custom_hsm_example`, which shows how to create a sample hsm to be used along side the provisioning client.
+There are two provisioning samples in the SDK and two HSM samples.  The provisioning samples, `prov_dev_client_ll_sample` and `prov_dev_client_sample` show how to use the provisioning client to connect to DPS and receive your IoTHub credentials.  The HSM samples include `iothub_client_sample_hsm`, which shows the us of the IoThub device client on an previously provisioned device and `custom_hsm_example`, which shows how to create a sample hsm to be used along side the provisioning client.
 
 The `prov_dev_client_ll_sample` version uses a non-threaded version of the api and the `prov_dev_client_sample` uses the threaded api version.  Before compiling the samples you must make modifications to the c files to get provisioning to work correctly.
 


### PR DESCRIPTION
Two typo fixes:

- `doc/Docker_SDK_Cross_Compile.md:211` — `seperate` → `separate`
- `provisioning_client/devdoc/using_provisioning_client.md:81` — `recieve` → `receive`

Docs only.
