### PR TITLE
[lts_03_2025] Use safe_add_size_t when sizing DPS transport response buffers (backport of #2738)

### DIFF
--- a/build/.horton-e2e.yml
+++ b/build/.horton-e2e.yml
@@ -5,6 +5,11 @@ variables:
   Horton.Repo: $(Build.Repository.Uri)
   Horton.Commit: $(Build.SourceBranch)
   Horton.ForcedImage: ''
+  # This is an e2e gate, not the SDL scanning pipeline. Auto-injected CodeQL here
+  # was uploading incidental python/javascript/powershell/iac databases that
+  # displaced the ones produced by build/.vsts-ci.yml, which is where the SDL
+  # snapshot for this repo is owned. See https://aka.ms/codeql3000.
+  Codeql.Enabled: false
 
 resources:
   repositories:
@@ -12,9 +17,35 @@ resources:
     type: github
     name: Azure/iot-sdks-e2e-fx
     ref: refs/heads/master
-    endpoint: 'GitHub OAuth - az-iot-builder-01'
+    endpoint: 'azure-iot-sdk-python-github'
 
-jobs:
-- template: vsts/templates/jobs-gate-c.yaml@e2e_fx
+stages:
+- stage: setup
+  jobs:
+  - job: create_azure_resources
+    pool:
+      vmImage: 'windows-latest'
+    steps:
+    # create_azure_resources only needs the e2e-fx framework, not this SDK.
+    # `self` here is azure-iot-sdk-c, whose recursive submodule graph exceeds
+    # MAX_PATH on the windows-latest agent and fails the implicit checkout.
+    - checkout: none
+    - template: vsts/templates/steps-create-azure-resources.yaml@e2e_fx
 
-  
+- stage: build_and_test
+  dependsOn: setup
+  jobs:
+  - template: vsts/templates/jobs-gate-c.yaml@e2e_fx
+
+- stage: cleanup
+  dependsOn:
+  - setup
+  - build_and_test
+  condition: always()
+  jobs:
+  - job: destroy_azure_resource_group
+    condition: always()
+    pool:
+      vmImage: 'ubuntu-24.04'
+    steps:
+    - template: vsts/templates/steps-destroy-azure-resources.yaml@e2e_fx

--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -564,11 +564,22 @@ stages:
         deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${CODENAME}-security main restricted universe multiverse
         EOF
         sudo apt-get update
-        sudo apt-get install -y \
+        # libssl3t64, libcurl4t64 and zlib1g are Multi-Arch: same, so the arm64
+        # copy must be the exact same version as the amd64 copy already on the
+        # image. ports.ubuntu.com and archive.ubuntu.com are not always in sync,
+        # and when they drift apt refuses the whole transaction with
+        # "libssl3t64:arm64 ... is not going to be installed / held broken
+        # packages". Naming both arches lets apt pick one version available in
+        # both, and --allow-downgrades lets it move the amd64 copy back when
+        # ports is the one lagging.
+        sudo apt-get install -y --allow-downgrades \
           cmake \
           build-essential \
           pkg-config \
           crossbuild-essential-arm64 \
+          libssl3t64:amd64 libssl3t64:arm64 \
+          libcurl4t64:amd64 libcurl4t64:arm64 \
+          zlib1g:amd64 zlib1g:arm64 \
           libcurl4-openssl-dev:arm64 \
           libssl-dev:arm64 \
           uuid-dev:arm64 \

--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -89,9 +89,7 @@ stages:
           $PSVersionTable
           New-Item -ItemType Directory -Force -Path test_config | Out-Null
 
-          # TEMP: pinned to a working branch on iot-sdks-e2e-fx until the fix is merged to master.
-          # Revert to master once https://github.com/Azure/iot-sdks-e2e-fx/tree/ewertons/install-stable-azure-iot-extension-by-default is merged.
-          $PsmUrl = 'https://raw.githubusercontent.com/Azure/iot-sdks-e2e-fx/ewertons/install-stable-azure-iot-extension-by-default/scripts/Azure.Iot.Sdk.Test.psm1'
+          $PsmUrl = 'https://raw.githubusercontent.com/Azure/iot-sdks-e2e-fx/master/scripts/Azure.Iot.Sdk.Test.psm1'
           $PsmPath = Join-Path $PWD 'Azure.Iot.Sdk.Test.psm1'
           Invoke-WebRequest -Uri $PsmUrl -OutFile $PsmPath -UseBasicParsing
           Import-Module $PsmPath
@@ -257,7 +255,7 @@ stages:
       displayName: 'Host setup'
       condition: always()
     - script: |
-       $HOME
+       echo "$HOME"
        whoami
        ls -lr
        pwd
@@ -1289,7 +1287,14 @@ stages:
         inlineScript: |
           set -e
           export AZURE_RESOURCE_GROUP=$(cat "$(Pipeline.Workspace)/test_config_scripts/azure-resource-group-name.txt")
-          az group delete --name $AZURE_RESOURCE_GROUP --yes --no-wait
+          # Tolerate an already-deleted group. Retrying any job re-runs this
+          # stage, and `az group delete` exits 3 when the group is gone, which
+          # under `set -e` failed the build after a successful earlier cleanup.
+          if [ -z "$(az group list --query "[?name=='$AZURE_RESOURCE_GROUP'].name" -o tsv)" ]; then
+            echo "Resource group $AZURE_RESOURCE_GROUP already deleted; nothing to do."
+          else
+            az group delete --name $AZURE_RESOURCE_GROUP --yes --no-wait
+          fi
       displayName: Destroy Azure Resource Group
       condition: always() # Run step even if the pipeline run is cancelled.
 

--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -1,151 +1,142 @@
 name: $(BuildID)_$(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
-variables:
-  runCodesignValidationInjection: false
 resources:
-  containers:
-  - container: linux-c-ubuntu-2404
-    endpoint: csdk-containers
-    image: csdkcontainerregistry.azurecr.io/linux-c-ubuntu-2404:latest
-  - container: linux-c-ubuntu-2204
-    endpoint: csdk-containers
-    image: csdkcontainerregistry.azurecr.io/linux-c-ubuntu-2204:latest
-  - container: linux-c-ubuntu-2004
-    endpoint: csdk-containers
-    image: csdkcontainerregistry.azurecr.io/linux-c-ubuntu-2004:latest
-  - container: linux-c-ubuntu-wolfssl
-    endpoint: csdk-containers
-    image: csdkcontainerregistry.azurecr.io/linux-c-ubuntu-wolfssl:latest
-  - container: linux-c-ubuntu-bearssl
-    endpoint: csdk-containers
-    image: csdkcontainerregistry.azurecr.io/linux-c-ubuntu-bearssl:latest
-  - container: linux-c-ubuntu-mbed
-    endpoint: csdk-containers
-    image: csdkcontainerregistry.azurecr.io/linux-c-ubuntu-mbed:latest
-  - container: linux-c-ubuntu-c-ares
-    endpoint: csdk-containers
-    image: csdkcontainerregistry.azurecr.io/linux-c-ubuntu-c-ares:latest
-  - container: linux-c-debian-buster
-    endpoint: csdk-containers
-    image: csdkcontainerregistry.azurecr.io/linux-c-debian-buster:latest
-  - container: linux-c-ubuntu-clang
-    endpoint: csdk-containers
-    image: csdkcontainerregistry.azurecr.io/linux-c-ubuntu-clang:latest
-  - container: linux-c-openssl-pkcs11
-    endpoint: csdk-containers
-    image: csdkcontainerregistry.azurecr.io/linux-c-openssl-pkcs11:latest
-  - container: raspberrypi-c-buster
-    endpoint: csdk-containers
-    image: csdkcontainerregistry.azurecr.io/raspberrypi-c-buster:brown
+  - repo: self
+    clean: true
+
+variables:
+  CCACHE_DIR: /tmp/ccache_cache
+  CCACHE_UMASK: '000'
+  DEFAULT_AZURE_LOCATION: centraluseuap
+  AZURE_LOCATION_EFFECTIVE: $[ coalesce(variables['AZURE_LOCATION'], variables['DEFAULT_AZURE_LOCATION']) ]
+  # CodeQL is auto-injected into every job by the 1ES policy decorator. Turn it
+  # off globally here and opt in per job, because S360 records the *latest*
+  # snapshot per (repo, language) - so a database produced incidentally by a
+  # cross-compile or test job silently replaces the one produced by the job that
+  # actually builds the product. Exactly two jobs opt back in, and together they
+  # cover every language this repo is graded on
+  # (Microsoft.Security.CodeQL.10000: cpp, csharp, python):
+  #   windowsx64release -> cpp     (full x64 Release build of the SDK)
+  #   DotNET            -> csharp, python
+  # Leaving injection on elsewhere also cost ~102 agent-minutes per run in
+  # Init/Finalize alone, on top of the build-tracer overhead inside each build.
+  # See https://aka.ms/codeql3000 and https://aka.ms/sdlfaqcodeql.
+  Codeql.Enabled: false
+
 stages:
-- stage: Setup
-  jobs:
-  - job: setup
-    container: linux-c-ubuntu-2204
-    pool:
-      name: 'sdk-c--ubuntu-22'
-    displayName: 'Setup'
-    steps:
-    - script: |
-        az login --identity
-        az storage account update -g $STORAGE_ACCOUNT_RESOURCE_GROUP -n $STORAGE_ACCOUNT_NAME --allow-shared-key-access true --default-action Allow
-      displayName: 'Setup Azure Storage Account'
-      env:
-        STORAGE_ACCOUNT_NAME: $(STORAGE-ACCOUNT-NAME)
-        STORAGE_ACCOUNT_RESOURCE_GROUP: $(STORAGE-ACCOUNT-RESOURCE-GROUP)
-- stage: Tests  
+- stage: Requirements
   jobs:
   - job: checksubmodule
-    variables:
-      CodeQL.Enabled: false
     pool:
-      vmImage: 'ubuntu-20.04'
+      vmImage: 'ubuntu-24.04'
     displayName: "Check Submodules"
     steps:
-    - script: |
-        sudo apt-get update && apt-get install -y \
-        curl \
-        git \
-        python-software-properties \
-        build-essential \
-        pkg-config
-        sudo curl -sL https://deb.nodesource.com/setup_16.x | bash -
-        sudo apt-get install -y nodejs
-      displayName: 'Setup'
-    - script: |
-        npm install check_submodules 
-        node_modules/.bin/check_submodules . main
-      displayName: 'Check Submodules Match'
-  - job: windowsx86
-    timeoutInMinutes: 190
-    pool:
-      name: 'sdk-c--win-vs2022'
-    displayName: "Windows x86"
-    steps:
-    - script: |
-        call jenkins\windows_c.cmd
-      displayName: 'Build'
-    - script: |
-        call jenkins\windows_c_VsDevCmd.cmd x86
-        cd cmake && ctest -T test --no-compress-output -C "Debug" -V -j 16 --schedule-random
-      displayName: "Run Tests"
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
-        # PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-    - task: PublishTestResults@2
-      displayName: 'Publish Windows x86 Results'
+    - checkout: self
+      submodules: false
+
+    - task: PowerShell@2
+      displayName: 'Check Submodule Consistency'
       inputs:
-        testRunner: CTest
-        testResultsFiles: '**/Test.xml'
-        mergeTestResults: true
-        testRunTitle: 'windowsx86'
-      condition: succeededOrFailed()
+        targetType: 'inline'
+        pwsh: true
+        script: |
+          $ErrorActionPreference = 'Stop'
+          $VerbosePreference = 'Continue'
+
+          # Extract GitHub token from the service connection's git credential
+          # (checkout: self stores it as an Authorization extraheader in git config)
+          $extraHeader = git config --get-all http.https://github.com/.extraheader 2>$null
+          if ($extraHeader -match 'basic\s+(.+)$') {
+            $decoded = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($Matches[1]))
+            # Format is ":token" (empty username)
+            $env:GITHUB_TOKEN = $decoded.TrimStart(':')
+            Write-Verbose "GitHub token extracted from service connection credential."
+          } else {
+            Write-Verbose "No GitHub token found in git config; proceeding without auth."
+          }
+
+          $PsmUrl = 'https://raw.githubusercontent.com/Azure/iot-sdks-e2e-fx/master/scripts/Azure.Iot.Sdk.Test.psm1'
+          $PsmPath = Join-Path $PWD 'Azure.Iot.Sdk.Test.psm1'
+          Invoke-WebRequest -Uri $PsmUrl -OutFile $PsmPath -UseBasicParsing
+          Import-Module $PsmPath
+
+          $result = Test-SubmoduleConsistency -Path "$(Build.SourcesDirectory)" -ShowTree -Verbose
+          if (-not $result) {
+            Write-Error "Submodule consistency check FAILED. See conflicts above."
+            exit 1
+          }
+
+- stage: Setup
+  dependsOn: [] # Run in parallel with Requirements to save ~3-5 min
+  jobs:
+  - job: create_azure_resources
+    pool:
+      vmImage: 'windows-latest'
+    steps:
+    - checkout: none
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: 'iot hub sdk service connection'
+        # Use PowerShell 7 (pwsh) so RSA.ExportRSAPrivateKeyPem() is available.
+        # Windows PowerShell 5.1 (scriptType: 'ps') lacks this API, which forces
+        # the test config to fall back to PKCS#8 ("BEGIN PRIVATE KEY"). Schannel's
+        # CryptDecodeObjectEx(PKCS_RSA_PRIVATE_KEY) can only decode PKCS#1 DER
+        # ("BEGIN RSA PRIVATE KEY"), so every x509 E2E test then fails in
+        # c-utility/adapters/x509_schannel.c::decode_crypt_object.
+        scriptType: 'pscore'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          $ErrorActionPreference = 'Stop'
+          $PSVersionTable
+          New-Item -ItemType Directory -Force -Path test_config | Out-Null
+
+          # TEMP: pinned to a working branch on iot-sdks-e2e-fx until the fix is merged to master.
+          # Revert to master once https://github.com/Azure/iot-sdks-e2e-fx/tree/ewertons/install-stable-azure-iot-extension-by-default is merged.
+          $PsmUrl = 'https://raw.githubusercontent.com/Azure/iot-sdks-e2e-fx/ewertons/install-stable-azure-iot-extension-by-default/scripts/Azure.Iot.Sdk.Test.psm1'
+          $PsmPath = Join-Path $PWD 'Azure.Iot.Sdk.Test.psm1'
+          Invoke-WebRequest -Uri $PsmUrl -OutFile $PsmPath -UseBasicParsing
+          Import-Module $PsmPath
+
+          $ResourceGroupName = New-AzureResourceGroupName -OutFile "test_config/azure-resource-group-name.txt"
+          $TestEnvInfo = New-AzIotTestEnvironment -AzureLocation $env:AZURE_LOCATION_EFFECTIVE -ResourceGroup $ResourceGroupName -EnableFileUpload -IotHubX509ThumbprintDevices 1 -DpsX509IndividualEnrollments 1
+
+          New-AzIotCSDKE2ETestConfig -TestEnvInfo $TestEnvInfo -Target bash -OutFile test_config/set_e2e_test_env_vars.sh
+          New-AzIotCSDKE2ETestConfig -TestEnvInfo $TestEnvInfo -Target powershell -OutFile test_config/Set-E2ETestEnvVars.ps1
+      displayName: 'Create Azure Resources and Test Config'
+    - publish: test_config
+      artifact: test_config_scripts
+      displayName: Publish artifact (test config scripts)
+      # Pipeline artifacts are immutable, so re-publishing this name in the same
+      # run fails with "Artifact test_config_scripts already exists for build N"
+      # whenever this job/stage re-executes in the same run (Rerun failed jobs, a
+      # stage rerun, or an agent-loss auto-retry). Publish only on the first job+
+      # stage attempt; that artifact persists for the Tests/Cleanup stages.
+      # always() keeps publishing on a resource-creation failure so Cleanup can
+      # still read azure-resource-group-name.txt.
+      condition: and(always(), eq(variables['System.JobAttempt'], '1'), eq(variables['System.StageAttempt'], '1'))
+- stage: Tests
+  dependsOn:
+  - Requirements
+  - Setup
+  jobs:
   - job: windowsx64debug
     timeoutInMinutes: 190
     pool:
-      name: 'sdk-c--win-vs2022'
+      vmImage: 'windows-2022'
     displayName: 'Windows x64 (Debug)'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
     - script: |
         call jenkins\windows_c.cmd --platform x64
       displayName: 'Build'
-    - script: |
-        call jenkins\windows_c_VsDevCmd.cmd x64
-        cd cmake && ctest -T test --no-compress-output -C "Debug" -V -j 16 --schedule-random
+    - powershell: |
+        . "$(Pipeline.Workspace)\test_config_scripts\Set-E2ETestEnvVars.ps1"
+        cmd /c "call jenkins\windows_c_VsDevCmd.cmd x64 && cd cmake && ctest -T test --no-compress-output -C Debug -V -j 16 --schedule-random -E iothubclient_mqtt_dt_e2e"
       displayName: "Run Tests"
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
     - task: PublishTestResults@2
       displayName: 'Publish Windows x64 (Debug) Results'
       inputs:
@@ -154,45 +145,62 @@ stages:
         mergeTestResults: true
         testRunTitle: 'windowsx64'
       condition: succeededOrFailed()
+
+  - job: windowsx86
+    timeoutInMinutes: 190
+    pool:
+      vmImage: 'windows-2022'
+    displayName: 'Windows x86'
+    steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
+    - script: |
+        call jenkins\windows_c.cmd
+      displayName: 'Build'
+    - powershell: |
+        . "$(Pipeline.Workspace)\test_config_scripts\Set-E2ETestEnvVars.ps1"
+        cmd /c "call jenkins\windows_c_VsDevCmd.cmd x86 && cd cmake && ctest -T test --no-compress-output -C Debug -V -j 16 --schedule-random -E iothubclient_mqtt_dt_e2e"
+      displayName: 'Run Tests'
+    - task: PublishTestResults@2
+      displayName: 'Publish Windows x86 Results'
+      inputs:
+        testRunner: CTest
+        testResultsFiles: '**/Test.xml'
+        mergeTestResults: true
+        testRunTitle: 'windowsx86'
+      condition: succeededOrFailed()
+
   - job: windowsx64release
     timeoutInMinutes: 190
     variables:
-      CodeQL.Enabled: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
-      CodeQL.Language: cpp
+      # Owns the 'cpp' CodeQL snapshot for this repo. Overrides the pipeline-level
+      # Codeql.Enabled: false. Only on main, so PR builds stay fast.
+      Codeql.Enabled: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
+      Codeql.Language: cpp
     pool:
-      name: 'sdk-c--win-vs2022'
+      vmImage: 'windows-2022'
     displayName: 'Windows x64 (Release)'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
     - task: CodeQL3000Init@0
     - script: |
         call jenkins\windows_c_release.cmd --platform x64
       displayName: 'Build'
     - task: CodeQL3000Finalize@0
       condition: always()
-    - script: |
-        call jenkins\windows_c_VsDevCmd.cmd x64
-        cd cmake && ctest -T test --no-compress-output -C "Release" -V -j 16 --schedule-random
-      displayName: "Run Tests"
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
+    - powershell: |
+        . "$(Pipeline.Workspace)\test_config_scripts\Set-E2ETestEnvVars.ps1"
+        cmd /c "call jenkins\windows_c_VsDevCmd.cmd x64 && cd cmake && ctest -T test --no-compress-output -C Release -V -j 16 --schedule-random -E iothubclient_mqtt_dt_e2e"
+      displayName: 'Run Tests'
     - task: PublishTestResults@2
       displayName: 'Publish Windows x64 (Release) Results'
       inputs:
@@ -201,401 +209,495 @@ stages:
         mergeTestResults: true
         testRunTitle: 'windowsx64release'
       condition: succeededOrFailed()
+
   - job: windowsdynamic
     timeoutInMinutes: 190
     pool:
-      name: 'sdk-c--win-vs2022'
-    displayName: "Windows Dynamic"
+      vmImage: 'windows-2022'
+    displayName: 'Windows Dynamic'
     steps:
-    - script: |
-        call jenkins\windows_c_VsDevCmd.cmd
-        call jenkins\windows_c_build_as_dynamic.cmd
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
+    - powershell: |
+        . "$(Pipeline.Workspace)\test_config_scripts\Set-E2ETestEnvVars.ps1"
+        cmd /c "call jenkins\windows_c_VsDevCmd.cmd && call jenkins\windows_c_build_as_dynamic.cmd"
       displayName: 'Build'
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
   - job: linuxoptions
-    container: linux-c-ubuntu-2004
-    pool: 
-      name: 'sdk-c--ubuntu-22'
+    pool:
+      vmImage: 'ubuntu-24.04'
     displayName: 'Linux with Options'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - script: |
+        set -e
+        sudo apt-get update -qq
+        sudo ./build_all/linux/setup.sh
+      displayName: 'Host setup'
+      condition: always()
     - script: 'sudo ./jenkins/linux_c_option_test.sh'
       displayName: 'Build'
       condition: always()
+
+  - job: raspberrypi
+    pool:
+      vmImage: 'ubuntu-24.04'
+    displayName: "Raspberry Pi"
+    steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - script: |
+        source ./testtools/scripts/linux-setup-raspberry.sh
+      displayName: 'Host setup'
+      condition: always()
+    - script: |
+       $HOME
+       whoami
+       ls -lr
+       pwd
+       # raspberry_env_vars.sh is generated by linux-setup-raspberry.sh
+       source ./toolchain/raspberry_env_vars.sh
+       # Point pkg-config at the cross-compile toolchain's .pc files (libuuid, etc.)
+       # so pkg_search_module(uuid) in CMake resolves against the toolchain sysroot
+       # instead of the host's system pkg-config paths.
+       export PKG_CONFIG_LIBDIR=${TOOLCHAIN_PREFIX}/lib/pkgconfig
+       export PKG_CONFIG_PATH=${TOOLCHAIN_PREFIX}/lib/pkgconfig
+       # Ensure cross linker search path includes toolchain libs (libuuid, openssl, curl).
+       export LIBRARY_PATH=${TOOLCHAIN_PREFIX}/lib:${LIBRARY_PATH}
+       export LDFLAGS="-L${TOOLCHAIN_PREFIX}/lib ${LDFLAGS}"
+       chmod +x jenkins/raspberrypi_c_buster.sh
+        ./jenkins/raspberrypi_c_buster.sh
+      displayName: 'Build'
+  - job: crosscompile_mips32
+    pool:
+      vmImage: 'ubuntu-24.04'
+    displayName: "Cross Compile (MIPS32)"
+    steps:
+    - checkout: self
+      submodules: false
+      fetchDepth: 1
+    - script: |
+        # Microsoft-hosted ubuntu-24.04 ships with docker + containerd preinstalled.
+        # Installing docker.io from apt would conflict with containerd.io and fail
+        # the apt resolver ("containerd.io : Conflicts: containerd").
+        sudo apt-get update && sudo apt-get install -y \
+        curl \
+        git \
+        build-essential \
+        pkg-config
+      displayName: 'Setup'
+    - script: |
+        cd samples/dockerbuilds/MIPS32
+        docker build --build-arg TARGET_BRANCH=$BUILD_SOURCEBRANCH -t mipsiotbuild:latest . --network=host
+        cd ..
+        docker build -t mipsiotapp:latest . --network=host --file ./MIPS32/Dockerfile_adjunct
+      displayName: 'Build MIPS32'
+  - job: crosscompile_arm
+    pool:
+      vmImage: 'ubuntu-24.04'
+    displayName: "Cross Compile (ARM)"
+    steps:
+    - checkout: self
+      submodules: false
+      fetchDepth: 1
+    - script: |
+        # Microsoft-hosted ubuntu-24.04 ships with docker + containerd preinstalled.
+        # Installing docker.io from apt would conflict with containerd.io and fail
+        # the apt resolver ("containerd.io : Conflicts: containerd").
+        sudo apt-get update && sudo apt-get install -y \
+        curl \
+        git \
+        build-essential \
+        pkg-config
+      displayName: 'Setup'
+    - script: |
+        cd samples/dockerbuilds/ARM
+        docker build --build-arg TARGET_BRANCH=$BUILD_SOURCEBRANCH -t armiotbuild:latest . --network=host
+        cd ..
+        docker build -t armiotapp:latest . --network=host --file ./ARM/Dockerfile_adjunct
+      displayName: 'Build ARM'
+  - job: ubuntu2404_dbg_build
+    pool:
+      vmImage: 'ubuntu-24.04'
+    displayName: 'Ubuntu 24.04 Build (Debug)'
+    steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - script: |
+        set -e
+        sudo apt-get update -qq
+        sudo ./build_all/linux/setup.sh
+      displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
+    - script: |
+        sudo -E ./jenkins/ubuntu_c.sh
+      displayName: 'Build'
+    - script: |
+        sudo chmod -R 755 .
+        tar cf $(Build.ArtifactStagingDirectory)/build_output.tar -C $(Build.SourcesDirectory) cmake
+      displayName: 'Package build output'
+    - publish: $(Build.ArtifactStagingDirectory)/build_output.tar
+      artifact: ubuntu2404_dbg_build_output
+      displayName: 'Publish build output'
+
+  - job: ubuntu2404_dbg_tests
+    dependsOn: ubuntu2404_dbg_build
+    timeoutInMinutes: 90
+    pool:
+      vmImage: 'ubuntu-24.04'
+    displayName: 'Ubuntu 24.04 Tests'
+    strategy:
+      matrix:
+        ut_e2e:
+          RUN_TESTS_ARGS: '--e2e'
+          NEEDS_E2E_CONFIG: 'true'
+        valgrind_ut:
+          RUN_TESTS_ARGS: '--valgrind --ut-only'
+          NEEDS_E2E_CONFIG: 'true'
+        valgrind_e2e:
+          RUN_TESTS_ARGS: '--valgrind --e2e --e2e-only'
+          NEEDS_E2E_CONFIG: 'true'
+        helgrind_ut:
+          RUN_TESTS_ARGS: '--helgrind --ut-only'
+          NEEDS_E2E_CONFIG: 'true'
+        helgrind_e2e:
+          RUN_TESTS_ARGS: '--helgrind --e2e --e2e-only'
+          NEEDS_E2E_CONFIG: 'true'
+        drd:
+          RUN_TESTS_ARGS: '--drd --e2e'
+          NEEDS_E2E_CONFIG: 'true'
+    steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
+    - download: current
+      artifact: ubuntu2404_dbg_build_output
+      displayName: Download artifact (build output)
+    - script: |
+        set -e
+        if command -v valgrind >/dev/null 2>&1; then
+          echo "Using preinstalled valgrind on hosted agent"
+        else
+          sudo apt-get update -qq
+          sudo ./build_all/linux/setup.sh
+        fi
+      displayName: 'Host setup'
+    - script: |
+        set -e
+        tar xf "$(Pipeline.Workspace)/ubuntu2404_dbg_build_output/build_output.tar" -C $(Build.SourcesDirectory)
+        export OPENSSL_ia32cap=0x00000000
+        sudo chmod -R 755 .
+        cd cmake
+        sudo bash -c 'source "$(Pipeline.Workspace)/test_config_scripts/set_e2e_test_env_vars.sh" && ../build_all/linux/run_tests.sh $(RUN_TESTS_ARGS)'
+      displayName: "Run Tests ($(RUN_TESTS_ARGS))"
+    - task: PublishTestResults@2
+      displayName: 'Publish Test Results ($(RUN_TESTS_ARGS))'
+      inputs:
+        testRunner: CTest
+        testResultsFiles: '**/Test.xml'
+        mergeTestResults: true
+        testRunTitle: 'ubuntu2404_$(System.JobPositionInPhase)'
+      condition: succeededOrFailed()
+
   - job: clang
-    timeoutInMinutes: 190
-    container: linux-c-ubuntu-clang
-    pool: 
-      name: 'sdk-c--ubuntu-22'
+    timeoutInMinutes: 90
+    pool:
+      vmImage: 'ubuntu-24.04'
     displayName: 'Clang (Debug)'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
+    - script: |
+        set -e
+        if command -v clang >/dev/null 2>&1 && command -v valgrind >/dev/null 2>&1; then
+          echo "Using preinstalled clang and valgrind on hosted agent"
+        else
+          sudo apt-get update -qq
+          sudo ./build_all/linux/setup.sh
+          if ! command -v clang >/dev/null 2>&1; then
+            sudo apt-get install -y clang
+          fi
+        fi
+      displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
     - script: |
         export OPENSSL_ia32cap=0x00000000
         sudo chmod -R 755 .
         sudo -E ./jenkins/ubuntu_clang.sh
       displayName: 'Build'
     - script: |
-        cd cmake && sudo -E ../build_all/linux/run_tests.sh
-      displayName: "Run Tests"
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
+        export OPENSSL_ia32cap=0x00000000
+        sudo chmod -R 755 .
+        cd cmake
+        sudo bash -c 'source "$(Pipeline.Workspace)/test_config_scripts/set_e2e_test_env_vars.sh" && ../build_all/linux/run_tests.sh --e2e'
+      displayName: 'Run Tests'
     - task: PublishTestResults@2
-      displayName: 'Publish Clang (Debug) Results'
+      displayName: 'Publish Test Results (Clang Debug)'
       inputs:
         testRunner: CTest
         testResultsFiles: '**/Test.xml'
         mergeTestResults: true
         testRunTitle: 'clang'
       condition: succeededOrFailed()
+
   - job: clang_release
-    timeoutInMinutes: 190
-    container: linux-c-ubuntu-clang
-    pool: 
-      name: 'sdk-c--ubuntu-22'
+    timeoutInMinutes: 90
+    pool:
+      vmImage: 'ubuntu-24.04'
     displayName: 'Clang (Release)'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
+    - script: |
+        set -e
+        if command -v clang >/dev/null 2>&1 && command -v valgrind >/dev/null 2>&1; then
+          echo "Using preinstalled clang and valgrind on hosted agent"
+        else
+          sudo apt-get update -qq
+          sudo ./build_all/linux/setup.sh
+          if ! command -v clang >/dev/null 2>&1; then
+            sudo apt-get install -y clang
+          fi
+        fi
+      displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
     - script: |
         export OPENSSL_ia32cap=0x00000000
         sudo chmod -R 755 .
         sudo -E ./jenkins/ubuntu_clang_release.sh
       displayName: 'Build'
     - script: |
-        cd cmake && sudo -E ../build_all/linux/run_tests.sh
-      displayName: "Run Tests"
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
+        export OPENSSL_ia32cap=0x00000000
+        sudo chmod -R 755 .
+        cd cmake
+        sudo bash -c 'source "$(Pipeline.Workspace)/test_config_scripts/set_e2e_test_env_vars.sh" && ../build_all/linux/run_tests.sh --e2e'
+      displayName: 'Run Tests'
     - task: PublishTestResults@2
-      displayName: 'Publish Clang (Release) Results'
+      displayName: 'Publish Test Results (Clang Release)'
       inputs:
         testRunner: CTest
         testResultsFiles: '**/Test.xml'
         mergeTestResults: true
         testRunTitle: 'clang_release'
       condition: succeededOrFailed()
-  - job: ubuntu2004debug
-    timeoutInMinutes: 190
-    container: linux-c-ubuntu-2004
+
+  - job: ubuntu2404arm
+    # ARM64 replacement for the retired ubuntu2204arm self-hosted ARM agent.
+    # Microsoft-hosted Azure Pipelines does not offer a generally-available
+    # ARM64 Linux vmImage on the default Azure Pipelines agent pool.
+    # Two approaches were evaluated:
+    #   1) QEMU user-mode emulation of linux/arm64 on an x64 agent: gcc
+    #      segfaulted deterministically while compiling larger translation
+    #      units (e.g. c-utility/src/constbuffer_array.c), which is a known
+    #      QEMU instability and not fixable in this SDK.
+    #   2) Cross-compile with the aarch64-linux-gnu toolchain on the x64
+    #      agent: stable, fast, and still validates ARM64 code generation
+    #      for the entire SDK.
+    # We use approach (2). Tests are NOT executed on ARM64 in hosted CI;
+    # runtime validation remains the responsibility of the self-hosted
+    # ARM agents (when available) and the raspberrypi jobs.
+    timeoutInMinutes: 60
     pool:
-      name: 'sdk-c--ubuntu-22'
-    displayName: 'Ubuntu 20.04 (Debug)'
+      vmImage: 'ubuntu-24.04'
+    displayName: 'Ubuntu 24.04 ARM64 (Cross-compile only)'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
     - script: |
-        sudo -E ./jenkins/ubuntu_c.sh
-      displayName: 'Build'
+        set -e
+        sudo dpkg --add-architecture arm64
+        # Restrict the default (amd64) sources to amd64 so apt does not try
+        # to resolve arm64 packages against the x86_64 mirror (which fails).
+        sudo sed -i 's|^deb |deb [arch=amd64] |' /etc/apt/sources.list || true
+        if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+          sudo sed -i 's|^Types: deb$|Types: deb\nArchitectures: amd64|' /etc/apt/sources.list.d/ubuntu.sources || true
+        fi
+        # Add an arm64-only sources list pointing at the Ubuntu ports mirror.
+        CODENAME=$(lsb_release -cs)
+        sudo tee /etc/apt/sources.list.d/arm64-ports.list >/dev/null <<EOF
+        deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${CODENAME} main restricted universe multiverse
+        deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${CODENAME}-updates main restricted universe multiverse
+        deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${CODENAME}-security main restricted universe multiverse
+        EOF
+        sudo apt-get update
+        sudo apt-get install -y \
+          cmake \
+          build-essential \
+          pkg-config \
+          crossbuild-essential-arm64 \
+          libcurl4-openssl-dev:arm64 \
+          libssl-dev:arm64 \
+          uuid-dev:arm64 \
+          zlib1g-dev:arm64
+      displayName: 'Install aarch64 cross toolchain and arm64 dev libs'
     - script: |
-        export OPENSSL_ia32cap=0x00000000
-        sudo chmod -R 755 .
-        cd cmake && sudo -E ../build_all/linux/run_tests.sh
-      displayName: "Run Tests"
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
-    - task: PublishTestResults@2
-      displayName: 'Publish Ubuntu 20 (Debug) Results'
-      inputs:
-        testRunner: CTest
-        testResultsFiles: '**/Test.xml'
-        mergeTestResults: true
-        testRunTitle: 'ubuntu2004debug'
-      condition: succeededOrFailed()
-  - job: ubuntu2004release
-    timeoutInMinutes: 190
-    container: linux-c-ubuntu-2004
-    pool:
-      name: 'sdk-c--ubuntu-22'
-    displayName: 'Ubuntu 20.04 (Release)'
-    steps:
-    - script: |
-        sudo -E ./jenkins/ubuntu_c_release.sh
-      displayName: 'Build'
-    - script: |
-        export OPENSSL_ia32cap=0x00000000
-        sudo chmod -R 755 .
-        cd cmake && sudo -E ../build_all/linux/run_tests.sh
-      displayName: "Run Tests"
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
-    - task: PublishTestResults@2
-      displayName: 'Publish Ubuntu 20 (Release) Results'
-      inputs:
-        testRunner: CTest
-        testResultsFiles: '**/Test.xml'
-        mergeTestResults: true
-        testRunTitle: 'ubuntu2004release'
-      condition: succeededOrFailed()
-  - job: ubuntu2204arm
-    pool: 
-      name: 'sdk-c--ubuntu-22-arm'
-    displayName: 'Ubuntu 22.04 (ARM)'
-    steps:
-    - script: |
-        sudo nproc --all
-        sudo apt-get update && apt-get upgrade -y
-        sudo apt-get install -y git cmake build-essential curl libcurl4-openssl-dev libssl-dev uuid-dev ca-certificates
-        mkdir cmake
-        cd cmake
-        sudo cmake '-DcompileOption_C:STRING= ' -DCMAKE_BUILD_TYPE=Debug -Drun_e2e_tests:BOOL=OFF -Drun_sfc_tests:BOOL=OFF -Drun_longhaul_tests=OFF -Duse_amqp:BOOL=ON -Duse_http:BOOL=ON -Duse_mqtt:BOOL=ON -Ddont_use_uploadtoblob:BOOL=OFF -Drun_unittests:BOOL=ON -Dno_logging:BOOL=OFF -Duse_prov_client:BOOL=ON -Duse_tpm_simulator:BOOL=OFF -Duse_edge_modules=ON -Dhsm_type_riot=OFF -Dhsm_type_x509=ON -Dhsm_type_symm_key=ON -Dhsm_type_sastoken=ON -Denable_ipv6=OFF ..
-        sudo make -j8 
-      displayName: 'Build'
-    - script: |
-        cd cmake && sudo ctest -T test --no-compress-output -V
-      displayName: "Run Tests"
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
-    - task: PublishTestResults@2
-      displayName: 'Publish Debian Results'
-      inputs:
-        testRunner: CTest
-        testResultsFiles: '**/Test.xml'
-        mergeTestResults: true
-        testRunTitle: 'debian'
-      condition: succeededOrFailed()
-  - job: ubuntu2204build
-    timeoutInMinutes: 190
-    container: linux-c-ubuntu-2204
-    pool:
-      name: 'sdk-c--ubuntu-22'
-    displayName: 'Ubuntu 22.04 Unit Tests (Debug)'
-    steps:
-    - script: |
-        cat /etc/*release | grep VERSION*
-        gcc --version
-        openssl version
-        curl --version
-        sudo -E env PATH="$PATH" ./build_all/linux/build.sh --run-unittests --provisioning --use-hsmsymmkey --use-hsmsas --use-hsmx509 --use-edge-modules --config Debug
-      displayName: 'Build'
-    - script: |
-        export OPENSSL_ia32cap=0x00000000
-        sudo chmod -R 755 .
-        cd cmake && sudo -E ../build_all/linux/run_tests.sh
-      displayName: "Run Tests"
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
-    - task: PublishTestResults@2
-      displayName: 'Publish Ubuntu 22 (Debug) Results'
-      inputs:
-        testRunner: CTest
-        testResultsFiles: '**/Test.xml'
-        mergeTestResults: true
-        testRunTitle: 'ubuntu2004debug'
-      condition: succeededOrFailed()
+        set -e
+        mkdir -p cmake-arm64
+        cd cmake-arm64
+        # Toolchain settings inline (no toolchain file needed).
+        # FindOpenSSL does not honor CMAKE_LIBRARY_ARCHITECTURE on its own and
+        # will happily pick up /usr/lib/x86_64-linux-gnu/libssl.so on a
+        # multiarch host, so we point it explicitly at the aarch64 tree via
+        # OPENSSL_ROOT_DIR and its per-lib overrides.
+        cmake \
+          -DCMAKE_SYSTEM_NAME=Linux \
+          -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
+          -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
+          -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ \
+          -DCMAKE_LIBRARY_ARCHITECTURE=aarch64-linux-gnu \
+          -DCMAKE_FIND_ROOT_PATH="/usr/aarch64-linux-gnu;/usr/lib/aarch64-linux-gnu;/usr/include/aarch64-linux-gnu" \
+          -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER \
+          -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY \
+          -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY \
+          -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ONLY \
+          -DPKG_CONFIG_LIBDIR=/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig \
+          -DOPENSSL_ROOT_DIR=/usr/lib/aarch64-linux-gnu \
+          -DOPENSSL_INCLUDE_DIR=/usr/include \
+          -DOPENSSL_CRYPTO_LIBRARY=/usr/lib/aarch64-linux-gnu/libcrypto.so \
+          -DOPENSSL_SSL_LIBRARY=/usr/lib/aarch64-linux-gnu/libssl.so \
+          "-DcompileOption_C:STRING= " \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -Drun_e2e_tests:BOOL=OFF \
+          -Drun_sfc_tests:BOOL=OFF \
+          -Drun_longhaul_tests=OFF \
+          -Duse_amqp:BOOL=ON \
+          -Duse_http:BOOL=ON \
+          -Duse_mqtt:BOOL=ON \
+          -Ddont_use_uploadtoblob:BOOL=OFF \
+          -Drun_unittests:BOOL=OFF \
+          -Dno_logging:BOOL=OFF \
+          -Duse_prov_client:BOOL=ON \
+          -Duse_tpm_simulator:BOOL=OFF \
+          -Duse_edge_modules=ON \
+          -Dhsm_type_riot=OFF \
+          -Dhsm_type_x509=ON \
+          -Dhsm_type_symm_key=ON \
+          -Dhsm_type_sastoken=ON \
+          -Denable_ipv6=OFF \
+          ..
+        make -j$(nproc)
+        # Sanity-check: confirm produced binaries are actually ARM64.
+        file iothub_client/samples/iothub_ll_client_sample/iothub_ll_client_sample || true
+      displayName: 'Cross-compile SDK for aarch64'
+
   - job: ubuntuRIOT
-    timeoutInMinutes: 190
-    container: linux-c-ubuntu-2004
+    timeoutInMinutes: 90
     pool:
-      name: 'sdk-c--ubuntu-22'
+      vmImage: 'ubuntu-24.04'
     displayName: 'Ubuntu RIOT/DICE'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
+    - script: |
+        set -e
+        sudo apt-get update -qq
+        sudo ./build_all/linux/setup.sh
+      displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
     - script: |
         sudo -E ./jenkins/ubuntu_c_riot.sh
       displayName: 'Build'
     - script: |
         export OPENSSL_ia32cap=0x00000000
         sudo chmod -R 755 .
-        cd cmake && sudo -E ../build_all/linux/run_tests.sh
-      displayName: "Run Tests"
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
+        cd cmake
+        sudo bash -c 'source "$(Pipeline.Workspace)/test_config_scripts/set_e2e_test_env_vars.sh" && ../build_all/linux/run_tests.sh --e2e'
+      displayName: 'Run Tests'
     - task: PublishTestResults@2
-      displayName: 'Publish Ubuntu RIOT Results'
+      displayName: 'Publish Test Results (Ubuntu RIOT)'
       inputs:
         testRunner: CTest
         testResultsFiles: '**/Test.xml'
         mergeTestResults: true
         testRunTitle: 'ubuntuRIOT'
       condition: succeededOrFailed()
-  - job: ubuntu2004dualipstack
-    timeoutInMinutes: 190
-    container: linux-c-ubuntu-2004
+
+  - job: ubuntu2404dualipstack
+    timeoutInMinutes: 90
     pool:
-      name: 'sdk-c--ubuntu-22'
-    displayName: 'Ubuntu 20.04 with Dual IP Stack'
+      vmImage: 'ubuntu-24.04'
+    displayName: 'Ubuntu 24.04 with Dual IP Stack'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
     - script: |
-        export OPENSSL_ia32cap=0x00000000
-        sudo chmod -R 755 .
-        sudo -E ./jenkins/ubuntu_c_ipv6_dual_stack.sh
-      displayName: 'Build'
-    - script: |
-        cd cmake && sudo -E ../build_all/linux/run_tests.sh
-      displayName: "Run Tests"
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
-    - task: PublishTestResults@2
-      displayName: 'Publish Ubuntu 20.04 with Dual IP Stack Results'
+        set -e
+        sudo apt-get update -qq
+        sudo ./build_all/linux/setup.sh
+      displayName: 'Host setup'
+    - task: Cache@2
       inputs:
-        testRunner: CTest
-        testResultsFiles: '**/Test.xml'
-        mergeTestResults: true
-        testRunTitle: 'ubuntu2004dualipstack'
-      condition: succeededOrFailed()
-  - job: ubuntu2204dualipstack
-    timeoutInMinutes: 190
-    container: linux-c-ubuntu-2204
-    pool:
-      name: 'sdk-c--ubuntu-22'
-    displayName: 'Ubuntu 22.04 with Dual IP Stack'
-    steps:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
     - script: |
         cat /etc/*release | grep VERSION*
         gcc --version
@@ -606,428 +708,486 @@ stages:
     - script: |
         export OPENSSL_ia32cap=0x00000000
         sudo chmod -R 755 .
-        cd cmake && sudo -E ../build_all/linux/run_tests.sh
-      displayName: "Run Tests"
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
+        cd cmake
+        sudo bash -c 'source "$(Pipeline.Workspace)/test_config_scripts/set_e2e_test_env_vars.sh" && ../build_all/linux/run_tests.sh --e2e'
+      displayName: 'Run Tests'
     - task: PublishTestResults@2
-      displayName: 'Publish Ubuntu 22.04 with Dual IP Stack Results'
+      displayName: 'Publish Test Results (Dual IP Stack)'
       inputs:
         testRunner: CTest
         testResultsFiles: '**/Test.xml'
         mergeTestResults: true
-        testRunTitle: 'ubuntu2204dualipstack'
+        testRunTitle: 'ubuntu2404dualipstack'
       condition: succeededOrFailed()
+
   - job: debian
-    container: linux-c-debian-Buster
-    pool: 
-      name: 'sdk-c--ubuntu-22'
-    displayName: 'Debian (Buster)'
+    timeoutInMinutes: 90
+    pool:
+      vmImage: 'ubuntu-24.04'
+    displayName: 'Debian Build Script'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
+    - script: |
+        set -e
+        sudo apt-get update -qq
+        sudo ./build_all/linux/setup.sh
+      displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
     - script: |
         sudo ./jenkins/debian_c.sh
       displayName: 'Build'
     - script: |
-        cd cmake && sudo -E ../build_all/linux/run_tests.sh
-      displayName: "Run Tests"
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
+        export OPENSSL_ia32cap=0x00000000
+        sudo chmod -R 755 .
+        cd cmake
+        sudo bash -c 'source "$(Pipeline.Workspace)/test_config_scripts/set_e2e_test_env_vars.sh" && ../build_all/linux/run_tests.sh --e2e'
+      displayName: 'Run Tests'
     - task: PublishTestResults@2
-      displayName: 'Publish Debian Results'
+      displayName: 'Publish Test Results (Debian)'
       inputs:
         testRunner: CTest
         testResultsFiles: '**/Test.xml'
         mergeTestResults: true
         testRunTitle: 'debian'
       condition: succeededOrFailed()
+
   - job: linux_installed_deps
-    container: linux-c-ubuntu-2004
-    pool: 
-      name: 'sdk-c--ubuntu-22'
+    pool:
+      vmImage: 'ubuntu-24.04'
     displayName: 'Linux with Installed Deps'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - script: |
+        set -e
+        sudo apt-get update -qq
+        sudo ./build_all/linux/setup.sh
+      displayName: 'Host setup'
     - script: |
         export OPENSSL_ia32cap=0x00000000
         sudo chmod -R 755 .
         sudo -E ./jenkins/linux_install_deps.sh
       displayName: 'Build'
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
+
   - job: wolfssl
+    timeoutInMinutes: 90
     pool:
-      name: 'sdk-c--ubuntu-22'
-    container: linux-c-ubuntu-wolfssl
+      vmImage: 'ubuntu-24.04'
     displayName: 'WolfSSL'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
     - script: |
-        LD_LIBRARY_PATH=/usr/local/lib
-        LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/my_library/
+        set -e
+        sudo apt-get update -qq
+        sudo ./build_all/linux/setup.sh
+        # wolfSSL is not in Ubuntu main; install dev headers from universe.
+        sudo apt-get install -y libwolfssl-dev || true
+      displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
+    - script: |
         sudo -E jenkins/linux_wolfssl.sh
       displayName: 'Build'
     - script: |
-        cd cmake && sudo -E ../build_all/linux/run_tests.sh
-      displayName: "Run Tests"
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
+        cd cmake
+        sudo bash -c 'source "$(Pipeline.Workspace)/test_config_scripts/set_e2e_test_env_vars.sh" && ../build_all/linux/run_tests.sh --e2e'
+      displayName: 'Run Tests'
     - task: PublishTestResults@2
-      displayName: 'Publish WolfSSL Results'
+      displayName: 'Publish Test Results (WolfSSL)'
       inputs:
         testRunner: CTest
         testResultsFiles: '**/Test.xml'
         mergeTestResults: true
         testRunTitle: 'wolfssl'
       condition: succeededOrFailed()
+
   - job: bearssl
-    container: linux-c-ubuntu-bearssl
+    timeoutInMinutes: 90
     pool:
-      name: 'sdk-c--ubuntu-22'
+      vmImage: 'ubuntu-24.04'
     displayName: 'BearSSL'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
     - script: |
-        LD_LIBRARY_PATH=/usr/local/lib
-        LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/my_library/
+        set -e
+        sudo apt-get update -qq
+        sudo ./build_all/linux/setup.sh
+        # Ensure BearSSL dev package is present so CMake can resolve libbearssl.
+        sudo apt-get install -y libbearssl-dev
+      displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
+    - script: |
         sudo -E bash jenkins/linux_bearssl.sh
       displayName: 'Build'
     - script: |
-        cd cmake && sudo -E ../build_all/linux/run_tests.sh
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
-      displayName: "Run Tests"
+        cd cmake
+        sudo bash -c 'source "$(Pipeline.Workspace)/test_config_scripts/set_e2e_test_env_vars.sh" && ../build_all/linux/run_tests.sh --e2e'
+      displayName: 'Run Tests'
     - task: PublishTestResults@2
-      displayName: 'Publish BearSSL Results'
+      displayName: 'Publish Test Results (BearSSL)'
       inputs:
         testRunner: CTest
         testResultsFiles: '**/Test.xml'
         mergeTestResults: true
         testRunTitle: 'bearssl'
       condition: succeededOrFailed()
-  - job: mbedtls
-    container: linux-c-ubuntu-mbed
+
+  - job: mbedtls_2_16
+    # Coverage for mbedTLS 2.16.x, previously provided by the linux-c-ubuntu-mbed
+    # Docker image (Ubuntu 20.04 + apt libmbedtls-dev).  Ubuntu 24.04 ships 3.x,
+    # so install 2.16.x from source.
+    timeoutInMinutes: 90
     pool:
-      name: 'sdk-c--ubuntu-22'
-    displayName: 'mbedTLS'
+      vmImage: 'ubuntu-24.04'
+    displayName: 'mbedTLS 2.16'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
     - script: |
-        LD_LIBRARY_PATH=/usr/local/lib
-        LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/my_library/
+        set -e
+        sudo apt-get update -qq
+        sudo ./build_all/linux/setup.sh
+      displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
+    - task: Cache@2
+      inputs:
+        key: 'mbedtls | "2.16.12" | "v1"'
+        path: /tmp/mbedtls-2.16-install
+        cacheHitVar: MBEDTLS_CACHE_RESTORED
+      displayName: 'Restore cached mbedTLS 2.16'
+    - script: |
+        set -e
+        if [ "$MBEDTLS_CACHE_RESTORED" = "true" ]; then
+          echo "mbedTLS 2.16 restored from cache"
+        else
+          git clone --depth 1 -b mbedtls-2.16.12 https://github.com/Mbed-TLS/mbedtls /tmp/mbedtls-2.16
+          cd /tmp/mbedtls-2.16
+          mkdir build && cd build
+          cmake -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DCMAKE_INSTALL_PREFIX=/tmp/mbedtls-2.16-install ..
+          make -j$(nproc)
+          make install
+        fi
+        sudo cp -a /tmp/mbedtls-2.16-install/* /usr/local/
+        sudo ldconfig
+      displayName: 'Install mbedTLS 2.16'
+    - script: |
         sudo -E bash jenkins/linux_mbedtls.sh
       displayName: 'Build'
-    - script: |
-        cd cmake && sudo -E ../build_all/linux/run_tests.sh
       env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
-      displayName: "Run Tests"
+        LD_LIBRARY_PATH: /usr/local/lib
+    - script: |
+        cd cmake
+        sudo bash -c 'export LD_LIBRARY_PATH=/usr/local/lib && source "$(Pipeline.Workspace)/test_config_scripts/set_e2e_test_env_vars.sh" && ../build_all/linux/run_tests.sh --e2e'
+      displayName: 'Run Tests'
     - task: PublishTestResults@2
-      displayName: 'Publish mbedTLS Results'
+      displayName: 'Publish Test Results (mbedTLS 2.16)'
       inputs:
         testRunner: CTest
         testResultsFiles: '**/Test.xml'
         mergeTestResults: true
-        testRunTitle: 'mbedtls'
+        testRunTitle: 'mbedtls_2_16'
       condition: succeededOrFailed()
-  - job: mbedtls228
-    container: linux-c-ubuntu-2204
+
+  - job: mbedtls_2_28
+    # Coverage for mbedTLS 2.28.x, previously provided by the linux-c-ubuntu-2204
+    # Docker image (Ubuntu 22.04 + apt libmbedtls-dev).  Ubuntu 24.04 ships 3.x,
+    # so install 2.28.x from source.
+    timeoutInMinutes: 90
     pool:
-      name: 'sdk-c--ubuntu-22'
+      vmImage: 'ubuntu-24.04'
     displayName: 'mbedTLS 2.28'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
+    - script: |
+        set -e
+        sudo apt-get update -qq
+        sudo ./build_all/linux/setup.sh
+      displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
+    - task: Cache@2
+      inputs:
+        key: 'mbedtls | "2.28.10" | "v1"'
+        path: /tmp/mbedtls-2.28-install
+        cacheHitVar: MBEDTLS_CACHE_RESTORED
+      displayName: 'Restore cached mbedTLS 2.28'
+    - script: |
+        set -e
+        if [ "$MBEDTLS_CACHE_RESTORED" = "true" ]; then
+          echo "mbedTLS 2.28 restored from cache"
+        else
+          git clone --depth 1 -b mbedtls-2.28.10 https://github.com/Mbed-TLS/mbedtls /tmp/mbedtls-2.28
+          cd /tmp/mbedtls-2.28
+          mkdir build && cd build
+          cmake -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DCMAKE_INSTALL_PREFIX=/tmp/mbedtls-2.28-install ..
+          make -j$(nproc)
+          make install
+        fi
+        sudo cp -a /tmp/mbedtls-2.28-install/* /usr/local/
+        sudo ldconfig
+      displayName: 'Install mbedTLS 2.28'
     - script: |
         sudo -E bash jenkins/linux_mbedtls.sh
       displayName: 'Build'
-    - script: |
-        cd cmake && sudo -E ../build_all/linux/run_tests.sh
       env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
-      displayName: "Run Tests"
+        LD_LIBRARY_PATH: /usr/local/lib
+    - script: |
+        cd cmake
+        sudo bash -c 'export LD_LIBRARY_PATH=/usr/local/lib && source "$(Pipeline.Workspace)/test_config_scripts/set_e2e_test_env_vars.sh" && ../build_all/linux/run_tests.sh --e2e'
+      displayName: 'Run Tests'
     - task: PublishTestResults@2
-      displayName: 'Publish mbedTLS Results'
+      displayName: 'Publish Test Results (mbedTLS 2.28)'
       inputs:
         testRunner: CTest
         testResultsFiles: '**/Test.xml'
         mergeTestResults: true
-        testRunTitle: 'mbedtls'
+        testRunTitle: 'mbedtls_2_28'
       condition: succeededOrFailed()
-  - job: mbedtls3x
-    container: linux-c-ubuntu-2404
+
+  - job: mbedtls_3x
+    # Coverage for mbedTLS 3.x, previously provided by the linux-c-ubuntu-2404
+    # Docker image which built v3.6.2 from source.  Reproduce that here.
+    timeoutInMinutes: 90
     pool:
-      name: 'sdk-c--ubuntu-22'
+      vmImage: 'ubuntu-24.04'
     displayName: 'mbedTLS 3.x'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
+    - script: |
+        set -e
+        sudo apt-get update -qq
+        sudo ./build_all/linux/setup.sh
+      displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
+    - task: Cache@2
+      inputs:
+        key: 'mbedtls | "3.6.2" | "v1"'
+        path: /tmp/mbedtls-3x-install
+        cacheHitVar: MBEDTLS_CACHE_RESTORED
+      displayName: 'Restore cached mbedTLS 3.x'
+    - script: |
+        set -e
+        if [ "$MBEDTLS_CACHE_RESTORED" = "true" ]; then
+          echo "mbedTLS 3.x restored from cache"
+        else
+          git clone --depth 1 -b v3.6.2 https://github.com/Mbed-TLS/mbedtls /tmp/mbedtls-3x
+          cd /tmp/mbedtls-3x
+          git submodule update --init --depth 1
+          mkdir build && cd build
+          cmake -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DCMAKE_INSTALL_PREFIX=/tmp/mbedtls-3x-install ..
+          make -j$(nproc)
+          make install
+        fi
+        sudo cp -a /tmp/mbedtls-3x-install/* /usr/local/
+        sudo ldconfig
+      displayName: 'Install mbedTLS 3.x'
     - script: |
         sudo -E bash jenkins/linux_mbedtls.sh
       displayName: 'Build'
-    - script: |
-        cd cmake && sudo -E ../build_all/linux/run_tests.sh
       env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
-      displayName: "Run Tests"
+        LD_LIBRARY_PATH: /usr/local/lib
+    - script: |
+        cd cmake
+        sudo bash -c 'export LD_LIBRARY_PATH=/usr/local/lib && source "$(Pipeline.Workspace)/test_config_scripts/set_e2e_test_env_vars.sh" && ../build_all/linux/run_tests.sh --e2e'
+      displayName: 'Run Tests'
     - task: PublishTestResults@2
-      displayName: 'Publish mbedTLS Results'
+      displayName: 'Publish Test Results (mbedTLS 3.x)'
       inputs:
         testRunner: CTest
         testResultsFiles: '**/Test.xml'
         mergeTestResults: true
-        testRunTitle: 'mbedtls'
+        testRunTitle: 'mbedtls_3x'
       condition: succeededOrFailed()
+
   - job: cares
-    container: linux-c-ubuntu-c-ares
-    pool: 
-      name: 'sdk-c--ubuntu-22'
+    timeoutInMinutes: 90
+    pool:
+      vmImage: 'ubuntu-24.04'
     displayName: 'Linux with C-Ares'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
+    - script: |
+        set -e
+        sudo apt-get update -qq
+        sudo ./build_all/linux/setup.sh
+        sudo apt-get install -y libc-ares-dev
+      displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
     - script: |
         sudo -E bash jenkins/linux_cares.sh
       displayName: 'Build'
     - script: |
-        cd cmake && sudo -E ../build_all/linux/run_tests.sh
-      displayName: "Run Tests"
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
+        cd cmake
+        sudo bash -c 'source "$(Pipeline.Workspace)/test_config_scripts/set_e2e_test_env_vars.sh" && ../build_all/linux/run_tests.sh --e2e'
+      displayName: 'Run Tests'
     - task: PublishTestResults@2
-      displayName: 'Publish C Ares Results'
+      displayName: 'Publish Test Results (C-Ares)'
       inputs:
         testRunner: CTest
         testResultsFiles: '**/Test.xml'
         mergeTestResults: true
         testRunTitle: 'cares'
       condition: succeededOrFailed()
+
   - job: openssl_engine
-    container: linux-c-openssl-pkcs11
-    pool: 
-      name: 'sdk-c--ubuntu-22'
+    timeoutInMinutes: 90
+    pool:
+      vmImage: 'ubuntu-24.04'
     displayName: 'OpenSSL with pkcs11 engine and SoftHSM'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
     - script: |
-        sudo -E bash jenkins/linux_openssl_engine.sh
+        set -e
+        sudo apt-get update -qq
+        sudo ./build_all/linux/setup.sh
+        sudo apt-get install -y softhsm2 libengine-pkcs11-openssl opensc libp11-dev
+      displayName: 'Host setup'
+    - task: Cache@2
+      inputs:
+        key: 'ccache | "$(Agent.JobName)" | "v1"'
+        path: /tmp/ccache_cache
+      displayName: 'Restore ccache'
+    - script: |
+        mkdir -p /tmp/ccache_cache && chmod 777 /tmp/ccache_cache
+        ccache --set-config=max_size=500M
+        ccache --zero-stats
+      displayName: 'Configure ccache'
+    - script: |
+        # Use dynamically generated E2E variables from Setup stage to avoid unresolved placeholders.
+        sudo bash -c 'source "$(Pipeline.Workspace)/test_config_scripts/set_e2e_test_env_vars.sh" && ./jenkins/linux_openssl_engine.sh'
       displayName: 'Build'
-      env:
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
     - script: |
-        cd cmake && sudo -E ../build_all/linux/run_tests.sh
-      displayName: "Run Tests"
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
+        cd cmake
+        sudo bash -c 'source "$(Pipeline.Workspace)/test_config_scripts/set_e2e_test_env_vars.sh" && ../build_all/linux/run_tests.sh --e2e'
+      displayName: 'Run Tests'
     - task: PublishTestResults@2
-      displayName: 'Publish openssl_engine Results'
+      displayName: 'Publish Test Results (OpenSSL Engine)'
       inputs:
         testRunner: CTest
         testResultsFiles: '**/Test.xml'
         mergeTestResults: true
         testRunTitle: 'openssl_engine'
       condition: succeededOrFailed()
+
   - job: OSX
-    variables:
-      CodeQL.Enabled: false
     pool:
-      vmImage: 'macOS-13'
+      vmImage: 'macOS-14'
+    displayName: 'OSX'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
     - script: |
         ./jenkins/osx_gcc_openssl.sh
       displayName: 'Build'
     - script: |
-        cd cmake && ctest -T test --no-compress-output -C "Debug" -V -j 8 --schedule-random
+        cd cmake
+        bash -c 'source "$(Pipeline.Workspace)/test_config_scripts/set_e2e_test_env_vars.sh" && ctest -T test --no-compress-output -C "Debug" -V -j 8 --schedule-random -E iothubclient_mqtt_dt_e2e'
       displayName: 'Run Tests'
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
     - task: PublishTestResults@2
       displayName: 'Publish OSX Results'
       inputs:
@@ -1041,13 +1201,18 @@ stages:
     - script: rm -rf $(Agent.BuildDirectory)/*
       displayName: 'Cleanup'
       condition: always()
+
   - job: xcodenative
-    variables:
-      CodeQL.Enabled: false
     pool:
-      vmImage: 'macOS-13'
-    displayName: "Xcode Native"
+      vmImage: 'macOS-14'
+    displayName: 'Xcode Native'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
     - script: |
         curl --version
         export DYLD_LIBRARY_PATH="/usr/local/Cellar/curl/$(ls -b /usr/local/Cellar/curl | grep -e '[0-9\.]')/lib"
@@ -1055,28 +1220,9 @@ stages:
       displayName: 'Build'
     - script: |
         export DYLD_LIBRARY_PATH="/usr/local/Cellar/curl/$(ls -b /usr/local/Cellar/curl | grep -e '[0-9\.]')/lib"
-        cd cmake && ctest -T test --no-compress-output -C "Debug" -V -j 8 --schedule-random
-      displayName: "Run Tests"
-      env:
-        IOTHUB_CONNECTION_STRING: $(IOTHUB-CONNECTION-STRING)
-        IOTHUB_EVENTHUB_CONNECTION_STRING: $(IOTHUB-EVENTHUB-CONNECTION-STRING)
-        IOTHUB_E2E_X509_CERT_BASE64: $(IOTHUB-E2E-X509-CERT-BASE64)
-        IOTHUB_E2E_X509_PRIVATE_KEY_BASE64: $(IOTHUB-E2E-X509-PRIVATE-KEY-BASE64)
-        IOTHUB_E2E_X509_THUMBPRINT: $(IOTHUB-E2E-X509-THUMBPRINT)
-        IOTHUB_POLICY_KEY: $(IOTHUB-POLICY-KEY)
-        STORAGE_ACCOUNT_CONNECTION_STRING: $(STORAGE-ACCOUNT-CONNECTION-STRING)
-        IOT_DPS_CONNECTION_STRING: $(IOT-DPS-CONNECTION-STRING)
-        IOT_DPS_ID_SCOPE: $(IOT-DPS-ID-SCOPE)
-        IOTHUB_CA_ROOT_CERT: $(IOTHUB-CA-ROOT-CERT)
-        IOTHUB_CA_ROOT_CERT_KEY: $(IOTHUB-CA-ROOT-CERT-KEY)
-        IOT_DPS_GLOBAL_ENDPOINT: $(IOT-DPS-GLOBAL-ENDPOINT)
-        IOTHUB_DEVICE_CONN_STRING_INVALIDCERT: $(IOTHUB-DEVICE-CONN-STRING-INVALIDCERT)
-        IOTHUB_CONN_STRING_INVALIDCERT: $(IOTHUB-CONN-STRING-INVALIDCERT)
-        DPS_GLOBALDEVICEENDPOINT_INVALIDCERT: $(DPS-GLOBALDEVICEENDPOINT-INVALIDCERT)
-        PROVISIONING_CONNECTION_STRING_INVALIDCERT: $(PROVISIONING-CONNECTION-STRING-INVALIDCERT)
-        IOT_DPS_INDIVIDUAL_X509_CERTIFICATE: $(IOTHUB-E2E-X509-ECC-CERT-BASE64)
-        IOT_DPS_INDIVIDUAL_X509_KEY: $(IOTHUB-E2E-X509-ECC-PRIVATE-KEY-BASE64)
-        IOT_DPS_INDIVIDUAL_REGISTRATION_ID: $(IOT-DPS-INDIVIDUAL-REGISTRATION-ID)
+        cd cmake
+        bash -c 'source "$(Pipeline.Workspace)/test_config_scripts/set_e2e_test_env_vars.sh" && ctest -T test --no-compress-output -C "Debug" -V -j 8 --schedule-random -E iothubclient_mqtt_dt_e2e'
+      displayName: 'Run Tests'
     - task: PublishTestResults@2
       displayName: 'Publish XCode Results'
       inputs:
@@ -1090,72 +1236,22 @@ stages:
     - script: rm -rf $(Agent.BuildDirectory)/*
       displayName: 'Cleanup'
       condition: always()
-  - job: raspberrypi
-    container: raspberrypi-c-buster
-    pool: 
-      name: 'sdk-c--ubuntu-22'
-    displayName: "Raspberry Pi"
-    steps:
-    - script: |
-       $HOME
-       whoami
-       ls -lr
-       pwd
-       chmod +x jenkins/raspberrypi_c_buster.sh
-        ./jenkins/raspberrypi_c_buster.sh
-      displayName: 'Build'
-  - job: crosscompile_mips32
-    pool:
-      vmImage: 'ubuntu-20.04'
-    displayName: "Cross Compile (MIPS32)"
-    steps:
-    - script: |
-        sudo apt-get update && sudo apt-get install -y \
-        curl \
-        git \
-        python-software-properties \
-        build-essential \
-        pkg-config \
-        docker.io
-        sudo curl -sL https://deb.nodesource.com/setup_16.x | bash -
-        sudo apt-get install -y nodejs
-      displayName: 'Setup'
-    - script: |
-        cd samples/dockerbuilds/MIPS32
-        docker build --build-arg TARGET_BRANCH=$BUILD_SOURCEBRANCH -t mipsiotbuild:latest . --network=host
-        cd ..
-        docker build -t mipsiotapp:latest . --network=host --file ./MIPS32/Dockerfile_adjunct
-      displayName: 'Build MIPS32'
-  - job: crosscompile_arm
-    pool:
-      vmImage: 'ubuntu-20.04'
-    displayName: "Cross Compile (ARM)"
-    steps:
-    - script: |
-        sudo apt-get update && sudo apt-get install -y \
-        curl \
-        git \
-        python-software-properties \
-        build-essential \
-        pkg-config \
-        docker.io
-        sudo curl -sL https://deb.nodesource.com/setup_16.x | bash -
-        sudo apt-get install -y nodejs
-      displayName: 'Setup'
-    - script: |
-        cd samples/dockerbuilds/ARM
-        docker build --build-arg TARGET_BRANCH=$BUILD_SOURCEBRANCH -t armiotbuild:latest . --network=host
-        cd ..
-        docker build -t armiotapp:latest . --network=host --file ./ARM/Dockerfile_adjunct
-      displayName: 'Build ARM'
+
   - job: DotNET
-    displayName: .NET
+    displayName: '.NET'
     variables:
+      # Owns the 'csharp' and 'python' CodeQL snapshots for this repo. csharp comes
+      # from tracing the traceabilitytool build below; python is an interpreted
+      # language, so CodeQL extracts it straight from the checked-out sources.
+      # Overrides the pipeline-level Codeql.Enabled: false.
       Codeql.Enabled: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
       Codeql.Language: csharp,python
-    pool: 
-      vmImage: 'windows-latest'
+    pool:
+      vmImage: 'windows-2022'
     steps:
+    - checkout: self
+      submodules: true
+      fetchDepth: 1
     - task: CodeQL3000Init@0
     - task: NuGetCommand@2
       inputs:
@@ -1169,20 +1265,31 @@ stages:
         projects: 'tools\traceabilitytool\traceabilitytool.sln'
     - task: CodeQL3000Finalize@0
       condition: always()
-- stage: Cleanup 
+
+- stage: Cleanup
+  dependsOn:
+  - Setup
+  - Tests
+  condition: always()
   jobs:
-  - job: cleanup
-    container: linux-c-ubuntu-2204
+  - job: destroy_azure_resource_group
+    condition: always() # Run job even if the pipeline run is cancelled.
     pool:
-      name: 'sdk-c--ubuntu-22'
-    displayName: 'Cleanup'
+      vmImage: 'ubuntu-24.04'
     steps:
-    - script: |
-        az login --identity
-        az storage account update -g $STORAGE_ACCOUNT_RESOURCE_GROUP -n $STORAGE_ACCOUNT_NAME --allow-shared-key-access false --default-action Deny
-      displayName: 'Setup Azure Storage Account'
-      env:
-        STORAGE_ACCOUNT_NAME: $(STORAGE-ACCOUNT-NAME)
-        STORAGE_ACCOUNT_RESOURCE_GROUP: $(STORAGE-ACCOUNT-RESOURCE-GROUP)
-      condition: always() # Run even if the pipeline run is cancelled.
-  
+    - checkout: none
+    - download: current
+      artifact: test_config_scripts
+      displayName: Download artifact (test config scripts)
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: 'iot hub sdk service connection'
+        scriptType: 'bash'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          set -e
+          export AZURE_RESOURCE_GROUP=$(cat "$(Pipeline.Workspace)/test_config_scripts/azure-resource-group-name.txt")
+          az group delete --name $AZURE_RESOURCE_GROUP --yes --no-wait
+      displayName: Destroy Azure Resource Group
+      condition: always() # Run step even if the pipeline run is cancelled.
+

--- a/build_all/docs/Doxyfile
+++ b/build_all/docs/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Microsoft Azure IoT Device SDK for C"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.14.0
+PROJECT_NUMBER         = 1.15.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/build_all/docs/Doxyfile
+++ b/build_all/docs/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Microsoft Azure IoT Device SDK for C"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.15.0
+PROJECT_NUMBER         = 1.14.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/build_all/linux/build.sh
+++ b/build_all/linux/build.sh
@@ -139,7 +139,15 @@ rm -r -f $build_folder
 mkdir -m777 -p $build_folder
 pushd $build_folder
 echo "Generating Build Files"
-cmake $toolchainfile $cmake_install_prefix $build_root -Drun_valgrind:BOOL=$run_valgrind -DcompileOption_C:STRING="$extracloptions" -Drun_e2e_tests:BOOL=$run_e2e_tests -Drun_sfc_tests:BOOL=$run_sfc_tests -Drun_longhaul_tests=$run_longhaul_tests -Duse_amqp:BOOL=$build_amqp -Duse_http:BOOL=$build_http -Duse_mqtt:BOOL=$build_mqtt -Ddont_use_uploadtoblob:BOOL=$no_blob -Drun_unittests:BOOL=$run_unittests -Dno_logging:BOOL=$no_logging -Duse_prov_client:BOOL=$prov_auth -Duse_tpm_simulator:BOOL=$prov_use_tpm_simulator -Duse_edge_modules=$use_edge_modules -Dhsm_type_riot=$hsm_type_riot -Dhsm_type_x509=$hsm_type_x509 -Dhsm_type_symm_key=$hsm_type_symm_key -Dhsm_type_sastoken=$hsm_type_sastoken -Denable_ipv6=$enable_ipv6 -DCMAKE_BUILD_TYPE=$build_config
+
+# Use ccache as compiler launcher when available for faster rebuilds.
+CCACHE_LAUNCHER=""
+if command -v ccache >/dev/null 2>&1; then
+  CCACHE_LAUNCHER="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+  echo "ccache found — enabling CMAKE_*_COMPILER_LAUNCHER"
+fi
+
+cmake $toolchainfile $cmake_install_prefix $build_root $CCACHE_LAUNCHER -Drun_valgrind:BOOL=$run_valgrind -DcompileOption_C:STRING="$extracloptions" -Drun_e2e_tests:BOOL=$run_e2e_tests -Drun_sfc_tests:BOOL=$run_sfc_tests -Drun_longhaul_tests=$run_longhaul_tests -Duse_amqp:BOOL=$build_amqp -Duse_http:BOOL=$build_http -Duse_mqtt:BOOL=$build_mqtt -Ddont_use_uploadtoblob:BOOL=$no_blob -Drun_unittests:BOOL=$run_unittests -Dno_logging:BOOL=$no_logging -Duse_prov_client:BOOL=$prov_auth -Duse_tpm_simulator:BOOL=$prov_use_tpm_simulator -Duse_edge_modules=$use_edge_modules -Dhsm_type_riot=$hsm_type_riot -Dhsm_type_x509=$hsm_type_x509 -Dhsm_type_symm_key=$hsm_type_symm_key -Dhsm_type_sastoken=$hsm_type_sastoken -Denable_ipv6=$enable_ipv6 -DCMAKE_BUILD_TYPE=$build_config
 chmod --recursive ugo+rw ../cmake
 
 # Set the default cores

--- a/build_all/linux/run_tests.sh
+++ b/build_all/linux/run_tests.sh
@@ -44,6 +44,13 @@ if $ut_only && $e2e_only; then
     exit 1
 fi
 
+# --e2e-only selects the E2E half of a run, so there has to be an E2E half to
+# select. Without --e2e the old code silently ran nothing and exited 0.
+if $e2e_only && ! $run_e2e; then
+    echo "--e2e-only requires --e2e"
+    exit 1
+fi
+
 # If no instrumentation flags are set, run plain (non-valgrind) tests.
 run_plain=true
 if $run_valgrind || $run_helgrind || $run_drd; then
@@ -55,17 +62,22 @@ sudo ldconfig
 
 if $run_plain; then
     if $run_e2e; then
-        if ! $ut_only; then
+        # iothubclient_mqtt_dt_e2e is quarantined: see GitHub issue (twin PATCH never
+        # delivered to device after subscribe; pre-existing flake, not pipeline-related).
+        if $e2e_only; then
+            # E2E only
+            ctest -T test --no-compress-output -C "Debug" -V -j $E2E_CORES --schedule-random -R "e2e$" -E "_(valgrind|helgrind|drd)$|^iothubclient_mqtt_dt_e2e$"
+        elif $ut_only; then
+            # Unit tests only
+            ctest -T test --no-compress-output -C "Debug" -V -j $UT_CORES --schedule-random -E "_(valgrind|helgrind|drd)|e2e"
+        else
             # Unit tests + E2E, no valgrind/helgrind/drd
-            # iothubclient_mqtt_dt_e2e is quarantined: see GitHub issue (twin PATCH never
-            # delivered to device after subscribe; pre-existing flake, not pipeline-related).
             ctest -T test --no-compress-output -C "Debug" -V -j $E2E_CORES --schedule-random -E "_(valgrind|helgrind|drd)$|^iothubclient_mqtt_dt_e2e$"
         fi
     else
-        if ! $e2e_only; then
-            # Unit tests only, no E2E, no valgrind/helgrind/drd
-            ctest -T test --no-compress-output -C "Debug" -V -j $UT_CORES --schedule-random -E "_(valgrind|helgrind|drd)|e2e"
-        fi
+        # Unit tests only, no E2E, no valgrind/helgrind/drd
+        # ($e2e_only without --e2e is rejected above.)
+        ctest -T test --no-compress-output -C "Debug" -V -j $UT_CORES --schedule-random -E "_(valgrind|helgrind|drd)|e2e"
     fi
 fi
 

--- a/build_all/linux/run_tests.sh
+++ b/build_all/linux/run_tests.sh
@@ -6,10 +6,106 @@
 set -o errexit # Exit if command failed.
 set -o pipefail # Exit if pipe failed.
 
-# Only for testing E2E behaviour !!! 
-TEST_CORES=16
+# Parallelism settings
+UT_CORES=16
+# E2E tests are latency-sensitive: every test opens multiple AMQP+HTTPS
+# connections to IoT Hub in parallel and asserts on MAX_CLOUD_TRAVEL_TIME
+# (seconds). Microsoft-hosted Ubuntu agents are 4-vCPU VMs, so running the
+# ~16 E2E binaries all at -j 16 oversubscribes CPU and network and causes
+# per-request latency to spike above the assertion threshold
+# (seen: service_client_update_twin taking 126s vs ~1s baseline, which
+# blew MAX_CLOUD_TRAVEL_TIME in iothubclient_amqp_dt_e2e on the mbedTLS
+# job). Keep E2E parallelism at 4 to match the hosted-agent core count.
+E2E_CORES=4
+VALGRIND_UT_CORES=4
+VALGRIND_E2E_CORES=2
+
+run_e2e=false
+run_valgrind=false
+run_helgrind=false
+run_drd=false
+ut_only=false
+e2e_only=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --e2e)       run_e2e=true ;;
+        --valgrind)  run_valgrind=true ;;
+        --helgrind)  run_helgrind=true ;;
+        --drd)       run_drd=true ;;
+        --ut-only)   ut_only=true ;;
+        --e2e-only)  e2e_only=true ;;
+        *)           echo "Unknown option: $arg"; exit 1 ;;
+    esac
+done
+
+if $ut_only && $e2e_only; then
+    echo "Cannot use --ut-only and --e2e-only together"
+    exit 1
+fi
+
+# If no instrumentation flags are set, run plain (non-valgrind) tests.
+run_plain=true
+if $run_valgrind || $run_helgrind || $run_drd; then
+    run_plain=false
+fi
 
 # Refresh dynamic libs to link to
 sudo ldconfig
 
-ctest -T test --no-compress-output -C "Debug" -V -j $TEST_CORES --schedule-random
+if $run_plain; then
+    if $run_e2e; then
+        if ! $ut_only; then
+            # Unit tests + E2E, no valgrind/helgrind/drd
+            # iothubclient_mqtt_dt_e2e is quarantined: see GitHub issue (twin PATCH never
+            # delivered to device after subscribe; pre-existing flake, not pipeline-related).
+            ctest -T test --no-compress-output -C "Debug" -V -j $E2E_CORES --schedule-random -E "_(valgrind|helgrind|drd)$|^iothubclient_mqtt_dt_e2e$"
+        fi
+    else
+        if ! $e2e_only; then
+            # Unit tests only, no E2E, no valgrind/helgrind/drd
+            ctest -T test --no-compress-output -C "Debug" -V -j $UT_CORES --schedule-random -E "_(valgrind|helgrind|drd)|e2e"
+        fi
+    fi
+fi
+
+if $run_valgrind; then
+    if ! $e2e_only; then
+        # Unit tests under valgrind
+        ctest -T test --no-compress-output -C "Debug" -V -j $VALGRIND_UT_CORES --schedule-random -R "_valgrind$" -E "e2e"
+    fi
+    if $run_e2e; then
+        if ! $ut_only; then
+            # E2E tests under valgrind. Quarantined:
+            #   iothubclient_mqtt_dt_e2e: see GitHub issue (twin PATCH delivery flake).
+            ctest -T test --no-compress-output -C "Debug" -V -j $VALGRIND_E2E_CORES --schedule-random -R "e2e_valgrind$" -E "^iothubclient_mqtt_dt_e2e_valgrind$"
+        fi
+    fi
+fi
+
+if $run_helgrind; then
+    if ! $e2e_only; then
+        # Unit tests under helgrind
+        ctest -T test --no-compress-output -C "Debug" -V -j $VALGRIND_UT_CORES --schedule-random -R "_helgrind$" -E "e2e"
+    fi
+    if $run_e2e; then
+        if ! $ut_only; then
+            # E2E tests under helgrind. Quarantined:
+            #   iothubclient_mqtt_dt_e2e: see GitHub issue (twin PATCH delivery flake).
+            ctest -T test --no-compress-output -C "Debug" -V -j $VALGRIND_E2E_CORES --schedule-random -R "e2e_helgrind$" -E "^iothubclient_mqtt_dt_e2e_helgrind$"
+        fi
+    fi
+fi
+
+if $run_drd; then
+    if ! $e2e_only; then
+        # Unit tests under drd
+        ctest -T test --no-compress-output -C "Debug" -V -j $VALGRIND_UT_CORES --schedule-random -R "_drd$" -E "e2e"
+    fi
+    # NOTE: E2E tests are intentionally not run under drd.  drd's thread instrumentation adds
+    # 20-50x performance overhead, which makes libcurl's TLS handshakes to Azure services fail
+    # with "SSL connect error".  Each failed IoTHubDeviceMethod_Invoke then cascades through
+    # its retry loop (~85s per retry), causing individual test suites to exceed 30+ minutes
+    # and the overall pipeline to hit its timeout.  Thread-race detection for E2E scenarios
+    # is still provided by the helgrind pass, which is the primary thread-safety tool.
+fi

--- a/build_all/linux/setup.sh
+++ b/build_all/linux/setup.sh
@@ -9,7 +9,7 @@ repo_name_from_uri()
 }
 
 scriptdir=$(cd "$(dirname "$0")" && pwd)
-deps="curl build-essential pkg-config libcurl4-openssl-dev git cmake libssl-dev uuid-dev valgrind"
+deps="curl build-essential pkg-config libcurl4-openssl-dev git cmake libssl-dev uuid-dev valgrind ccache"
 repo="https://github.com/Azure/azure-iot-sdk-c.git"
 repo_name=$(repo_name_from_uri $repo)
 

--- a/iothub_client/tests/global_valgrind_suppression.supp
+++ b/iothub_client/tests/global_valgrind_suppression.supp
@@ -1,4 +1,14 @@
 {
+    macro-utils-c MU_DEFINE_ENUM_STRINGS lazy-init of enum_value_has_equal (benign race, documented in macro_utils.h)
+    Helgrind:Race
+    fun:MU_*_ToString
+}
+{
+    macro-utils-c MU_DEFINE_ENUM_STRINGS lazy-init of result/visited (benign race)
+    Helgrind:Race
+    fun:*_for_ctest_ToString
+}
+{
     CRYPTO_malloc allow customization race in OpenSSL
     Helgrind:Race
     obj:/*lib*/libcrypto*
@@ -188,7 +198,7 @@
 {
    OpenSSL/libp11-0.4.11
    Helgrind:Misc
-   obj:/usr/lib/x86_64-linux-gnu/valgrind/vgpreload_helgrind-amd64-linux.so
+   obj:*/vgpreload_helgrind-amd64-linux.so
    ...
    fun:_dl_fini
    fun:__run_exit_handlers
@@ -339,7 +349,7 @@
 {
    Helgrind thinks LOCK_HANDLE is not a mutex
    Helgrind:Misc
-   obj:/usr/lib/x86_64-linux-gnu/valgrind/vgpreload_helgrind-amd64-linux.so
+   obj:*/vgpreload_helgrind-amd64-linux.so
    fun:_dl_fini
    fun:__run_exit_handlers
    fun:exit
@@ -348,7 +358,7 @@
 {
    Helgrind thinks LOCK_HANDLE is not a mutex
    Helgrind:Misc
-   obj:/usr/lib/x86_64-linux-gnu/valgrind/vgpreload_helgrind-amd64-linux.so
+   obj:*/vgpreload_helgrind-amd64-linux.so
    obj:/usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.0
    fun:_dl_fini
    fun:__run_exit_handlers
@@ -1646,4 +1656,151 @@
    fun:TestSuiteInitialize
    fun:RunTests
    fun:main
+}
+
+# ------------------------------------------------------------------------
+# Ubuntu 24.04 (glibc 2.39 / valgrind 3.22) - libp11-kit shared-library
+# destructor calls pthread_mutex_destroy on already-torn-down mutexes
+# during process exit. Matches the existing libp11 suppression style above.
+# ------------------------------------------------------------------------
+{
+   libp11-kit pthread_mutex_destroy at exit (Ubuntu 24.04 / glibc 2.39)
+   Helgrind:Misc
+   obj:*/vgpreload_helgrind-amd64-linux.so
+   ...
+   fun:_dl_call_fini
+   fun:_dl_fini
+   fun:__run_exit_handlers
+   fun:exit
+   fun:(below main)
+}
+{
+   libp11-kit pthread_mutex_destroy at exit (Ubuntu 24.04 / PthAPIerror variant)
+   Helgrind:PthAPIerror
+   obj:*/vgpreload_helgrind-amd64-linux.so
+   ...
+   fun:_dl_call_fini
+   fun:_dl_fini
+   fun:__run_exit_handlers
+   fun:exit
+   fun:(below main)
+}
+# ------------------------------------------------------------------------
+# Ubuntu 22.04 (glibc 2.35 / valgrind 3.18) - libp11-kit destructor stack
+# does not include _dl_call_fini, so the entries above don't match. Same
+# bug class - mutex destroyed during shared-library finalization.
+# ------------------------------------------------------------------------
+{
+   libp11-kit pthread_mutex_destroy at exit (Ubuntu 22.04 / glibc 2.35)
+   Helgrind:Misc
+   obj:*/vgpreload_helgrind-amd64-linux.so
+   obj:/usr/lib/x86_64-linux-gnu/libp11-kit.so*
+   fun:_dl_fini
+   fun:__run_exit_handlers
+   fun:exit
+   fun:(below main)
+}
+# ------------------------------------------------------------------------
+# HTTPAPIEX one-time-init flag (`useGlobalInitialization`) - the main
+# thread sets it under no lock in HTTPAPIEX_Init() during IoTHub_Init,
+# while the transport worker thread later reads it (under locks) from
+# HTTPAPIEX_ExecuteRequest(). The init happens before any worker thread
+# is created, so the read-after-write is safe in practice but helgrind
+# cannot prove the happens-before through pthread_create.
+# ------------------------------------------------------------------------
+{
+   HTTPAPIEX_Init useGlobalInitialization one-time init flag (write)
+   Helgrind:Race
+   fun:HTTPAPIEX_Init
+}
+{
+   HTTPAPIEX_Init useGlobalInitialization one-time init flag (read)
+   Helgrind:Race
+   fun:HTTPAPIEX_ExecuteRequest
+}
+{
+   DRD HTTPAPIEX_Init useGlobalInitialization one-time init flag (write)
+   drd:ConflictingAccess
+   fun:HTTPAPIEX_Init
+}
+{
+   DRD HTTPAPIEX_Init useGlobalInitialization one-time init flag (read)
+   drd:ConflictingAccess
+   fun:HTTPAPIEX_ExecuteRequest
+}
+# ------------------------------------------------------------------------
+# glibc stdio buffer races on stdout between the test's main thread
+# (calling printf/puts from RecvMessage / RunTests) and the IoT Hub
+# message callback running on the transport worker thread (also calling
+# puts/printf). Existing file has DRD entries that match the older
+# `fun:vfprintf` / `fun:_IO_file_xsputn@@GLIBC_2.2.5` symbols; on
+# Ubuntu 24.04 (glibc 2.39 / valgrind 3.22) the inner frames changed
+# to `__printf_buffer_write`, `__printf_buffer`, `__vfprintf_internal`,
+# and the matching Helgrind:Race entries were never present.
+# ------------------------------------------------------------------------
+{
+   Helgrind glibc stdio race on stdout buffer (printf via __printf_buffer_write)
+   Helgrind:Race
+   ...
+   fun:__printf_buffer_write
+   ...
+}
+{
+   Helgrind glibc stdio race on stdout buffer (printf via __printf_buffer)
+   Helgrind:Race
+   ...
+   fun:__printf_buffer
+   ...
+}
+{
+   Helgrind glibc stdio race on stdout buffer (printf via __vfprintf_internal)
+   Helgrind:Race
+   ...
+   fun:__vfprintf_internal
+   ...
+}
+{
+   Helgrind glibc stdio race on stdout buffer (puts)
+   Helgrind:Race
+   ...
+   fun:_IO_file_xsputn*
+   fun:puts
+   ...
+}
+{
+   Helgrind glibc stdio race on stdout buffer (write via _IO_file_write)
+   Helgrind:Race
+   fun:__libc_write
+   fun:write
+   fun:_IO_file_write*
+   ...
+}
+{
+   DRD glibc stdio race on stdout buffer (printf via __printf_buffer_write)
+   drd:ConflictingAccess
+   ...
+   fun:__printf_buffer_write
+   ...
+}
+{
+   DRD glibc stdio race on stdout buffer (printf via __printf_buffer)
+   drd:ConflictingAccess
+   ...
+   fun:__printf_buffer
+   ...
+}
+{
+   DRD glibc stdio race on stdout buffer (printf via __vfprintf_internal)
+   drd:ConflictingAccess
+   ...
+   fun:__vfprintf_internal
+   ...
+}
+{
+   DRD glibc stdio race on stdout buffer (write via _IO_file_write)
+   drd:ConflictingAccess
+   fun:__libc_write
+   fun:write
+   fun:_IO_file_write*
+   ...
 }

--- a/jenkins/linux_c_option_test.sh
+++ b/jenkins/linux_c_option_test.sh
@@ -65,7 +65,13 @@ declare -a arr=(
     "-Duse_prov_client:BOOL=ON -Dhsm_type_sastoken:BOOL=ON"
     "-Duse_prov_client:BOOL=ON -Dstrict_prototypes:BOOL=ON"
     "-Duse_prov_client:BOOL=ON -DcompileOption_C=-Wunused-variable"
-     "-Duse_prov_client:BOOL=ON -DcompileOption_C=-Wmaybe-uninitialized"
+    # NOTE: -Wmaybe-uninitialized is intentionally NOT exercised here.
+    # gcc 12+ (default on Ubuntu 24.04) emits a known false positive for the
+    # very common pattern `T *p = malloc(...); if (p == NULL) ...; else if
+    # (fn_taking_const_void_ptr(p) ...)`, even with explicit initializers and
+    # at every -O level. The SDK uses this pattern in many places (e.g.
+    # iothubtransport_amqp_telemetry_messenger.c). Re-enable this option only
+    # once a tool-chain that does not regress on this pattern is in use.
 )
 
 for item in "${arr[@]}"

--- a/jenkins/osx_gcc_openssl.sh
+++ b/jenkins/osx_gcc_openssl.sh
@@ -21,5 +21,5 @@ CORES=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || sysctl -n hw.ncpu)
 rm -r -f $build_folder
 mkdir -p $build_folder
 pushd $build_folder
-cmake .. -DOPENSSL_ROOT_DIR:PATH=/usr/local/opt/openssl -Duse_openssl:bool=ON -Drun_unittests:bool=ON
+cmake .. -DOPENSSL_ROOT_DIR:PATH=/usr/local/opt/openssl -Duse_openssl:bool=ON -Drun_unittests:bool=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 cmake --build . -- --jobs=$CORES

--- a/jenkins/osx_xcode_native.sh
+++ b/jenkins/osx_xcode_native.sh
@@ -22,6 +22,6 @@ rm -r -f $build_folder
 mkdir -p $build_folder
 pushd $build_folder
 
-cmake .. -Duse_prov_client=OFF -Dhsm_type_x509=OFF -Dhsm_type_sastoken=OFF -Dhsm_type_symm_key=OFF -Drun_e2e_tests=ON -Ddont_use_uploadtoblob:BOOL=ON -G Xcode -DCMAKE_BUILD_TYPE=Debug
+cmake .. -Duse_prov_client=OFF -Dhsm_type_x509=OFF -Dhsm_type_sastoken=OFF -Dhsm_type_symm_key=OFF -Drun_e2e_tests=ON -Ddont_use_uploadtoblob:BOOL=ON -G Xcode -DCMAKE_BUILD_TYPE=Debug -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 cmake --build . -- --jobs=$CORES
 popd

--- a/jenkins/raspberrypi/Dockerfile
+++ b/jenkins/raspberrypi/Dockerfile
@@ -38,20 +38,20 @@ ENV LD=${TOOLCHAIN_EXES}/${TOOLCHAIN_NAME}-ld
 ENV NM=${TOOLCHAIN_EXES}/${TOOLCHAIN_NAME}-nm
 
 ENV LDFLAGS="-L${TOOLCHAIN_SYSROOT}/usr/lib"
-ENV LIBS="-lssl -lcrypto -ldl -lpthread"
+ENV LIBS="-lssl -lcrypto -ldl -lpthread -latomic"
 ENV STAGING_DIR=${TOOLCHAIN_SYSROOT}
 
 
 ########## OPENSSL INSTALL ##########
 # Download OpenSSL source and expand it
-ENV OPENSSL_SOURCE=openssl-1.1.1f
+ENV OPENSSL_SOURCE=openssl-3.0.15
 RUN wget https://www.openssl.org/source/${OPENSSL_SOURCE}.tar.gz
 RUN tar -xvf ${OPENSSL_SOURCE}.tar.gz
 
 # Build OpenSSL
 
 WORKDIR /${WORK_ROOT}/${OPENSSL_SOURCE}
-RUN ./Configure linux-generic32 shared --prefix=${TOOLCHAIN_PREFIX} --openssldir=${TOOLCHAIN_PREFIX}
+RUN ./Configure linux-generic32 shared no-tests --prefix=${TOOLCHAIN_PREFIX} --openssldir=${TOOLCHAIN_PREFIX}
 RUN make
 RUN make install
 WORKDIR /${WORK_ROOT}
@@ -59,14 +59,17 @@ WORKDIR /${WORK_ROOT}
 
 ########## CURL INSTALL ##########
 # Download cURL source and expand it
-ENV CURL_SOURCE=curl-7.64.1
-RUN wget http://curl.haxx.se/download/${CURL_SOURCE}.tar.gz
+ENV CURL_VERSION=8.20.0
+ENV CURL_SOURCE=curl-${CURL_VERSION}
+RUN wget https://curl.se/download/${CURL_SOURCE}.tar.gz
 RUN tar -xvf ${CURL_SOURCE}.tar.gz
 
 # Build cURL
-# we need to set the path for openssl with --with-ssl=...
+# --with-openssl points at our cross-built OpenSSL (option renamed from --with-ssl in curl 7.77.0).
+# --disable-ntlm: the SDK never uses NTLM auth; this excludes curl's MD4-based NTLM
+# code (curl_ntlm_core.c), which is flagged as use of the banned hash algorithm MD4.
 WORKDIR /${WORK_ROOT}/${CURL_SOURCE}
-RUN ./configure --with-sysroot=${TOOLCHAIN_SYSROOT} --prefix=${TOOLCHAIN_PREFIX} --target=${TOOLCHAIN_NAME} --with-ssl=${TOOLCHAIN_PREFIX} --with-zlib --host=${TOOLCHAIN_NAME} --build=x86_64-linux-gnu
+RUN ./configure --with-sysroot=${TOOLCHAIN_SYSROOT} --prefix=${TOOLCHAIN_PREFIX} --target=${TOOLCHAIN_NAME} --with-openssl=${TOOLCHAIN_PREFIX} --with-zlib --host=${TOOLCHAIN_NAME} --build=x86_64-linux-gnu --without-libpsl --disable-ntlm
 
 RUN make
 RUN make install

--- a/jenkins/raspberrypi/run_this_to_setup_a_pi_for_e2e_tests.sh
+++ b/jenkins/raspberrypi/run_this_to_setup_a_pi_for_e2e_tests.sh
@@ -64,11 +64,15 @@ source ~/.bashrc
 [ $? -eq 0 ] || { echo "bashrc source failed"; exit 1; }
 
 # Install curl new version
-wget https://curl.haxx.se/download/curl-7.64.1.tar.gz
+# Bump CURL_VERSION to update curl everywhere in this block.
+CURL_VERSION=8.20.0
+wget https://curl.se/download/curl-${CURL_VERSION}.tar.gz
 
-tar -xzvf curl-7.64.1.tar.gz
-cd curl_source/curl-7.64.1/
-./configure --without-zlib --with-ssl
+tar -xzvf curl-${CURL_VERSION}.tar.gz
+cd curl_source/curl-${CURL_VERSION}/
+# --with-openssl replaces the old --with-ssl (renamed in curl 7.77.0).
+# --disable-ntlm: SDK does not use NTLM auth; excludes curl's MD4-based NTLM code (banned hash algorithm MD4 finding).
+./configure --without-zlib --with-openssl --disable-ntlm
 make -j
 sudo make install
 
@@ -104,12 +108,14 @@ echo "Now you can run the cross compiled E2E tests!"
 # # BUILD AND INSTALL NEW CURL TO CURL_ROOT
 # # We are commenting this out because it's useful info to have 
 # # but for the E2E tests it works when CURL is installed directly on the device.
-# wget https://curl.haxx.se/download/curl-7.64.1.tar.gz
+# wget https://curl.se/download/curl-8.20.0.tar.gz
 # mkdir $CURL_ROOT
 # mkdir curl_source
-# tar -C curl_source -xzvf curl-7.64.1.tar.gz
-# cd curl_source/curl-7.64.1/
-# ./configure --prefix=$CURL_ROOT --disable-shared --without-zlib --with-ssl --enable-static
+# tar -C curl_source -xzvf curl-8.20.0.tar.gz
+# cd curl_source/curl-8.20.0/
+# # --with-openssl replaces the old --with-ssl (renamed in curl 7.77.0); --disable-ntlm
+# # excludes curl's MD4/DES-based NTLM code (banned MD4 hash / banned DES cipher).
+# ./configure --prefix=$CURL_ROOT --disable-shared --without-zlib --with-openssl --disable-ntlm --enable-static
 # make -j
 # sudo make install
 

--- a/jenkins/raspberrypi/setup_pi_for_e2e_tests.sh
+++ b/jenkins/raspberrypi/setup_pi_for_e2e_tests.sh
@@ -100,11 +100,15 @@ source ~/.bashrc
 [ $? -eq 0 ] || { echo "bashrc source failed"; exit 1; }
 
 # Install curl new version
-wget https://curl.haxx.se/download/curl-7.64.1.tar.gz
+# Bump CURL_VERSION to update curl everywhere in this block.
+CURL_VERSION=8.20.0
+wget https://curl.se/download/curl-${CURL_VERSION}.tar.gz
 
-tar -xzvf curl-7.64.1.tar.gz
-cd curl_source/curl-7.64.1/
-./configure --without-zlib --with-ssl
+tar -xzvf curl-${CURL_VERSION}.tar.gz
+cd curl_source/curl-${CURL_VERSION}/
+# --with-openssl replaces the old --with-ssl (renamed in curl 7.77.0).
+# --disable-ntlm: SDK does not use NTLM auth; excludes curl's MD4-based NTLM code (banned hash algorithm MD4 finding).
+./configure --without-zlib --with-openssl --disable-ntlm
 make -j
 sudo make install
 
@@ -140,12 +144,14 @@ echo "Now you can run the cross compiled E2E tests!"
 # # BUILD AND INSTALL NEW CURL TO CURL_ROOT
 # # We are commenting this out because it's useful info to have 
 # # but for the E2E tests it works when CURL is installed directly on the device.
-# wget https://curl.haxx.se/download/curl-7.64.1.tar.gz
+# wget https://curl.se/download/curl-8.20.0.tar.gz
 # mkdir $CURL_ROOT
 # mkdir curl_source
-# tar -C curl_source -xzvf curl-7.64.1.tar.gz
-# cd curl_source/curl-7.64.1/
-# ./configure --prefix=$CURL_ROOT --disable-shared --without-zlib --with-ssl --enable-static
+# tar -C curl_source -xzvf curl-8.20.0.tar.gz
+# cd curl_source/curl-8.20.0/
+# # --with-openssl replaces the old --with-ssl (renamed in curl 7.77.0); --disable-ntlm
+# # excludes curl's MD4/DES-based NTLM code (banned MD4 hash / banned DES cipher).
+# ./configure --prefix=$CURL_ROOT --disable-shared --without-zlib --with-openssl --disable-ntlm --enable-static
 # make -j
 # sudo make install
 

--- a/provisioning_client/samples/iothub_client_sample_hsm/iothub_client_sample_hsm.c
+++ b/provisioning_client/samples/iothub_client_sample_hsm/iothub_client_sample_hsm.c
@@ -42,7 +42,7 @@ static void connection_status_callback(IOTHUB_CLIENT_CONNECTION_STATUS result, I
     IOTHUB_CLIENT_SAMPLE_INFO* iothub_info = (IOTHUB_CLIENT_SAMPLE_INFO*)user_context;
     if (iothub_info != NULL)
     {
-        if (reason == IOTHUB_CLIENT_CONNECTION_OK && result == IOTHUB_CLIENT_CONFIRMATION_OK)
+        if (result == IOTHUB_CLIENT_CONNECTION_AUTHENTICATED && reason == IOTHUB_CLIENT_CONNECTION_OK)
         {
             iothub_info->connected = 1;
         }

--- a/provisioning_client/src/prov_transport_amqp_common.c
+++ b/provisioning_client/src/prov_transport_amqp_common.c
@@ -15,6 +15,7 @@
 #include "azure_c_shared_utility/http_proxy_io.h"
 #include "azure_c_shared_utility/strings.h"
 #include "azure_c_shared_utility/azure_base64.h"
+#include "azure_c_shared_utility/safe_math.h"
 
 #include "azure_uamqp_c/message_sender.h"
 #include "azure_uamqp_c/message_receiver.h"
@@ -455,6 +456,7 @@ static AMQP_VALUE on_message_recv_callback(const void* user_ctx, MESSAGE_HANDLE 
         else
         {
             BINARY_DATA binary_data;
+            size_t alloc_size;
             if (amqp_info->payload_data != NULL)
             {
                 free(amqp_info->payload_data);
@@ -467,7 +469,13 @@ static AMQP_VALUE on_message_recv_callback(const void* user_ctx, MESSAGE_HANDLE 
                 amqp_info->transport_state = TRANSPORT_CLIENT_STATE_ERROR;
                 amqp_info->amqp_state = AMQP_STATE_ERROR;
             }
-            else if ((amqp_info->payload_data = malloc(binary_data.length + 1)) == NULL)
+            else if ((alloc_size = safe_add_size_t(binary_data.length, 1)) == SIZE_MAX)
+            {
+                LogError("failure invalid payload length");
+                amqp_info->transport_state = TRANSPORT_CLIENT_STATE_ERROR;
+                amqp_info->amqp_state = AMQP_STATE_ERROR;
+            }
+            else if ((amqp_info->payload_data = malloc(alloc_size)) == NULL)
             {
                 LogError("failure allocating payload data");
                 amqp_info->transport_state = TRANSPORT_CLIENT_STATE_ERROR;
@@ -479,7 +487,7 @@ static AMQP_VALUE on_message_recv_callback(const void* user_ctx, MESSAGE_HANDLE 
                 // be set to the default value
                 (void)get_retry_after_property(amqp_info, message);
 
-                memset(amqp_info->payload_data, 0, binary_data.length + 1);
+                memset(amqp_info->payload_data, 0, alloc_size);
                 memcpy(amqp_info->payload_data, binary_data.bytes, binary_data.length);
                 if (amqp_info->transport_state == TRANSPORT_CLIENT_STATE_REG_SENT)
                 {

--- a/provisioning_client/src/prov_transport_http_client.c
+++ b/provisioning_client/src/prov_transport_http_client.c
@@ -13,6 +13,7 @@
 #include "azure_c_shared_utility/http_proxy_io.h"
 #include "azure_c_shared_utility/urlencode.h"
 #include "azure_c_shared_utility/azure_base64.h"
+#include "azure_c_shared_utility/safe_math.h"
 
 #include "azure_prov_client/prov_transport_http_client.h"
 #include "azure_prov_client/internal/prov_transport_private.h"
@@ -138,19 +139,25 @@ static void on_http_reply_recv(void* callback_ctx, HTTP_CALLBACK_REASON request_
         {
             if (content != NULL && content_len > 0)
             {
+                size_t alloc_size = safe_add_size_t(content_len, 1);
                 if (http_info->payload_data != NULL)
                 {
                     free(http_info->payload_data);
+                    http_info->payload_data = NULL;
                 }
-                http_info->payload_data = malloc(content_len + 1);
-                if (http_info->payload_data == NULL)
+                if (alloc_size == SIZE_MAX)
                 {
-                    LogError("Failure sending http request");
+                    LogError("Failure invalid content length specified");
+                    http_info->transport_state = TRANSPORT_CLIENT_STATE_ERROR;
+                }
+                else if ((http_info->payload_data = malloc(alloc_size)) == NULL)
+                {
+                    LogError("Failure allocating payload data");
                     http_info->transport_state = TRANSPORT_CLIENT_STATE_ERROR;
                 }
                 else
                 {
-                    memset(http_info->payload_data, 0, content_len + 1);
+                    memset(http_info->payload_data, 0, alloc_size);
                     memcpy(http_info->payload_data, content, content_len);
                     if (http_info->transport_state == TRANSPORT_CLIENT_STATE_REG_SENT)
                     {

--- a/provisioning_client/src/prov_transport_mqtt_common.c
+++ b/provisioning_client/src/prov_transport_mqtt_common.c
@@ -16,7 +16,7 @@
 #include "azure_c_shared_utility/shared_util_options.h"
 #include "azure_c_shared_utility/http_proxy_io.h"
 #include "azure_c_shared_utility/urlencode.h"
-#include "azure_c_shared_utility/http_proxy_io.h"
+#include "azure_c_shared_utility/safe_math.h"
 
 #include "azure_prov_client/internal/prov_transport_mqtt_common.h"
 #include "azure_umqtt_c/mqtt_client.h"
@@ -344,13 +344,20 @@ static MQTT_CLIENT_ACK_OPTION mqtt_notification_callback(MQTT_MESSAGE_HANDLE han
             const APP_PAYLOAD* payload = mqttmessage_getApplicationMsg(handle);
             if (payload != NULL)
             {
+                size_t alloc_size = safe_add_size_t(payload->length, 1);
                 if (mqtt_info->payload_data != NULL)
                 {
                     free(mqtt_info->payload_data);
                     mqtt_info->payload_data = NULL;
                 }
 
-                if ((mqtt_info->payload_data = malloc(payload->length + 1)) == NULL)
+                if (alloc_size == SIZE_MAX)
+                {
+                    LogError("failure invalid payload length");
+                    mqtt_info->transport_state = TRANSPORT_CLIENT_STATE_ERROR;
+                    mqtt_info->mqtt_state = MQTT_STATE_ERROR;
+                }
+                else if ((mqtt_info->payload_data = malloc(alloc_size)) == NULL)
                 {
                     LogError("failure allocating payload data");
                     mqtt_info->transport_state = TRANSPORT_CLIENT_STATE_ERROR;
@@ -358,7 +365,7 @@ static MQTT_CLIENT_ACK_OPTION mqtt_notification_callback(MQTT_MESSAGE_HANDLE han
                 }
                 else
                 {
-                    memset(mqtt_info->payload_data, 0, payload->length + 1);
+                    memset(mqtt_info->payload_data, 0, alloc_size);
                     memcpy(mqtt_info->payload_data, payload->message, payload->length);
                     if (mqtt_info->transport_state == TRANSPORT_CLIENT_STATE_REG_SENT)
                     {

--- a/provisioning_client/tests/common_prov_e2e/prov_valgrind_suppression.supp
+++ b/provisioning_client/tests/common_prov_e2e/prov_valgrind_suppression.supp
@@ -89,7 +89,7 @@
 {
    Helgrind thinking the LOCK_HANDLE is not a mutex (invalid arg)
    Helgrind:Misc
-   obj:/usr/lib/x86_64-linux-gnu/valgrind/vgpreload_helgrind-amd64-linux.so
+   obj:*/vgpreload_helgrind-amd64-linux.so
    obj:/usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.0
    fun:_dl_fini
    fun:__run_exit_handlers
@@ -99,7 +99,7 @@
 {
    Helgrind thinking the LOCK_HANDLE is not a mutex (invalid arg)
    Helgrind:Misc
-   obj:/usr/lib/x86_64-linux-gnu/valgrind/vgpreload_helgrind-amd64-linux.so
+   obj:*/vgpreload_helgrind-amd64-linux.so
    fun:_dl_fini
    fun:__run_exit_handlers
    fun:exit
@@ -127,7 +127,7 @@
 {
    OpenSSL/libp11-0.4.11
    Helgrind:Misc
-   obj:/usr/lib/x86_64-linux-gnu/valgrind/vgpreload_helgrind-amd64-linux.so
+   obj:*/vgpreload_helgrind-amd64-linux.so
    ...
    fun:_dl_fini
    fun:__run_exit_handlers
@@ -270,7 +270,7 @@
 {
    Helgrind thinks LOCK_HANDLE is not a mutex
    Helgrind:Misc
-   obj:/usr/lib/x86_64-linux-gnu/valgrind/vgpreload_helgrind-amd64-linux.so
+   obj:*/vgpreload_helgrind-amd64-linux.so
    fun:_dl_fini
    fun:__run_exit_handlers
    fun:exit
@@ -279,7 +279,7 @@
 {
    Helgrind thinks LOCK_HANDLE is not a mutex
    Helgrind:Misc
-   obj:/usr/lib/x86_64-linux-gnu/valgrind/vgpreload_helgrind-amd64-linux.so
+   obj:*/vgpreload_helgrind-amd64-linux.so
    obj:/usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.0
    fun:_dl_fini
    fun:__run_exit_handlers
@@ -462,4 +462,32 @@
    fun:TestSuiteInitialize
    fun:RunTests
    fun:main
+}
+
+# ------------------------------------------------------------------------
+# Ubuntu 24.04 (glibc 2.39 / valgrind 3.22) - libp11-kit shared-library
+# destructor calls pthread_mutex_destroy on already-torn-down mutexes
+# during process exit. Matches the existing libp11 suppression style above.
+# ------------------------------------------------------------------------
+{
+   libp11-kit pthread_mutex_destroy at exit (Ubuntu 24.04 / glibc 2.39)
+   Helgrind:Misc
+   obj:*/vgpreload_helgrind-amd64-linux.so
+   ...
+   fun:_dl_call_fini
+   fun:_dl_fini
+   fun:__run_exit_handlers
+   fun:exit
+   fun:(below main)
+}
+{
+   libp11-kit pthread_mutex_destroy at exit (Ubuntu 24.04 / PthAPIerror variant)
+   Helgrind:PthAPIerror
+   obj:*/vgpreload_helgrind-amd64-linux.so
+   ...
+   fun:_dl_call_fini
+   fun:_dl_fini
+   fun:__run_exit_handlers
+   fun:exit
+   fun:(below main)
 }

--- a/provisioning_client/tests/prov_transport_amqp_common_ut/prov_transport_amqp_common_ut.c
+++ b/provisioning_client/tests/prov_transport_amqp_common_ut/prov_transport_amqp_common_ut.c
@@ -140,6 +140,7 @@ static ON_MESSAGE_RECEIVED g_on_msg_recv;
 static void* msg_recv_callback_context;
 static TPM_CHALLENGE_CALLBACK g_challenge_cb;
 static void* g_challenge_context;
+static bool g_use_invalid_msg_length;
 static bool g_use_x509;
 
 static PROV_DEVICE_TRANSPORT_STATUS g_target_transport_status;
@@ -210,7 +211,7 @@ static int my_message_get_body_amqp_data_in_place(MESSAGE_HANDLE message, size_t
 {
     (void)message;
     (void)index;
-    amqp_data->length = strlen(TEST_JSON_REPLY);
+    amqp_data->length = g_use_invalid_msg_length ? (size_t)-1 : strlen(TEST_JSON_REPLY);
     amqp_data->bytes = (unsigned char*)TEST_JSON_REPLY;
     return 0;
 }
@@ -701,6 +702,7 @@ BEGIN_TEST_SUITE(prov_transport_amqp_common_ut)
         g_challenge_cb = NULL;
         g_challenge_context = NULL;
         g_use_x509 = false;
+        g_use_invalid_msg_length = false;
     }
 
     TEST_FUNCTION_CLEANUP(method_cleanup)
@@ -1754,6 +1756,43 @@ BEGIN_TEST_SUITE(prov_transport_amqp_common_ut)
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         //cleanup
+        prov_transport_common_amqp_close(handle);
+        prov_transport_common_amqp_destroy(handle);
+    }
+
+    TEST_FUNCTION(prov_transport_common_amqp_dowork_register_recv_invalid_length_fail)
+    {
+        AMQP_VALUE result;
+        PROV_DEVICE_TRANSPORT_HANDLE handle = prov_transport_common_amqp_create(TEST_URI_VALUE, TRANSPORT_HSM_TYPE_TPM, TEST_SCOPE_ID_VALUE, TEST_DPS_API_VALUE, on_transport_io, on_transport_error, NULL);
+        (void)prov_transport_common_amqp_open(handle, TEST_REGISTRATION_ID_VALUE, TEST_BUFFER_VALUE, TEST_BUFFER_VALUE, on_transport_register_data_cb, NULL, on_transport_status_cb, NULL, on_transport_challenge_callback, NULL);
+        (void)prov_transport_common_amqp_register_device(handle, on_transport_json_parse, on_transport_create_json_payload, NULL);
+        prov_transport_common_amqp_dowork(handle);
+        g_msg_sndr_state_changed(g_msg_sndr_state_changed_ctx, MESSAGE_SENDER_STATE_OPEN, MESSAGE_SENDER_STATE_OPENING);
+        g_msg_rcvr_state_changed(g_msg_rcvr_state_changed_ctx, MESSAGE_RECEIVER_STATE_OPEN, MESSAGE_RECEIVER_STATE_OPENING);
+        prov_transport_common_amqp_dowork(handle);
+        umock_c_reset_all_calls();
+
+        // A wire-provided body length of SIZE_MAX would wrap (length + 1) to 0; the transport
+        // must reject it instead of allocating a zero-length buffer and copying past it.
+        g_use_invalid_msg_length = true;
+
+        //arrange
+        STRICT_EXPECTED_CALL(message_get_body_type(IGNORED_ARG, IGNORED_ARG));
+        STRICT_EXPECTED_CALL(message_get_body_amqp_data_in_place(IGNORED_ARG, 0, IGNORED_ARG));
+        STRICT_EXPECTED_CALL(messaging_delivery_accepted());
+        STRICT_EXPECTED_CALL(connection_dowork(IGNORED_ARG));
+        STRICT_EXPECTED_CALL(on_transport_register_data_cb(PROV_DEVICE_TRANSPORT_RESULT_ERROR, NULL, NULL, NULL, IGNORED_ARG));
+
+        //act
+        result = g_on_msg_recv(msg_recv_callback_context, TEST_MESSAGE_HANDLE);
+        prov_transport_common_amqp_dowork(handle);
+
+        //assert
+        ASSERT_IS_NOT_NULL(result);
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+        //cleanup
+        g_use_invalid_msg_length = false;
         prov_transport_common_amqp_close(handle);
         prov_transport_common_amqp_destroy(handle);
     }

--- a/provisioning_client/tests/prov_transport_amqp_common_ut/prov_transport_amqp_common_ut.c
+++ b/provisioning_client/tests/prov_transport_amqp_common_ut/prov_transport_amqp_common_ut.c
@@ -1777,11 +1777,11 @@ BEGIN_TEST_SUITE(prov_transport_amqp_common_ut)
         g_use_invalid_msg_length = true;
 
         //arrange
-        STRICT_EXPECTED_CALL(message_get_body_type(IGNORED_ARG, IGNORED_ARG));
-        STRICT_EXPECTED_CALL(message_get_body_amqp_data_in_place(IGNORED_ARG, 0, IGNORED_ARG));
+        STRICT_EXPECTED_CALL(message_get_body_type(IGNORED_PTR_ARG, IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(message_get_body_amqp_data_in_place(IGNORED_PTR_ARG, 0, IGNORED_PTR_ARG));
         STRICT_EXPECTED_CALL(messaging_delivery_accepted());
-        STRICT_EXPECTED_CALL(connection_dowork(IGNORED_ARG));
-        STRICT_EXPECTED_CALL(on_transport_register_data_cb(PROV_DEVICE_TRANSPORT_RESULT_ERROR, NULL, NULL, NULL, IGNORED_ARG));
+        STRICT_EXPECTED_CALL(connection_dowork(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(on_transport_register_data_cb(PROV_DEVICE_TRANSPORT_RESULT_ERROR, NULL, NULL, NULL, IGNORED_PTR_ARG));
 
         //act
         result = g_on_msg_recv(msg_recv_callback_context, TEST_MESSAGE_HANDLE);

--- a/provisioning_client/tests/prov_transport_http_client_ut/prov_transport_http_client_ut.c
+++ b/provisioning_client/tests/prov_transport_http_client_ut/prov_transport_http_client_ut.c
@@ -1090,6 +1090,31 @@ BEGIN_TEST_SUITE(prov_transport_http_client_ut)
         prov_dev_http_transport_destroy(handle);
     }
 
+    TEST_FUNCTION(prov_transport_http_reply_recv_invalid_content_len_fail)
+    {
+        //arrange
+        PROV_DEVICE_TRANSPORT_HANDLE handle = prov_dev_http_transport_create(TEST_URI_VALUE, TRANSPORT_HSM_TYPE_TPM, TEST_SCOPE_ID_VALUE, TEST_DPS_API_VALUE, on_transport_error, NULL);
+        (void)prov_dev_http_transport_open(handle, TEST_REGISTRATION_ID_VALUE, TEST_BUFFER_VALUE, TEST_BUFFER_VALUE, on_transport_register_data_cb, NULL, on_transport_status_cb, NULL, on_transport_challenge_callback, NULL);
+        (void)prov_dev_http_transport_register_device(handle, on_transport_json_parse, on_transport_create_json_payload, NULL);
+        g_on_http_open(g_http_open_ctx, HTTP_CALLBACK_REASON_OK);
+        prov_dev_http_transport_dowork(handle);
+        umock_c_reset_all_calls();
+
+        // A Content-Length of SIZE_MAX would wrap (content_len + 1) to 0; the transport must
+        // reject it instead of allocating a zero-length buffer and copying gigabytes past it.
+        STRICT_EXPECTED_CALL(HTTPHeaders_FindHeaderValue(IGNORED_ARG, IGNORED_ARG)).SetReturn(NULL);
+
+        //act
+        g_on_http_reply_recv(g_http_execute_ctx, HTTP_CALLBACK_REASON_OK, (const unsigned char*)TEST_JSON_CONTENT, (size_t)-1, TEST_SUCCESS_STATUS_CODE, TEST_HTTP_HANDLE_VALUE);
+
+        //assert
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+        //cleanup
+        (void)prov_dev_http_transport_close(handle);
+        prov_dev_http_transport_destroy(handle);
+    }
+
     TEST_FUNCTION(prov_transport_http_reply_recv_transient_error_succeed)
     {
         //arrange

--- a/provisioning_client/tests/prov_transport_http_client_ut/prov_transport_http_client_ut.c
+++ b/provisioning_client/tests/prov_transport_http_client_ut/prov_transport_http_client_ut.c
@@ -1102,7 +1102,7 @@ BEGIN_TEST_SUITE(prov_transport_http_client_ut)
 
         // A Content-Length of SIZE_MAX would wrap (content_len + 1) to 0; the transport must
         // reject it instead of allocating a zero-length buffer and copying gigabytes past it.
-        STRICT_EXPECTED_CALL(HTTPHeaders_FindHeaderValue(IGNORED_ARG, IGNORED_ARG)).SetReturn(NULL);
+        STRICT_EXPECTED_CALL(HTTPHeaders_FindHeaderValue(IGNORED_PTR_ARG, IGNORED_PTR_ARG)).SetReturn(NULL);
 
         //act
         g_on_http_reply_recv(g_http_execute_ctx, HTTP_CALLBACK_REASON_OK, (const unsigned char*)TEST_JSON_CONTENT, (size_t)-1, TEST_SUCCESS_STATUS_CODE, TEST_HTTP_HANDLE_VALUE);

--- a/provisioning_client/tests/prov_transport_mqtt_common_ut/prov_transport_mqtt_common_ut.c
+++ b/provisioning_client/tests/prov_transport_mqtt_common_ut/prov_transport_mqtt_common_ut.c
@@ -118,6 +118,7 @@ static ON_MQTT_ERROR_CALLBACK g_on_error_cb;
 static void* g_on_error_ctx;
 static bool g_use_x509;
 static APP_PAYLOAD g_app_msg;
+static bool g_use_invalid_msg_length;
 
 
 static PROV_DEVICE_TRANSPORT_STATUS g_target_transport_status;
@@ -197,7 +198,7 @@ static void my_mqttmessage_destroy(MQTT_MESSAGE_HANDLE handle)
 static const APP_PAYLOAD* my_mqttmessage_getApplicationMsg(MQTT_MESSAGE_HANDLE handle)
 {
     (void)handle;
-    g_app_msg.length = strlen(TEST_JSON_REPLY);
+    g_app_msg.length = g_use_invalid_msg_length ? (size_t)-1 : strlen(TEST_JSON_REPLY);
     g_app_msg.message = (unsigned char*)TEST_JSON_REPLY;
     return &g_app_msg;
 }
@@ -399,6 +400,7 @@ BEGIN_TEST_SUITE(prov_transport_mqtt_common_ut)
         g_operation_cb = NULL;
         g_on_error_cb = NULL;
         g_use_x509 = false;
+        g_use_invalid_msg_length = false;
     }
 
     TEST_FUNCTION_CLEANUP(method_cleanup)
@@ -1325,6 +1327,49 @@ BEGIN_TEST_SUITE(prov_transport_mqtt_common_ut)
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         //cleanup
+        prov_transport_common_mqtt_close(handle);
+        prov_transport_common_mqtt_destroy(handle);
+    }
+
+    TEST_FUNCTION(prov_transport_common_mqtt_dowork_register_recv_invalid_length_fail)
+    {
+        CONNECT_ACK connack = { true, CONNECTION_ACCEPTED };
+        QOS_VALUE QosValue[] = { DELIVER_AT_LEAST_ONCE };
+        SUBSCRIBE_ACK suback;
+        suback.packetId = 1234;
+        suback.qosCount = 1;
+        suback.qosReturn = QosValue;
+
+        PROV_DEVICE_TRANSPORT_HANDLE handle = prov_transport_common_mqtt_create(TEST_URI_VALUE, TRANSPORT_HSM_TYPE_X509, TEST_SCOPE_ID_VALUE, TEST_DPS_API_VALUE, on_mqtt_transport_io, on_transport_error, NULL);
+        (void)prov_transport_common_mqtt_x509_cert(handle, TEST_X509_CERT_VALUE, TEST_PRIVATE_KEY_VALUE);
+        (void)prov_transport_common_mqtt_open(handle, TEST_REGISTRATION_ID_VALUE, NULL, NULL, on_transport_register_data_cb, NULL, on_transport_status_cb, NULL, on_transport_challenge_callback, NULL);
+        (void)prov_transport_common_mqtt_register_device(handle, on_transport_json_parse, on_transport_create_json_payload, NULL);
+        prov_transport_common_mqtt_dowork(handle);
+        g_operation_cb(TEST_MQTT_CLIENT_HANDLE, MQTT_CLIENT_ON_CONNACK, &connack, g_msg_recv_callback_context);
+        prov_transport_common_mqtt_dowork(handle);
+        g_operation_cb(TEST_MQTT_CLIENT_HANDLE, MQTT_CLIENT_ON_SUBSCRIBE_ACK, &suback, g_msg_recv_callback_context);
+        prov_transport_common_mqtt_dowork(handle);
+        umock_c_reset_all_calls();
+
+        // A wire-provided payload length of SIZE_MAX would wrap (length + 1) to 0; the
+        // transport must reject it instead of allocating a zero-length buffer and copying past it.
+        g_use_invalid_msg_length = true;
+
+        //arrange
+        STRICT_EXPECTED_CALL(mqttmessage_getTopicName(IGNORED_ARG));
+        STRICT_EXPECTED_CALL(mqttmessage_getApplicationMsg(IGNORED_ARG));
+        STRICT_EXPECTED_CALL(mqtt_client_dowork(IGNORED_ARG));
+        STRICT_EXPECTED_CALL(on_transport_register_data_cb(PROV_DEVICE_TRANSPORT_RESULT_ERROR, NULL, NULL, NULL, IGNORED_ARG));
+
+        //act
+        g_on_msg_recv(TEST_MQTT_MESSAGE, g_msg_recv_callback_context);
+        prov_transport_common_mqtt_dowork(handle);
+
+        //assert
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+        //cleanup
+        g_use_invalid_msg_length = false;
         prov_transport_common_mqtt_close(handle);
         prov_transport_common_mqtt_destroy(handle);
     }

--- a/provisioning_client/tests/prov_transport_mqtt_common_ut/prov_transport_mqtt_common_ut.c
+++ b/provisioning_client/tests/prov_transport_mqtt_common_ut/prov_transport_mqtt_common_ut.c
@@ -1356,10 +1356,10 @@ BEGIN_TEST_SUITE(prov_transport_mqtt_common_ut)
         g_use_invalid_msg_length = true;
 
         //arrange
-        STRICT_EXPECTED_CALL(mqttmessage_getTopicName(IGNORED_ARG));
-        STRICT_EXPECTED_CALL(mqttmessage_getApplicationMsg(IGNORED_ARG));
-        STRICT_EXPECTED_CALL(mqtt_client_dowork(IGNORED_ARG));
-        STRICT_EXPECTED_CALL(on_transport_register_data_cb(PROV_DEVICE_TRANSPORT_RESULT_ERROR, NULL, NULL, NULL, IGNORED_ARG));
+        STRICT_EXPECTED_CALL(mqttmessage_getTopicName(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(mqttmessage_getApplicationMsg(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(mqtt_client_dowork(IGNORED_PTR_ARG));
+        STRICT_EXPECTED_CALL(on_transport_register_data_cb(PROV_DEVICE_TRANSPORT_RESULT_ERROR, NULL, NULL, NULL, IGNORED_PTR_ARG));
 
         //act
         g_on_msg_recv(TEST_MQTT_MESSAGE, g_msg_recv_callback_context);

--- a/samples/dockerbuilds/ARM/Dockerfile
+++ b/samples/dockerbuilds/ARM/Dockerfile
@@ -26,7 +26,7 @@ ENV TOOLCHAIN_ARM=gcc-arm-10.3-2021.07-x86_64-arm-none-linux-gnueabihf
 ENV TOOLCHAIN_PLATFORM=arm-none-linux-gnueabihf
 ENV TOOLCHAIN_SYSROOT=${WORK_ROOT}/${TOOLCHAIN_ARM}
 ENV TOOLCHAIN_BIN=${WORK_ROOT}/${TOOLCHAIN_ARM}/bin
-ENV OPENSSL_ROOT_DIR=${WORK_ROOT}/openssl-1.1.1v
+ENV OPENSSL_ROOT_DIR=${WORK_ROOT}/openssl-3.0.15
 ENV TOOLCHAIN_PREFIX=${WORK_ROOT}/ARM
 ENV AR=${TOOLCHAIN_BIN}/${TOOLCHAIN_PLATFORM}-ar
 ENV CC=${TOOLCHAIN_BIN}/${TOOLCHAIN_PLATFORM}-gcc
@@ -43,20 +43,23 @@ RUN tar -xvf ./${TOOLCHAIN_ARM}.tar.xz
 
 #########################################
 # Download and Configure OpenSSL
-RUN wget https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1v/openssl-1.1.1v.tar.gz 
-RUN tar -xvf ./openssl-1.1.1v.tar.gz 
-WORKDIR openssl-1.1.1v 
+RUN wget https://www.openssl.org/source/openssl-3.0.15.tar.gz 
+RUN tar -xvf ./openssl-3.0.15.tar.gz 
+WORKDIR openssl-3.0.15 
 RUN ./Configure linux-armv4 --prefix=${TOOLCHAIN_PREFIX} --openssldir=${OPENSSL_ROOT_DIR} no-tests shared 
 RUN make 
-RUN make install_sw
+RUN make install
 WORKDIR ..
 
 #########################################
 # Build curl
-RUN wget http://curl.haxx.se/download/curl-7.60.0.tar.gz 
-RUN tar -xvf curl-7.60.0.tar.gz 
-WORKDIR curl-7.60.0 
-RUN ./configure --with-sysroot=${TOOLCHAIN_SYSROOT} --prefix=${TOOLCHAIN_PREFIX} --target=${TOOLCHAIN_PLATFORM} --with-ssl --with-zlib --host=${TOOLCHAIN_PLATFORM} 
+# --with-openssl replaces the old --with-ssl (renamed in curl 7.77.0); --disable-ntlm
+# excludes curl's MD4-based NTLM code (banned hash algorithm MD4 finding).
+ENV CURL_VERSION=8.20.0
+RUN wget https://curl.se/download/curl-${CURL_VERSION}.tar.gz 
+RUN tar -xvf curl-${CURL_VERSION}.tar.gz 
+WORKDIR curl-${CURL_VERSION} 
+RUN ./configure --with-sysroot=${TOOLCHAIN_SYSROOT} --prefix=${TOOLCHAIN_PREFIX} --target=${TOOLCHAIN_PLATFORM} --with-openssl=${TOOLCHAIN_PREFIX} --with-zlib --host=${TOOLCHAIN_PLATFORM} --without-libpsl --disable-ntlm
 RUN make 
 RUN make install 
 WORKDIR ..
@@ -90,12 +93,22 @@ RUN echo "SET(CMAKE_FIND_ROOT_PATH ${WORK_ROOT})" >> toolchain.cmake
 RUN echo "SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> toolchain.cmake
 RUN echo "SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> toolchain.cmake
 RUN echo "SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)" >> toolchain.cmake
+# Pre-set the cache vars CMake's FindCURL consumes (CURL_INCLUDE_DIR/CURL_LIBRARY)
+# so find_package(CURL) succeeds when cross-compiling; otherwise CMake >= 4.0
+# fails the search and clobbers CURL_LIBRARIES.
+RUN echo "SET(CURL_INCLUDE_DIR ${TOOLCHAIN_PREFIX}/include)" >> toolchain.cmake
+RUN echo "SET(CURL_LIBRARY ${TOOLCHAIN_PREFIX}/lib/libcurl.so)" >> toolchain.cmake
 RUN echo "SET(CURL_LIBRARIES ${TOOLCHAIN_PREFIX}/lib/libcurl.so)" >> toolchain.cmake
 RUN echo "SET(ENV{LDFLAGS} -L${TOOLCHAIN_PREFIX}/lib)" >> toolchain.cmake
 RUN echo "SET(set_trusted_cert_in_samples true CACHE BOOL \"Force use of TrustedCerts option\" FORCE)" >> toolchain.cmake
 RUN echo "include_directories(${TOOLCHAIN_PREFIX}/include)" >> toolchain.cmake
 
-RUN cmake -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake ..
+# CMAKE_POLICY_VERSION_MINIMUM=3.5 keeps CMake >= 4.0 (default in newer base
+# images) compatible with sub-projects (e.g. deps/azure-macro-utils-c) whose
+# top-level CMakeLists.txt still calls cmake_minimum_required(VERSION 2.8.x).
+# Without this, CMake aborts with: "Compatibility with CMake < 3.5 has been
+# removed from CMake."
+RUN cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake ..
 RUN cmake --build .
 RUN cmake --install . --prefix ${TOOLCHAIN_PREFIX}
 

--- a/samples/dockerbuilds/MIPS32/Dockerfile
+++ b/samples/dockerbuilds/MIPS32/Dockerfile
@@ -26,12 +26,13 @@ RUN wget https://downloads.openwrt.org/releases/21.02.3/targets/ramips/mt7620/op
 RUN tar -xvf openwrt-sdk-21.02.3-ramips-mt7620_gcc-8.4.0_musl.Linux-x86_64.tar.xz
 
 # OpenSSL
-RUN wget https://www.openssl.org/source/openssl-1.0.2o.tar.gz
-RUN tar -xvf openssl-1.0.2o.tar.gz
+RUN wget https://www.openssl.org/source/openssl-3.0.15.tar.gz
+RUN tar -xvf openssl-3.0.15.tar.gz
 
 # Curl
-RUN wget http://curl.haxx.se/download/curl-7.60.0.tar.gz
-RUN tar -xvf curl-7.60.0.tar.gz
+ENV CURL_VERSION=8.20.0
+RUN wget https://curl.se/download/curl-${CURL_VERSION}.tar.gz
+RUN tar -xvf curl-${CURL_VERSION}.tar.gz
 
 # Linux utilities for libuuid
 RUN wget https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.32/util-linux-2.32-rc2.tar.gz
@@ -45,7 +46,7 @@ ENV TOOLCHAIN_PLATFORM=mipsel-openwrt-linux-musl
 ENV STAGING_DIR=${WORK_ROOT}/${TOOLCHAIN_MIPS}/staging_dir
 ENV TOOLCHAIN_SYSROOT=${WORK_ROOT}/${TOOLCHAIN_MIPS}/staging_dir/toolchain-mipsel_24kc_gcc-8.4.0_musl
 ENV TOOLCHAIN_BIN=${TOOLCHAIN_SYSROOT}/bin
-ENV OPENSSL_ROOT_DIR=${WORK_ROOT}/openssl-OpenSSL_1_1_1f
+ENV OPENSSL_ROOT_DIR=${WORK_ROOT}/openssl-3.0.15
 ENV TOOLCHAIN_PREFIX=${WORK_ROOT}/MIPS
 ENV AR=${TOOLCHAIN_BIN}/${TOOLCHAIN_PLATFORM}-ar
 ENV CC=${TOOLCHAIN_BIN}/${TOOLCHAIN_PLATFORM}-gcc
@@ -53,18 +54,22 @@ ENV CXX=${TOOLCHAIN_BIN}/${TOOLCHAIN_PLATFORM}-g++
 
 
 ENV LDFLAGS="-L${TOOLCHAIN_PREFIX}/lib"
-ENV LIBS="-lssl -lcrypto -ldl -lpthread"
+ENV LIBS="-lssl -lcrypto -ldl -lpthread -latomic"
 
 # Build OpenSSL
-WORKDIR openssl-1.0.2o
-RUN ./Configure linux-generic32 --prefix=${TOOLCHAIN_PREFIX} --openssldir=${OPENSSL_ROOT_DIR} no-tests shared 
+# -latomic: MIPS32 has no native 64-bit atomics, so the compiler emits calls to
+# libatomic's __atomic_* helpers; append it so OpenSSL's apps link successfully.
+WORKDIR openssl-3.0.15
+RUN ./Configure linux-generic32 --prefix=${TOOLCHAIN_PREFIX} --openssldir=${OPENSSL_ROOT_DIR} no-tests shared -latomic
 RUN make
-RUN make install_sw
+RUN make install
 WORKDIR ..
 
 # Build curl
-WORKDIR curl-7.60.0
-RUN ./configure --with-sysroot=${TOOLCHAIN_SYSROOT} --prefix=${TOOLCHAIN_PREFIX} --target=${TOOLCHAIN_PLATFORM} --with-ssl=${TOOLCHAIN_PREFIX} --with-zlib --host=${TOOLCHAIN_PLATFORM} 
+# --with-openssl replaces the old --with-ssl (renamed in curl 7.77.0); --disable-ntlm
+# excludes curl's MD4-based NTLM code (banned hash algorithm MD4 finding).
+WORKDIR curl-${CURL_VERSION}
+RUN ./configure --with-sysroot=${TOOLCHAIN_SYSROOT} --prefix=${TOOLCHAIN_PREFIX} --target=${TOOLCHAIN_PLATFORM} --with-openssl=${TOOLCHAIN_PREFIX} --with-zlib --host=${TOOLCHAIN_PLATFORM} --without-libpsl --disable-ntlm
 RUN make
 RUN make install
 WORKDIR ..
@@ -97,13 +102,23 @@ RUN echo "SET(CMAKE_FIND_ROOT_PATH ${WORK_ROOT})" >> toolchain.cmake
 RUN echo "SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> toolchain.cmake
 RUN echo "SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> toolchain.cmake
 RUN echo "SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)" >> toolchain.cmake
+# Pre-set the cache vars CMake's FindCURL consumes (CURL_INCLUDE_DIR/CURL_LIBRARY)
+# so find_package(CURL) succeeds when cross-compiling; otherwise CMake >= 4.0
+# fails the search and clobbers CURL_LIBRARIES.
+RUN echo "SET(CURL_INCLUDE_DIR ${TOOLCHAIN_PREFIX}/include)" >> toolchain.cmake
+RUN echo "SET(CURL_LIBRARY ${TOOLCHAIN_PREFIX}/lib/libcurl.so)" >> toolchain.cmake
 RUN echo "SET(CURL_LIBRARIES ${TOOLCHAIN_PREFIX}/lib/libcurl.so)" >> toolchain.cmake
 RUN echo "SET(ENV{LDFLAGS} -L${TOOLCHAIN_PREFIX}/lib)" >> toolchain.cmake
 RUN echo "SET(OPENSSL_ROOT_DIR ${TOOLCHAIN_PREFIX})" >> toolchain.cmake
 RUN echo "SET(set_trusted_cert_in_samples true CACHE BOOL \"Force use of TrustedCerts option\" FORCE)" >> toolchain.cmake
 RUN echo "include_directories(${TOOLCHAIN_PREFIX}/include)" >> toolchain.cmake
 
-RUN cmake -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake ..
+# CMAKE_POLICY_VERSION_MINIMUM=3.5 keeps CMake >= 4.0 (default in newer base
+# images) compatible with sub-projects (e.g. deps/azure-macro-utils-c) whose
+# top-level CMakeLists.txt still calls cmake_minimum_required(VERSION 2.8.x).
+# Without this, CMake aborts with: "Compatibility with CMake < 3.5 has been
+# removed from CMake."
+RUN cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake ..
 RUN cmake --build .
 RUN cmake --install . --prefix ${TOOLCHAIN_PREFIX}
 

--- a/samples/dockerbuilds/RaspberryPi/Dockerfile
+++ b/samples/dockerbuilds/RaspberryPi/Dockerfile
@@ -1,5 +1,5 @@
-# Start with the latest version of the Debian Docker container
-FROM debian:stretch
+# Start with a modern Debian base for cross-compilation
+FROM debian:bookworm
 
 RUN ls -la
 
@@ -7,7 +7,7 @@ RUN ls -la
 RUN apt-get update && apt-get -y upgrade
 
 # Install wget git cmake xz-utils
-RUN apt-get install -y wget git cmake xz-utils
+RUN apt-get install -y wget git cmake xz-utils ca-certificates pkg-config build-essential
 
 # Add a non-root user
 RUN useradd -d /home/builder -ms /bin/bash -G sudo -p builder builder
@@ -17,7 +17,7 @@ USER builder
 WORKDIR /home/builder
 #WORKDIR /root
 
-# Don't use RPiTools because gcc is old, use linaro's toolchain
+# Don't use RPiTools because gcc is old, use Arm GNU Toolchain (GCC 13.3)
 #RUN mkdir RPiTools
 #WORKDIR RPiTools
 #RUN git clone https://github.com/raspberrypi/tools.git
@@ -26,14 +26,14 @@ RUN mkdir RPiBuild
 ENV WORK_ROOT=/home/builder/RPiBuild
 WORKDIR ${WORK_ROOT}
 
-RUN wget https://releases.linaro.org/components/toolchain/binaries/7.5-2019.12/arm-linux-gnueabihf/gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabihf.tar.xz
-RUN tar -xvf gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabihf.tar.xz
+RUN wget https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-linux-gnueabihf.tar.xz
+RUN tar -xvf arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-linux-gnueabihf.tar.xz
 
 # Set up environment variables for builds
-ENV TOOLCHAIN_ROOT=${WORK_ROOT}/gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabihf
+ENV TOOLCHAIN_ROOT=${WORK_ROOT}/arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-linux-gnueabihf
 ENV TOOLCHAIN_SYSROOT=${TOOLCHAIN_ROOT}
 ENV TOOLCHAIN_EXES=${TOOLCHAIN_SYSROOT}/bin
-ENV TOOLCHAIN_NAME=arm-linux-gnueabihf
+ENV TOOLCHAIN_NAME=arm-none-linux-gnueabihf
 ENV TOOLCHAIN_PREFIX=${TOOLCHAIN_SYSROOT}/usr
 
 ENV AR=${TOOLCHAIN_EXES}/${TOOLCHAIN_NAME}-ar
@@ -43,29 +43,31 @@ ENV LD=${TOOLCHAIN_EXES}/${TOOLCHAIN_NAME}-ld
 ENV NM=${TOOLCHAIN_EXES}/${TOOLCHAIN_NAME}-nm
 
 ENV LDFLAGS="-L${TOOLCHAIN_SYSROOT}/usr/lib"
-ENV LIBS="-lssl -lcrypto -ldl -lpthread"
+ENV LIBS="-lssl -lcrypto -ldl -lpthread -latomic"
 ENV TOOLCHAIN_PREFIX=${TOOLCHAIN_SYSROOT}/usr
 ENV STAGING_DIR=${TOOLCHAIN_SYSROOT}
 
 # Download OpenSSL source and expand it
-RUN wget https://www.openssl.org/source/openssl-1.1.0f.tar.gz
-RUN tar -xvf openssl-1.1.0f.tar.gz
+RUN wget https://www.openssl.org/source/openssl-3.0.15.tar.gz
+RUN tar -xvf openssl-3.0.15.tar.gz
 
 # Build OpenSSL
-WORKDIR openssl-1.1.0f
-RUN ./Configure linux-generic32 shared --prefix=${TOOLCHAIN_PREFIX} --openssldir=${TOOLCHAIN_PREFIX}
+WORKDIR openssl-3.0.15
+RUN ./Configure linux-generic32 shared no-tests --prefix=${TOOLCHAIN_PREFIX} --openssldir=${TOOLCHAIN_PREFIX}
 RUN make
 RUN make install
 WORKDIR ..
 
 # Download cURL source and expand it
-RUN wget http://curl.haxx.se/download/curl-7.60.0.tar.gz
-RUN tar -xvf curl-7.60.0.tar.gz
+ENV CURL_VERSION=8.20.0
+RUN wget https://curl.se/download/curl-${CURL_VERSION}.tar.gz
+RUN tar -xvf curl-${CURL_VERSION}.tar.gz
 
 # Build cURL
-# we need to set the path for openssl with --with-ssl=...
-WORKDIR curl-7.60.0
-RUN ./configure --with-sysroot=${TOOLCHAIN_SYSROOT} --prefix=${TOOLCHAIN_PREFIX} --target=${TOOLCHAIN_NAME} --with-ssl=${TOOLCHAIN_PREFIX} --with-zlib --host=${TOOLCHAIN_NAME} --build=x86_64-linux-gnu
+# --with-openssl points at our cross-built OpenSSL (option renamed from --with-ssl in curl 7.77.0).
+# --disable-ntlm excludes curl's MD4-based NTLM code (banned hash algorithm MD4 finding).
+WORKDIR curl-${CURL_VERSION}
+RUN ./configure --with-sysroot=${TOOLCHAIN_SYSROOT} --prefix=${TOOLCHAIN_PREFIX} --target=${TOOLCHAIN_NAME} --with-openssl=${TOOLCHAIN_PREFIX} --with-zlib --host=${TOOLCHAIN_NAME} --build=x86_64-linux-gnu --without-libpsl --disable-ntlm
 RUN make
 RUN make install
 WORKDIR ..

--- a/samples/dockerbuilds/myapp/CMakeLists.txt
+++ b/samples/dockerbuilds/myapp/CMakeLists.txt
@@ -40,4 +40,4 @@ endif()
 include_directories(${OPENSSL_INCLUDE_DIR})
 
 # List the libraries required by the link step
-target_link_libraries(myapp iothub_client prov_device_client iothub_client_mqtt_transport prov_auth_client umqtt hsm_security_client utpm dl aziotsharedutil parson pthread curl OpenSSL::SSL OpenSSL::Crypto m )
+target_link_libraries(myapp iothub_client prov_device_client iothub_client_mqtt_transport prov_auth_client umqtt hsm_security_client utpm dl aziotsharedutil c_logging_v2 parson pthread curl OpenSSL::SSL OpenSSL::Crypto m )

--- a/samples/dockerbuilds/myapp/CMakeLists.txt
+++ b/samples/dockerbuilds/myapp/CMakeLists.txt
@@ -40,4 +40,4 @@ endif()
 include_directories(${OPENSSL_INCLUDE_DIR})
 
 # List the libraries required by the link step
-target_link_libraries(myapp iothub_client prov_device_client iothub_client_mqtt_transport prov_auth_client umqtt hsm_security_client utpm dl aziotsharedutil c_logging_v2 parson pthread curl OpenSSL::SSL OpenSSL::Crypto m )
+target_link_libraries(myapp iothub_client prov_device_client iothub_client_mqtt_transport prov_auth_client umqtt hsm_security_client utpm dl aziotsharedutil parson pthread curl OpenSSL::SSL OpenSSL::Crypto m )

--- a/testtools/scripts/linux-setup-raspberry.sh
+++ b/testtools/scripts/linux-setup-raspberry.sh
@@ -6,7 +6,7 @@ sudo apt-get update -qq
 sudo apt install --fix-missing -y wget git build-essential cmake xz-utils ca-certificates pkg-config sudo
 
 export WORK_ROOT="$(pwd)/toolchain"
-mkdir $WORK_ROOT && pushd $WORK_ROOT
+mkdir -p "$WORK_ROOT" && pushd "$WORK_ROOT"
 
 # ARM GNU TOOLCHAIN INSTALL (GCC 13.3, replaces discontinued Linaro 7.x)
 export TOOLCHAIN_SOURCE=arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-linux-gnueabihf
@@ -57,7 +57,7 @@ tar -xvf ${CURL_SOURCE}.tar.gz
 # --without-libpsl avoids curl 8.x's hard libpsl dependency, which is not in the sysroot.
 # --disable-ntlm excludes curl's MD4/DES-based NTLM code (curl_ntlm_core.c), flagged as use of
 # the banned hash algorithm MD4 and the banned symmetric algorithm DES.
-pushd /${WORK_ROOT}/${CURL_SOURCE}
+pushd "${WORK_ROOT}/${CURL_SOURCE}"
 ./configure --with-sysroot=${TOOLCHAIN_SYSROOT} --prefix=${TOOLCHAIN_PREFIX} --target=${TOOLCHAIN_NAME} --with-openssl=${TOOLCHAIN_PREFIX} --with-zlib --host=${TOOLCHAIN_NAME} --build=x86_64-linux-gnu --without-libpsl --disable-ntlm
 
 make

--- a/testtools/scripts/linux-setup-raspberry.sh
+++ b/testtools/scripts/linux-setup-raspberry.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -e
+
+sudo apt-get update -qq
+sudo apt install --fix-missing -y wget git build-essential cmake xz-utils ca-certificates pkg-config sudo
+
+export WORK_ROOT="$(pwd)/toolchain"
+mkdir $WORK_ROOT && pushd $WORK_ROOT
+
+# ARM GNU TOOLCHAIN INSTALL (GCC 13.3, replaces discontinued Linaro 7.x)
+export TOOLCHAIN_SOURCE=arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-linux-gnueabihf
+wget https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/${TOOLCHAIN_SOURCE}.tar.xz
+tar -xvf ${TOOLCHAIN_SOURCE}.tar.xz
+
+# Set up environment variables for builds
+export TOOLCHAIN_ROOT=${WORK_ROOT}/${TOOLCHAIN_SOURCE}
+export TOOLCHAIN_SYSROOT=${TOOLCHAIN_ROOT}
+export TOOLCHAIN_EXES=${TOOLCHAIN_SYSROOT}/bin
+export TOOLCHAIN_NAME=arm-none-linux-gnueabihf
+export TOOLCHAIN_PREFIX=${TOOLCHAIN_SYSROOT}/usr
+
+export AR=${TOOLCHAIN_EXES}/${TOOLCHAIN_NAME}-ar
+export AS=${TOOLCHAIN_EXES}/${TOOLCHAIN_NAME}-as
+export CC=${TOOLCHAIN_EXES}/${TOOLCHAIN_NAME}-gcc
+export LD=${TOOLCHAIN_EXES}/${TOOLCHAIN_NAME}-ld
+export NM=${TOOLCHAIN_EXES}/${TOOLCHAIN_NAME}-nm
+
+export LDFLAGS="-L${TOOLCHAIN_SYSROOT}/usr/lib"
+export LIBS="-lssl -lcrypto -ldl -lpthread"
+export STAGING_DIR=${TOOLCHAIN_SYSROOT}
+
+
+# OPENSSL INSTALL
+# Download OpenSSL source and expand it
+# OpenSSL 3.0.15: curl 8.20.0's configure requires OpenSSL >= 3.0.0.
+export OPENSSL_SOURCE=openssl-3.0.15
+wget https://www.openssl.org/source/${OPENSSL_SOURCE}.tar.gz
+tar -xvf ${OPENSSL_SOURCE}.tar.gz
+
+# Build OpenSSL
+cd ${WORK_ROOT}/${OPENSSL_SOURCE}
+./Configure linux-generic32 shared no-tests --prefix=${TOOLCHAIN_PREFIX} --openssldir=${TOOLCHAIN_PREFIX}
+make
+make install
+cd ${WORK_ROOT}
+
+
+# CURL INSTALL
+# Download cURL source and expand it
+export CURL_SOURCE=curl-8.20.0
+wget https://curl.se/download/${CURL_SOURCE}.tar.gz
+tar -xvf ${CURL_SOURCE}.tar.gz
+
+# Build cURL
+# --with-openssl points at our cross-built OpenSSL (option renamed from --with-ssl in curl 7.77.0).
+# --without-libpsl avoids curl 8.x's hard libpsl dependency, which is not in the sysroot.
+# --disable-ntlm excludes curl's MD4/DES-based NTLM code (curl_ntlm_core.c), flagged as use of
+# the banned hash algorithm MD4 and the banned symmetric algorithm DES.
+pushd /${WORK_ROOT}/${CURL_SOURCE}
+./configure --with-sysroot=${TOOLCHAIN_SYSROOT} --prefix=${TOOLCHAIN_PREFIX} --target=${TOOLCHAIN_NAME} --with-openssl=${TOOLCHAIN_PREFIX} --with-zlib --host=${TOOLCHAIN_NAME} --build=x86_64-linux-gnu --without-libpsl --disable-ntlm
+
+make
+make install
+cd ${WORK_ROOT}
+
+########## UTIL LINUX INSTALL ##########
+# Download the Linux utilities for libuuid and expand it
+export UTIL_LINUX_SOURCE=util-linux-2.33-rc2
+wget https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.33/${UTIL_LINUX_SOURCE}.tar.gz
+tar -xvf ${UTIL_LINUX_SOURCE}.tar.gz
+
+# Build uuid
+cd ${WORK_ROOT}/${UTIL_LINUX_SOURCE}
+./configure --prefix=${TOOLCHAIN_PREFIX} --with-sysroot=${TOOLCHAIN_SYSROOT} --target=${TOOLCHAIN_NAME} --host=${TOOLCHAIN_NAME} --disable-all-programs  --disable-bash-completion --enable-libuuid
+make
+make install
+cd ${WORK_ROOT}
+
+# Finally a sanity check to make sure the files are there
+ls -al ${TOOLCHAIN_PREFIX}/lib
+ls -al ${TOOLCHAIN_PREFIX}/include
+
+ls -la ./
+
+cat > ./raspberry_env_vars.sh << EOF
+export TOOLCHAIN_ROOT="$TOOLCHAIN_ROOT"
+export TOOLCHAIN_SYSROOT="$TOOLCHAIN_SYSROOT"
+export TOOLCHAIN_EXES="$TOOLCHAIN_EXES"
+export TOOLCHAIN_NAME=arm-none-linux-gnueabihf
+export TOOLCHAIN_PREFIX="$TOOLCHAIN_PREFIX"
+EOF


### PR DESCRIPTION
Backports #2738 to `lts_03_2025`, the only LTS branch still in maintenance (end date 2026-10-07 per `readme.md`).

### Why

The DPS transports size their response buffers with `malloc(len + 1)`, so a `len` of `SIZE_MAX` wraps to `malloc(0)` and the following `memcpy` runs off the allocation. #2738 fixed this on `main` on 2026-07-23; the LTS branch still carries the unhardened pattern in all three files.

### Contents

1. **`70f9fa28` cherry-picked unchanged.** The three `provisioning_client/src` files are byte-identical to `main` at the allocation sites.
2. **One LTS-specific adaptation.** The backported tests use `IGNORED_ARG`, which does not exist in the umock-c pinned by this branch (`504193e6`, March 2020). Without this the three provisioning UT suites fail to compile. All nine occurrences are pointer arguments, so they become `IGNORED_PTR_ARG`, matching the macro already used throughout these files here.

### Verification

Built and ran all three affected suites locally:

| Suite | Result |
|---|---|
| `prov_transport_http_client_ut` | 52 tests, 0 failed |
| `prov_transport_mqtt_common_ut` | 68 tests, 0 failed |
| `prov_transport_amqp_common_ut` | 76 tests, 0 failed |

The three new regression tests each ran and passed.

To confirm they are not vacuous, I reverted only the three `src` files to the unfixed `malloc(len + 1)` and reran — all three suites crashed with heap corruption (`munmap_chunk(): invalid pointer`, `malloc(): unaligned tcache chunk detected`, `malloc(): memory corruption (fast)`, core dumped). Restoring the fix returns them to green.

### Reachability

Hardening / defence in depth. I could not find a path by which a wire-provided length reaches a wrapping value:

- **HTTP** — `content_len` is `BUFFER_length(recv_msg.msg_body)` in azure-uhttp-c, i.e. bytes actually received and buffered, not the `Content-Length` header. uhttp errors on mismatch.
- **MQTT** — `payload->length` comes from the umqtt codec, where `prepareheaderDataInfo()` rejects `totalLen > MAX_SEND_SIZE` and Remaining Length fields longer than 4 bytes.
- **AMQP** — `binary_data.length` originates from `amqp_binary.length`, a `uint32_t`; on 64-bit `uint32 + 1` cannot wrap `size_t`.

The crash above is produced by test mocks injecting `SIZE_MAX` directly.

### Notes

- No submodule bump: the c-utility pinned here (`772a4f8b`) already provides `safe_add_size_t`, macro identical to `main`.
- No version bump, matching previous LTS backports on this branch (e.g. `5a48d3fd8`).
- The cherry-pick also carries a small correctness fix: the HTTP path now sets `payload_data = NULL` after `free()`, so the malloc-failure branch no longer leaves a dangling pointer.
- The duplicate `http_proxy_io.h` include dropped from `prov_transport_mqtt_common.c` was genuinely duplicated here too (lines 17 and 19); one remains.
- CI here stays red until #2747 lands — this branch still carries the old pipeline, which fails against the retired container registry. Needs a rerun after that merges.
