### PR TITLE
Make the ARM64 cross-compile job resilient to multiarch version skew

### DIFF
--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -596,7 +596,9 @@ stages:
           echo "arm64 dependency install failed (attempt ${attempt} of 3)"
           if [ "${attempt}" = "2" ]; then
             echo "Repointing amd64 sources at archive.ubuntu.com to clear the version skew"
-            sudo sed -i -E 's|https?://[a-z0-9.-]*archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
+            # Swap only the host, keeping the original scheme so an https
+            # source is not downgraded to http.
+            sudo sed -i -E 's|(https?://)[a-z0-9.-]*archive\.ubuntu\.com/ubuntu|\1archive.ubuntu.com/ubuntu|g' \
               /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
           fi
           sleep 20

--- a/build/.vsts-ci.yml
+++ b/build/.vsts-ci.yml
@@ -565,16 +565,47 @@ stages:
         deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${CODENAME}-updates main restricted universe multiverse
         deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${CODENAME}-security main restricted universe multiverse
         EOF
+        # Multi-Arch: same packages (libssl3t64, zlib1g, ...) must be at the
+        # exact same version for amd64 and arm64. The default amd64 mirror and
+        # ports.ubuntu.com publish independently, so for a window after a
+        # security update the arm64 index can offer a version the amd64 mirror
+        # does not carry yet. apt then reports the arm64 dev libs as
+        # uninstallable, e.g.
+        #   libcurl4t64:arm64 : Depends: libssl3t64:arm64 (>= 3.0.0)
+        #                       but it is not going to be installed
+        # Retry, and before the last attempt repoint amd64 at the canonical
+        # archive, which is published in lockstep with ports.
+        install_arm64_deps() {
+          sudo apt-get install -y \
+            cmake \
+            build-essential \
+            pkg-config \
+            crossbuild-essential-arm64 \
+            libcurl4-openssl-dev:arm64 \
+            libssl-dev:arm64 \
+            uuid-dev:arm64 \
+            zlib1g-dev:arm64
+        }
         sudo apt-get update
-        sudo apt-get install -y \
-          cmake \
-          build-essential \
-          pkg-config \
-          crossbuild-essential-arm64 \
-          libcurl4-openssl-dev:arm64 \
-          libssl-dev:arm64 \
-          uuid-dev:arm64 \
-          zlib1g-dev:arm64
+        installed=0
+        for attempt in 1 2 3; do
+          if install_arm64_deps; then
+            installed=1
+            break
+          fi
+          echo "arm64 dependency install failed (attempt ${attempt} of 3)"
+          if [ "${attempt}" = "2" ]; then
+            echo "Repointing amd64 sources at archive.ubuntu.com to clear the version skew"
+            sudo sed -i -E 's|https?://[a-z0-9.-]*archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
+              /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
+          fi
+          sleep 20
+          sudo apt-get update || true
+        done
+        if [ "${installed}" != "1" ]; then
+          echo "Could not install the arm64 dependencies after 3 attempts" >&2
+          exit 1
+        fi
       displayName: 'Install aarch64 cross toolchain and arm64 dev libs'
     - script: |
         set -e


### PR DESCRIPTION
Makes the ARM64 cross-compile job resilient to multiarch version skew.

## Failure

```
libcurl4t64:arm64 : Depends: libssl3t64:arm64 (>= 3.0.0) but it is not going to be installed
libkrb5-3:arm64   : Depends: libssl3t64:arm64 (>= 3.0.0) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

The step fails during apt install, before any compilation.

## Cause

The job installs arm64 dev libraries next to the amd64 host packages. `Multi-Arch: same` packages such as `libssl3t64` must be at the exact same version for both architectures, but the amd64 mirror and ports.ubuntu.com publish independently. In the window after a security update the arm64 index offers a version the amd64 mirror does not carry yet, so apt cannot satisfy `libssl3t64:arm64`.

Intermittent, not specific to any change: the same job succeeded on another pull request 12 minutes before this failure, and succeeds on main.

## Fix

Retry the install up to three times; before the last attempt, repoint the amd64 sources at `archive.ubuntu.com`, which is published in lockstep with ports.

## Validation

The step script was extracted from the YAML and exercised locally against stubbed `apt-get`/`sudo`:

| scenario | exit | install attempts | repoint |
|---|---|---|---|
| install always fails | 1 | 3 | 1 |
| fails twice, then succeeds | 0 | 3 | 1 |
| succeeds first time | 0 | 1 | 0 |

The happy path is unchanged, so no added latency in the normal case. YAML parses and the script passes `bash -n`. The apt resolution itself cannot be reproduced outside a hosted Ubuntu 24.04 agent.
